### PR TITLE
Phase 0: foundation for bottom-up microbenchmark validation

### DIFF
--- a/src/graphs/benchmarks/schema.py
+++ b/src/graphs/benchmarks/schema.py
@@ -27,6 +27,36 @@ class BenchmarkCategory(Enum):
     CUSTOM = "custom"                  # User-defined benchmarks
 
 
+class LayerTag(Enum):
+    """
+    Physical layer of the hardware hierarchy that a benchmark isolates.
+
+    The layered benchmark strategy probes one physical layer at a time so a
+    measurement maps cleanly to a specific resource-model field. Composite
+    benchmarks (e.g., end-to-end ResNet) span multiple layers and use
+    ``COMPOSITE`` to indicate they validate the stack rather than a single
+    layer.
+
+    See ``docs/plans/bottom-up-microbenchmark-plan.md`` for the full layering.
+
+    Layers:
+        ALU             - single FMA / MAC / tensor-core slot in isolation
+        REGISTER_SIMD   - register file, SIMD lane, warp issue, systolic fill
+        SCRATCHPAD      - L1, L2, tile scratchpad, tiling overhead
+        ONCHIP          - chip-wide L3 / LLC, distributed L3, NoC hops, coherence
+        DRAM            - external DRAM (HBM, GDDR, DDR, LPDDR)
+        CLUSTER         - PCIe, NVLink, NV-HBI, ICI, NUMA, collectives
+        COMPOSITE       - spans multiple layers (legacy / end-to-end benchmarks)
+    """
+    ALU = "alu"
+    REGISTER_SIMD = "register_simd"
+    SCRATCHPAD = "scratchpad"
+    ONCHIP = "onchip"
+    DRAM = "dram"
+    CLUSTER = "cluster"
+    COMPOSITE = "composite"
+
+
 class Precision(Enum):
     """Supported numerical precisions"""
     FP64 = "fp64"
@@ -486,6 +516,12 @@ class BenchmarkResult:
     peak_memory_bytes: Optional[int] = None
     allocated_memory_bytes: Optional[int] = None
 
+    # Hierarchy layer this result characterizes. COMPOSITE is the
+    # default for backward compatibility with existing top-down
+    # benchmarks (GEMM, Conv2d, MLP sweeps) that exercise multiple
+    # layers at once.
+    layer: LayerTag = LayerTag.COMPOSITE
+
     # Status
     success: bool = True
     error_message: str = ""
@@ -510,6 +546,7 @@ class BenchmarkResult:
             'energy_joules': self.energy_joules,
             'peak_memory_bytes': self.peak_memory_bytes,
             'allocated_memory_bytes': self.allocated_memory_bytes,
+            'layer': self.layer.value,
             'success': self.success,
             'error_message': self.error_message,
             'extra': self.extra,
@@ -520,6 +557,12 @@ class BenchmarkResult:
         data = data.copy()
         if data.get('timing'):
             data['timing'] = TimingStats.from_dict(data['timing'])
+        # Back-compat: results serialized before LayerTag existed default
+        # to COMPOSITE; string values from JSON are re-parsed to the enum.
+        layer = data.get('layer', LayerTag.COMPOSITE)
+        if isinstance(layer, str):
+            layer = LayerTag(layer)
+        data['layer'] = layer
         return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
 
     def to_json(self, indent: int = 2) -> str:

--- a/src/graphs/benchmarks/schema.py
+++ b/src/graphs/benchmarks/schema.py
@@ -559,8 +559,10 @@ class BenchmarkResult:
             data['timing'] = TimingStats.from_dict(data['timing'])
         # Back-compat: results serialized before LayerTag existed default
         # to COMPOSITE; string values from JSON are re-parsed to the enum.
-        layer = data.get('layer', LayerTag.COMPOSITE)
-        if isinstance(layer, str):
+        layer = data.get('layer')
+        if layer is None:
+            layer = LayerTag.COMPOSITE
+        elif isinstance(layer, str):
             layer = LayerTag(layer)
         data['layer'] = layer
         return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})

--- a/src/graphs/calibration/fitters/__init__.py
+++ b/src/graphs/calibration/fitters/__init__.py
@@ -1,0 +1,123 @@
+"""
+Calibration fitters subpackage.
+
+This package is the canonical home for all calibration fitters — modules
+that consume benchmark measurements (``BenchmarkResult`` CSV / JSON)
+and emit fitted coefficients for the hardware resource model.
+
+Two categories of fitters live here:
+
+1. **Legacy fitters** — existing modules
+   (``roofline_fitter``, ``energy_fitter``, ``efficiency_curves``,
+   ``utilization_fitter``, ``utilization_curves``) currently live at
+   ``graphs.calibration.<name>`` and are re-exported here for forward
+   compatibility. Their physical relocation is deferred to a follow-up
+   cleanup PR so that Phase 0 changes remain additive and non-breaking.
+
+2. **Layered fitters** (added in Phase 1 onward) — one fitter per
+   hierarchy layer (ALU, register/SIMD, scratchpad, on-chip L3, DRAM,
+   cluster). These land here directly as
+   ``layer1_alu_fitter.py``, ``layer2_register_fitter.py``, etc.
+
+Preferred import style (new code):
+
+    from graphs.calibration.fitters import fit_roofline, fit_energy_model
+
+Existing imports from ``graphs.calibration.<name>`` continue to work
+unchanged.
+"""
+
+from __future__ import annotations
+
+# Re-export legacy fitters from their current locations.
+# When the physical relocation happens, only these imports change.
+from graphs.calibration.roofline_fitter import (
+    RooflineFitter,
+    RooflineParameters,
+    FitMetrics,
+    FitQuality,
+    fit_roofline,
+)
+from graphs.calibration.energy_fitter import (
+    EnergyFitter,
+    EnergyCoefficients,
+    EnergyFitMetrics,
+    EnergyFitQuality,
+    fit_energy_model,
+)
+from graphs.calibration.efficiency_curves import (
+    EfficiencyCurve,
+    AsymptoticCurve,
+    PiecewiseLinearCurve,
+    PolynomialCurve,
+    ConstantCurve,
+    EfficiencyProfile,
+    CurveType,
+    CurveFitResult,
+    fit_efficiency_curve,
+    auto_fit_efficiency_curve,
+)
+from graphs.calibration.utilization_fitter import (
+    UtilizationFitter,
+    UtilizationFitQuality,
+    UtilizationFitMetrics,
+    UtilizationCurveResult,
+    UtilizationProfile,
+    fit_utilization,
+)
+from graphs.calibration.utilization_curves import (
+    UtilizationCurve,
+    AsymptoticUtilizationCurve,
+    PiecewiseLinearUtilizationCurve,
+    PolynomialUtilizationCurve,
+    ConstantUtilizationCurve,
+    fit_utilization_curve,
+    auto_fit_utilization_curve,
+    create_typical_compute_curve,
+    create_typical_memory_curve,
+    interpolate_utilization,
+)
+
+__all__ = [
+    # Roofline
+    'RooflineFitter',
+    'RooflineParameters',
+    'FitMetrics',
+    'FitQuality',
+    'fit_roofline',
+    # Energy
+    'EnergyFitter',
+    'EnergyCoefficients',
+    'EnergyFitMetrics',
+    'EnergyFitQuality',
+    'fit_energy_model',
+    # Efficiency curves
+    'EfficiencyCurve',
+    'AsymptoticCurve',
+    'PiecewiseLinearCurve',
+    'PolynomialCurve',
+    'ConstantCurve',
+    'EfficiencyProfile',
+    'CurveType',
+    'CurveFitResult',
+    'fit_efficiency_curve',
+    'auto_fit_efficiency_curve',
+    # Utilization fitter
+    'UtilizationFitter',
+    'UtilizationFitQuality',
+    'UtilizationFitMetrics',
+    'UtilizationCurveResult',
+    'UtilizationProfile',
+    'fit_utilization',
+    # Utilization curves
+    'UtilizationCurve',
+    'AsymptoticUtilizationCurve',
+    'PiecewiseLinearUtilizationCurve',
+    'PolynomialUtilizationCurve',
+    'ConstantUtilizationCurve',
+    'fit_utilization_curve',
+    'auto_fit_utilization_curve',
+    'create_typical_compute_curve',
+    'create_typical_memory_curve',
+    'interpolate_utilization',
+]

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -26,6 +26,7 @@ from graphs.core.structures import (
     BottleneckType,
     PartitionReport,
 )
+from graphs.core.confidence import ConfidenceLevel, EstimationConfidence
 
 # Aliases for backward compatibility (these were originally in transform.partitioning)
 # Importing directly from ir.structures avoids pulling in torch dependency
@@ -645,6 +646,15 @@ class HardwareResourceModel:
     # NEW: BOM cost modeling for market analysis
     bom_cost_profile: Optional[BOMCostProfile] = None
 
+    # Provenance of individual resource-model fields.
+    # Maps field name (e.g., "peak_bandwidth", "energy_per_flop_fp32") to
+    # the EstimationConfidence that describes where that value came from.
+    # Unannotated fields default to UNKNOWN via ``get_provenance``. The
+    # bottom-up benchmark suite (see docs/plans/bottom-up-microbenchmark-plan.md)
+    # populates this map as each layer's fitter upgrades a field from
+    # THEORETICAL to INTERPOLATED or CALIBRATED.
+    field_provenance: Dict[str, EstimationConfidence] = field(default_factory=dict)
+
     def get_peak_ops(self, precision: Precision) -> float:
         """
         Get peak operations per second for a given precision.
@@ -679,6 +689,64 @@ class HardwareResourceModel:
             penalty = occupancy / self.min_occupancy
             return self.compute_units * occupancy * penalty
         return self.compute_units * occupancy
+
+    # ------------------------------------------------------------------
+    # Field provenance API
+    # ------------------------------------------------------------------
+    # Every field of a HardwareResourceModel originates from one of
+    #   - a datasheet (THEORETICAL)
+    #   - an interpolation across two measured points (INTERPOLATED)
+    #   - a direct measurement on this silicon (CALIBRATED)
+    #   - unknown / unannotated (UNKNOWN)
+    # The ``field_provenance`` map records this per-field. Bottom-up
+    # benchmark fitters use these setters so callers can ask "what is
+    # the confidence on the L3 cache energy for this SKU?" without
+    # scraping source comments.
+
+    def set_provenance(
+        self,
+        field_name: str,
+        confidence: EstimationConfidence,
+    ) -> None:
+        """
+        Record the provenance of a named resource-model field.
+
+        ``field_name`` is free-form so it can cover nested or derived
+        quantities (e.g., ``"thermal.maxn.efficiency_factor"``).
+        """
+        self.field_provenance[field_name] = confidence
+
+    def get_provenance(self, field_name: str) -> EstimationConfidence:
+        """
+        Return the provenance for a field, or UNKNOWN if unrecorded.
+
+        Returning UNKNOWN (rather than None) keeps callers from having
+        to branch on absence: ``model.get_provenance(x).level`` is
+        always safe.
+        """
+        return self.field_provenance.get(field_name, EstimationConfidence.unknown())
+
+    def aggregate_confidence(self) -> EstimationConfidence:
+        """
+        Return the weakest per-field confidence across the model.
+
+        Estimation rules require aggregate confidence to be the minimum
+        across the analysis chain. If any field is UNKNOWN or
+        THEORETICAL, the aggregate demotes to match. Empty provenance
+        maps to UNKNOWN.
+        """
+        if not self.field_provenance:
+            return EstimationConfidence.unknown()
+
+        # Ordering: CALIBRATED > INTERPOLATED > THEORETICAL > UNKNOWN.
+        rank = {
+            ConfidenceLevel.CALIBRATED: 3,
+            ConfidenceLevel.INTERPOLATED: 2,
+            ConfidenceLevel.THEORETICAL: 1,
+            ConfidenceLevel.UNKNOWN: 0,
+        }
+        worst = min(self.field_provenance.values(), key=lambda c: rank[c.level])
+        return worst
 
 
 @dataclass

--- a/tests/benchmarks/test_schema.py
+++ b/tests/benchmarks/test_schema.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from graphs.benchmarks.schema import (
     BenchmarkSpec,
     BenchmarkCategory,
+    LayerTag,
     Precision,
     DeviceType,
     ExecutionConfig,
@@ -476,6 +477,68 @@ class TestSpecValidation:
         )
         assert spec.output_height > 0
         assert spec.output_width > 0
+
+
+class TestLayerTag:
+    """Tests for LayerTag enum and BenchmarkResult.layer integration."""
+
+    def test_layer_tag_values(self):
+        assert LayerTag.ALU.value == "alu"
+        assert LayerTag.REGISTER_SIMD.value == "register_simd"
+        assert LayerTag.SCRATCHPAD.value == "scratchpad"
+        assert LayerTag.ONCHIP.value == "onchip"
+        assert LayerTag.DRAM.value == "dram"
+        assert LayerTag.CLUSTER.value == "cluster"
+        assert LayerTag.COMPOSITE.value == "composite"
+
+    def test_result_defaults_to_composite(self):
+        result = BenchmarkResult(
+            spec_name="legacy",
+            timestamp="2026-04-16T00:00:00Z",
+            device="cpu",
+        )
+        assert result.layer is LayerTag.COMPOSITE
+
+    def test_result_accepts_explicit_layer(self):
+        result = BenchmarkResult(
+            spec_name="alu_fma",
+            timestamp="2026-04-16T00:00:00Z",
+            device="cpu",
+            layer=LayerTag.ALU,
+        )
+        assert result.layer is LayerTag.ALU
+
+    def test_json_roundtrip_preserves_layer(self):
+        result = BenchmarkResult(
+            spec_name="dram_stream",
+            timestamp="2026-04-16T00:00:00Z",
+            device="cpu",
+            bandwidth_gbps=75.0,
+            layer=LayerTag.DRAM,
+        )
+        restored = BenchmarkResult.from_json(result.to_json())
+        assert restored.layer is LayerTag.DRAM
+
+    def test_from_dict_back_compat_missing_layer(self):
+        # Simulate a result serialized before LayerTag existed.
+        legacy_payload = {
+            'spec_name': 'pre_layer_tag_result',
+            'timestamp': '2025-01-01T00:00:00Z',
+            'device': 'cuda:0',
+            'gflops': 1200.0,
+        }
+        restored = BenchmarkResult.from_dict(legacy_payload)
+        assert restored.layer is LayerTag.COMPOSITE
+
+    def test_from_dict_accepts_string_layer(self):
+        payload = {
+            'spec_name': 'str_layer',
+            'timestamp': '2026-04-16T00:00:00Z',
+            'device': 'cpu',
+            'layer': 'alu',
+        }
+        restored = BenchmarkResult.from_dict(payload)
+        assert restored.layer is LayerTag.ALU
 
 
 if __name__ == "__main__":

--- a/tests/benchmarks/test_schema.py
+++ b/tests/benchmarks/test_schema.py
@@ -540,6 +540,16 @@ class TestLayerTag:
         restored = BenchmarkResult.from_dict(payload)
         assert restored.layer is LayerTag.ALU
 
+    def test_from_dict_handles_explicit_null_layer(self):
+        payload = {
+            'spec_name': 'null_layer',
+            'timestamp': '2026-04-16T00:00:00Z',
+            'device': 'cpu',
+            'layer': None,
+        }
+        restored = BenchmarkResult.from_dict(payload)
+        assert restored.layer is LayerTag.COMPOSITE
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/calibration/test_fitters_namespace.py
+++ b/tests/calibration/test_fitters_namespace.py
@@ -51,7 +51,7 @@ class TestFittersNamespaceAllExports:
     """Every entry in __all__ must resolve to an existing attribute."""
 
     def test_all_symbols_resolve(self):
-        import graphs.calibration.fitters as fitters_pkg
+        from graphs.calibration import fitters as fitters_pkg
         for name in fitters_pkg.__all__:
             assert hasattr(fitters_pkg, name), f"Missing re-export: {name}"
 

--- a/tests/calibration/test_fitters_namespace.py
+++ b/tests/calibration/test_fitters_namespace.py
@@ -1,0 +1,78 @@
+"""
+Tests for the graphs.calibration.fitters subpackage.
+
+The subpackage is the canonical home for calibration fitters going
+forward. During the Phase 0 transition, it re-exports legacy fitters
+from their existing module locations. Those exports must be the SAME
+objects (identity, not equality) so that ``isinstance`` checks and
+class registries continue to work regardless of import path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestFittersNamespaceReExports:
+    """Legacy fitter symbols re-exported via graphs.calibration.fitters."""
+
+    def test_fit_roofline_is_same_function(self):
+        from graphs.calibration.roofline_fitter import fit_roofline as legacy
+        from graphs.calibration.fitters import fit_roofline as new
+        assert new is legacy
+
+    def test_fit_energy_model_is_same_function(self):
+        from graphs.calibration.energy_fitter import fit_energy_model as legacy
+        from graphs.calibration.fitters import fit_energy_model as new
+        assert new is legacy
+
+    def test_fit_efficiency_curve_is_same_function(self):
+        from graphs.calibration.efficiency_curves import fit_efficiency_curve as legacy
+        from graphs.calibration.fitters import fit_efficiency_curve as new
+        assert new is legacy
+
+    def test_fit_utilization_is_same_function(self):
+        from graphs.calibration.utilization_fitter import fit_utilization as legacy
+        from graphs.calibration.fitters import fit_utilization as new
+        assert new is legacy
+
+    def test_roofline_fitter_class_is_same(self):
+        from graphs.calibration.roofline_fitter import RooflineFitter as legacy
+        from graphs.calibration.fitters import RooflineFitter as new
+        assert new is legacy
+
+    def test_energy_coefficients_class_is_same(self):
+        from graphs.calibration.energy_fitter import EnergyCoefficients as legacy
+        from graphs.calibration.fitters import EnergyCoefficients as new
+        assert new is legacy
+
+
+class TestFittersNamespaceAllExports:
+    """Every entry in __all__ must resolve to an existing attribute."""
+
+    def test_all_symbols_resolve(self):
+        import graphs.calibration.fitters as fitters_pkg
+        for name in fitters_pkg.__all__:
+            assert hasattr(fitters_pkg, name), f"Missing re-export: {name}"
+
+    def test_top_level_calibration_still_works(self):
+        # The pre-Phase-0 top-level calibration surface must be unchanged.
+        from graphs.calibration import (
+            RooflineFitter,
+            EnergyCoefficients,
+            EfficiencyCurve,
+            UtilizationFitter,
+            fit_roofline,
+            fit_energy_model,
+        )
+        # Smoke check: all of these are usable objects, not None sentinels.
+        assert RooflineFitter is not None
+        assert EnergyCoefficients is not None
+        assert EfficiencyCurve is not None
+        assert UtilizationFitter is not None
+        assert callable(fit_roofline)
+        assert callable(fit_energy_model)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/hardware/test_field_provenance.py
+++ b/tests/hardware/test_field_provenance.py
@@ -69,7 +69,7 @@ class TestFieldProvenanceSetGet:
         model.set_provenance("energy_per_flop_fp32", conf)
 
         out = model.get_provenance("energy_per_flop_fp32")
-        assert out is conf
+        assert out == conf
         assert out.level is ConfidenceLevel.CALIBRATED
         assert out.score == pytest.approx(0.92)
         assert out.calibration_id == "i7_12700k_layer1_fp32_20260416"

--- a/tests/hardware/test_field_provenance.py
+++ b/tests/hardware/test_field_provenance.py
@@ -15,7 +15,6 @@ from graphs.core.confidence import ConfidenceLevel, EstimationConfidence
 from graphs.hardware.resource_model import (
     HardwareResourceModel,
     HardwareType,
-    Precision,
 )
 
 

--- a/tests/hardware/test_field_provenance.py
+++ b/tests/hardware/test_field_provenance.py
@@ -1,0 +1,142 @@
+"""
+Tests for HardwareResourceModel.field_provenance and its helper API.
+
+The provenance map lets callers ask "what is the confidence behind this
+resource-model field?" directly, rather than scraping source comments.
+Bottom-up benchmark fitters write into it as each layer graduates from
+THEORETICAL to INTERPOLATED or CALIBRATED.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graphs.core.confidence import ConfidenceLevel, EstimationConfidence
+from graphs.hardware.resource_model import (
+    HardwareResourceModel,
+    HardwareType,
+    Precision,
+)
+
+
+def _make_minimal_model() -> HardwareResourceModel:
+    """Construct a HardwareResourceModel with just the required fields."""
+    return HardwareResourceModel(
+        name="test-sku",
+        hardware_type=HardwareType.CPU,
+        compute_units=4,
+        threads_per_unit=1,
+        warps_per_unit=1,
+        peak_bandwidth=75e9,
+        l1_cache_per_unit=32 * 1024,
+        l2_cache_total=8 * 1024 * 1024,
+        main_memory=16 * 1024 ** 3,
+        energy_per_flop_fp32=1.5e-12,
+        energy_per_byte=25e-12,
+    )
+
+
+class TestFieldProvenanceDefaults:
+    """Zero-provenance behavior."""
+
+    def test_fresh_model_has_empty_provenance(self):
+        model = _make_minimal_model()
+        assert model.field_provenance == {}
+
+    def test_unrecorded_field_returns_unknown(self):
+        model = _make_minimal_model()
+        conf = model.get_provenance("peak_bandwidth")
+        assert conf.level is ConfidenceLevel.UNKNOWN
+        # get_provenance must return an EstimationConfidence, never None,
+        # so callers can safely chain: model.get_provenance(x).level.
+        assert isinstance(conf, EstimationConfidence)
+
+    def test_empty_map_aggregates_to_unknown(self):
+        model = _make_minimal_model()
+        assert model.aggregate_confidence().level is ConfidenceLevel.UNKNOWN
+
+
+class TestFieldProvenanceSetGet:
+    """set/get round-trip and value preservation."""
+
+    def test_set_then_get_preserves_confidence(self):
+        model = _make_minimal_model()
+        conf = EstimationConfidence.calibrated(
+            score=0.92,
+            source="layer1_alu_fitter/i7_12700k_avx2_fp32",
+            calibration_id="i7_12700k_layer1_fp32_20260416",
+        )
+        model.set_provenance("energy_per_flop_fp32", conf)
+
+        out = model.get_provenance("energy_per_flop_fp32")
+        assert out is conf
+        assert out.level is ConfidenceLevel.CALIBRATED
+        assert out.score == pytest.approx(0.92)
+        assert out.calibration_id == "i7_12700k_layer1_fp32_20260416"
+
+    def test_independent_fields_do_not_interfere(self):
+        model = _make_minimal_model()
+        model.set_provenance("peak_bandwidth", EstimationConfidence.calibrated())
+        model.set_provenance(
+            "energy_per_byte", EstimationConfidence.theoretical()
+        )
+
+        assert model.get_provenance("peak_bandwidth").level is ConfidenceLevel.CALIBRATED
+        assert model.get_provenance("energy_per_byte").level is ConfidenceLevel.THEORETICAL
+        assert model.get_provenance("some_other_field").level is ConfidenceLevel.UNKNOWN
+
+    def test_set_overrides_previous_entry(self):
+        model = _make_minimal_model()
+        model.set_provenance(
+            "peak_bandwidth", EstimationConfidence.theoretical(source="datasheet")
+        )
+        model.set_provenance(
+            "peak_bandwidth",
+            EstimationConfidence.calibrated(source="STREAM triad @ 75 GB/s"),
+        )
+        assert model.get_provenance("peak_bandwidth").level is ConfidenceLevel.CALIBRATED
+
+    def test_nested_field_name_is_supported(self):
+        model = _make_minimal_model()
+        model.set_provenance(
+            "thermal.maxn.efficiency_factor",
+            EstimationConfidence.interpolated(),
+        )
+        assert (
+            model.get_provenance("thermal.maxn.efficiency_factor").level
+            is ConfidenceLevel.INTERPOLATED
+        )
+
+
+class TestAggregateConfidence:
+    """aggregate_confidence returns the weakest across all fields."""
+
+    def test_all_calibrated_aggregates_calibrated(self):
+        model = _make_minimal_model()
+        model.set_provenance("a", EstimationConfidence.calibrated())
+        model.set_provenance("b", EstimationConfidence.calibrated())
+        assert model.aggregate_confidence().level is ConfidenceLevel.CALIBRATED
+
+    def test_one_theoretical_demotes_aggregate(self):
+        model = _make_minimal_model()
+        model.set_provenance("good1", EstimationConfidence.calibrated())
+        model.set_provenance("good2", EstimationConfidence.calibrated())
+        model.set_provenance("weak", EstimationConfidence.theoretical())
+        agg = model.aggregate_confidence()
+        assert agg.level is ConfidenceLevel.THEORETICAL
+
+    def test_unknown_dominates(self):
+        model = _make_minimal_model()
+        model.set_provenance("x", EstimationConfidence.calibrated())
+        model.set_provenance("y", EstimationConfidence.unknown())
+        assert model.aggregate_confidence().level is ConfidenceLevel.UNKNOWN
+
+    def test_mixed_interpolated_theoretical_picks_theoretical(self):
+        model = _make_minimal_model()
+        model.set_provenance("x", EstimationConfidence.interpolated())
+        model.set_provenance("y", EstimationConfidence.theoretical())
+        assert model.aggregate_confidence().level is ConfidenceLevel.THEORETICAL
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/validation/composition/__init__.py
+++ b/validation/composition/__init__.py
@@ -1,0 +1,11 @@
+"""
+Bottom-up composition validation.
+
+Each hierarchy layer's benchmark (see
+``docs/plans/bottom-up-microbenchmark-plan.md``) fits a set of resource-
+model coefficients. The composition test takes the fitted coefficients
+from layers 1..N and predicts the behavior of layer N+1, then diffs
+the prediction against that layer's measured values. A composition
+miss catches coefficient drift that a top-down composite calibration
+would silently absorb.
+"""

--- a/validation/composition/__init__.py
+++ b/validation/composition/__init__.py
@@ -8,4 +8,30 @@ from layers 1..N and predicts the behavior of layer N+1, then diffs
 the prediction against that layer's measured values. A composition
 miss catches coefficient drift that a top-down composite calibration
 would silently absorb.
+
+Preferred import style (Phase 1+)::
+
+    from validation.composition import register_layer_check, CompositionCheck
 """
+
+from validation.composition.test_layer_composition import (
+    CheckStatus,
+    CompositionCheck,
+    CompositionCheckResult,
+    CompositionReport,
+    clear_registry,
+    register_layer_check,
+    registered_checks,
+    run_all_checks,
+)
+
+__all__ = [
+    "CheckStatus",
+    "CompositionCheck",
+    "CompositionCheckResult",
+    "CompositionReport",
+    "clear_registry",
+    "register_layer_check",
+    "registered_checks",
+    "run_all_checks",
+]

--- a/validation/composition/test_layer_composition.py
+++ b/validation/composition/test_layer_composition.py
@@ -25,6 +25,7 @@ decisions.
 
 from __future__ import annotations
 
+import argparse
 import sys
 from dataclasses import dataclass, field
 from enum import Enum
@@ -128,8 +129,14 @@ class CompositionReport:
 
     @property
     def all_passed(self) -> bool:
-        # An empty registry (Phase 0 state) counts as passing — there is
-        # nothing to fail until Phase 1 lands its first check.
+        """True when zero checks FAILED.
+
+        SKIPPED checks are non-failing: a run where every check skips
+        (e.g., measurement data missing for a SKU) reports green. An
+        empty registry (Phase 0 state) also reports green. Phase 1+
+        code that needs to distinguish "all healthy" from "all skipped"
+        should inspect n_skipped explicitly.
+        """
         return self.n_failed == 0
 
     def format(self) -> str:
@@ -178,8 +185,16 @@ def run_all_checks() -> CompositionReport:
 def test_composition_scaffold_runs() -> None:
     """The scaffold must import, run, and report cleanly before any
     Phase 1+ checks are registered."""
-    report = run_all_checks()
-    assert report.all_passed, report.format()
+    saved = registered_checks()
+    clear_registry()
+    try:
+        report = run_all_checks()
+        assert report.all_passed, report.format()
+        assert report.results == []
+    finally:
+        clear_registry()
+        for c in saved:
+            register_layer_check(c)
 
 
 def test_registry_api_is_functional() -> None:
@@ -187,36 +202,40 @@ def test_registry_api_is_functional() -> None:
     behaves (add, list, clear)."""
     from graphs.benchmarks.schema import LayerTag as LT
 
-    def _runner() -> CompositionCheckResult:
-        return CompositionCheckResult(
-            name="phase0_self_test",
-            hardware="dummy",
-            from_layers=[LT.ALU],
-            predicts_layer=LT.REGISTER_SIMD,
-            status=CheckStatus.SKIPPED,
-            details="phase 0 self-test",
-        )
-
+    saved = registered_checks()
     clear_registry()
-    assert registered_checks() == []
+    try:
+        assert registered_checks() == []
 
-    register_layer_check(
-        CompositionCheck(
-            name="phase0_self_test",
-            hardware="dummy",
-            from_layers=[LT.ALU],
-            predicts_layer=LT.REGISTER_SIMD,
-            runner=_runner,
+        def _runner() -> CompositionCheckResult:
+            return CompositionCheckResult(
+                name="phase0_self_test",
+                hardware="dummy",
+                from_layers=[LT.ALU],
+                predicts_layer=LT.REGISTER_SIMD,
+                status=CheckStatus.SKIPPED,
+                details="phase 0 self-test",
+            )
+
+        register_layer_check(
+            CompositionCheck(
+                name="phase0_self_test",
+                hardware="dummy",
+                from_layers=[LT.ALU],
+                predicts_layer=LT.REGISTER_SIMD,
+                runner=_runner,
+            )
         )
-    )
-    assert len(registered_checks()) == 1
+        assert len(registered_checks()) == 1
 
-    report = run_all_checks()
-    assert len(report.results) == 1
-    assert report.results[0].status is CheckStatus.SKIPPED
-    assert report.all_passed  # SKIPPED is not a failure
-
-    clear_registry()
+        report = run_all_checks()
+        assert len(report.results) == 1
+        assert report.results[0].status is CheckStatus.SKIPPED
+        assert report.all_passed
+    finally:
+        clear_registry()
+        for c in saved:
+            register_layer_check(c)
 
 
 # --------------------------------------------------------------------------- #
@@ -230,6 +249,15 @@ def main(argv: Optional[List[str]] = None) -> int:
         0  - all registered checks passed (or registry is empty)
         1  - at least one registered check failed
     """
+    parser = argparse.ArgumentParser(
+        description="Bottom-up layer composition validation"
+    )
+    parser.add_argument(
+        "--verbose", action="store_true",
+        help="Print per-check detail (reserved for Phase 1+)"
+    )
+    parser.parse_args(argv)
+
     report = run_all_checks()
     print(report.format())
     return 0 if report.all_passed else 1

--- a/validation/composition/test_layer_composition.py
+++ b/validation/composition/test_layer_composition.py
@@ -1,0 +1,239 @@
+"""
+Bottom-up layer composition validation.
+
+Validates that a resource model built from layer-1..N fitted coefficients
+reproduces layer-(N+1) measurements within a target tolerance. This is
+the core cross-check that separates the bottom-up methodology from the
+current top-down-only calibration path.
+
+Scaffolded in Phase 0. Each subsequent phase (1..6) lands its
+corresponding check via ``register_layer_check``. Until those phases
+ship, this module runs, reports an empty check set, and exits cleanly
+with status 0.
+
+Runnable two ways:
+
+    # Standalone (per the validation rules in .claude/rules/validation.md):
+    python validation/composition/test_layer_composition.py
+
+    # Via pytest (discovered automatically):
+    python -m pytest validation/composition/test_layer_composition.py
+
+Both paths exercise the same registry and produce the same pass/fail
+decisions.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Dict, List, Optional
+
+from graphs.benchmarks.schema import LayerTag
+
+
+# --------------------------------------------------------------------------- #
+# Check registry
+# --------------------------------------------------------------------------- #
+
+class CheckStatus(Enum):
+    PASSED = "passed"
+    FAILED = "failed"
+    SKIPPED = "skipped"  # e.g. no measurement data available for this SKU
+
+
+@dataclass
+class CompositionCheckResult:
+    """Outcome of a single composition check."""
+    name: str
+    hardware: str
+    predicts_layer: LayerTag
+    from_layers: List[LayerTag]
+    status: CheckStatus
+    max_relative_error: float = 0.0
+    tolerance: float = 0.15
+    details: str = ""
+
+    def summary_line(self) -> str:
+        tag = {
+            CheckStatus.PASSED: "PASS",
+            CheckStatus.FAILED: "FAIL",
+            CheckStatus.SKIPPED: "SKIP",
+        }[self.status]
+        layers = "+".join(l.value for l in self.from_layers) or "-"
+        return (
+            f"[{tag}] {self.hardware:20s} {layers:20s} -> {self.predicts_layer.value:12s} "
+            f"err={self.max_relative_error*100:5.1f}% tol={self.tolerance*100:5.1f}% "
+            f"{self.name}"
+        )
+
+
+@dataclass
+class CompositionCheck:
+    """
+    A single bottom-up composition check.
+
+    ``runner`` is a zero-arg callable that returns a CompositionCheckResult.
+    The runner owns its data loading (from calibration_data/ or
+    validation/empirical/results/) so a missing file becomes SKIPPED
+    rather than a crash.
+    """
+    name: str
+    hardware: str
+    from_layers: List[LayerTag]
+    predicts_layer: LayerTag
+    runner: Callable[[], CompositionCheckResult]
+    tolerance: float = 0.15
+
+
+# Module-level registry. Phase 1 lands the first ALU -> SCRATCHPAD check.
+_CHECKS: List[CompositionCheck] = []
+
+
+def register_layer_check(check: CompositionCheck) -> None:
+    """Add a composition check to the global registry."""
+    _CHECKS.append(check)
+
+
+def clear_registry() -> None:
+    """Testing helper — remove all registered checks."""
+    _CHECKS.clear()
+
+
+def registered_checks() -> List[CompositionCheck]:
+    """Read-only view of the current registry."""
+    return list(_CHECKS)
+
+
+# --------------------------------------------------------------------------- #
+# Runner
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class CompositionReport:
+    results: List[CompositionCheckResult] = field(default_factory=list)
+
+    @property
+    def n_passed(self) -> int:
+        return sum(1 for r in self.results if r.status is CheckStatus.PASSED)
+
+    @property
+    def n_failed(self) -> int:
+        return sum(1 for r in self.results if r.status is CheckStatus.FAILED)
+
+    @property
+    def n_skipped(self) -> int:
+        return sum(1 for r in self.results if r.status is CheckStatus.SKIPPED)
+
+    @property
+    def all_passed(self) -> bool:
+        # An empty registry (Phase 0 state) counts as passing — there is
+        # nothing to fail until Phase 1 lands its first check.
+        return self.n_failed == 0
+
+    def format(self) -> str:
+        lines = ["=" * 78, "Bottom-Up Layer Composition Report", "=" * 78]
+        if not self.results:
+            lines.append(
+                "(no composition checks registered; Phase 0 scaffold is live)"
+            )
+        else:
+            for r in self.results:
+                lines.append(r.summary_line())
+        lines.append("-" * 78)
+        lines.append(
+            f"Totals: {self.n_passed} passed, "
+            f"{self.n_failed} failed, {self.n_skipped} skipped "
+            f"({len(self.results)} total)"
+        )
+        lines.append("=" * 78)
+        return "\n".join(lines)
+
+
+def run_all_checks() -> CompositionReport:
+    """Execute every registered composition check and collect results."""
+    report = CompositionReport()
+    for check in _CHECKS:
+        try:
+            result = check.runner()
+        except Exception as exc:  # noqa: BLE001 - runners should be defensive
+            result = CompositionCheckResult(
+                name=check.name,
+                hardware=check.hardware,
+                predicts_layer=check.predicts_layer,
+                from_layers=check.from_layers,
+                status=CheckStatus.FAILED,
+                details=f"runner raised {type(exc).__name__}: {exc}",
+                tolerance=check.tolerance,
+            )
+        report.results.append(result)
+    return report
+
+
+# --------------------------------------------------------------------------- #
+# pytest entry point
+# --------------------------------------------------------------------------- #
+
+def test_composition_scaffold_runs() -> None:
+    """The scaffold must import, run, and report cleanly before any
+    Phase 1+ checks are registered."""
+    report = run_all_checks()
+    assert report.all_passed, report.format()
+
+
+def test_registry_api_is_functional() -> None:
+    """Phase 1 will register checks here; ensure the API it relies on
+    behaves (add, list, clear)."""
+    from graphs.benchmarks.schema import LayerTag as LT
+
+    def _runner() -> CompositionCheckResult:
+        return CompositionCheckResult(
+            name="phase0_self_test",
+            hardware="dummy",
+            from_layers=[LT.ALU],
+            predicts_layer=LT.REGISTER_SIMD,
+            status=CheckStatus.SKIPPED,
+            details="phase 0 self-test",
+        )
+
+    clear_registry()
+    assert registered_checks() == []
+
+    register_layer_check(
+        CompositionCheck(
+            name="phase0_self_test",
+            hardware="dummy",
+            from_layers=[LT.ALU],
+            predicts_layer=LT.REGISTER_SIMD,
+            runner=_runner,
+        )
+    )
+    assert len(registered_checks()) == 1
+
+    report = run_all_checks()
+    assert len(report.results) == 1
+    assert report.results[0].status is CheckStatus.SKIPPED
+    assert report.all_passed  # SKIPPED is not a failure
+
+    clear_registry()
+
+
+# --------------------------------------------------------------------------- #
+# Standalone entry point
+# --------------------------------------------------------------------------- #
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point: run the composition report and exit accordingly.
+
+    Exit codes:
+        0  - all registered checks passed (or registry is empty)
+        1  - at least one registered check failed
+    """
+    report = run_all_checks()
+    print(report.format())
+    return 0 if report.all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/validation/composition/test_layer_composition.py
+++ b/validation/composition/test_layer_composition.py
@@ -29,7 +29,7 @@ import argparse
 import sys
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Dict, List, Optional
+from typing import Callable, List, Optional
 
 from graphs.benchmarks.schema import LayerTag
 


### PR DESCRIPTION
## Summary

Phase 0 of the bottom-up microbenchmark plan (see `docs/plans/bottom-up-microbenchmark-plan.md`). Lays the scaffolding that Phase 1+ benchmarks hook into. **Additive and backward-compatible** — no existing import path, serialized result, or test breaks.

Implements **TASK-2026-013** ([`docs/tasks/active/TASK-2026-013.yaml`](../blob/main/docs/tasks/active/TASK-2026-013.yaml)). Part of the M4.5 bottom-up validation umbrella (issue #2; spec [`TASK-2026-012`](../blob/main/docs/tasks/active/TASK-2026-012.yaml)).

Closes #3.

## Changes

- **`LayerTag` enum** in `graphs.benchmarks.schema` + `BenchmarkResult.layer` field (default `COMPOSITE` for back-compat). Legacy JSON restores correctly.
- **`graphs.calibration.fitters` subpackage** — re-export layer for legacy fitters (roofline, energy, efficiency curves, utilization). Phase 1+ fitters land here directly; physical relocation deferred per `DECISION-2026-04-16-001`.
- **`HardwareResourceModel.field_provenance`** `Dict[str, EstimationConfidence]` with `set_provenance` / `get_provenance` / `aggregate_confidence` helpers. Unrecorded fields return `UNKNOWN` so callers can chain `.level` safely. Aggregate returns the weakest level across the map.
- **`validation/composition/test_layer_composition.py`** — scaffold for the cross-layer composition check. Runnable standalone and via pytest. Registry API (`register_layer_check`, `run_all_checks`) is exercised in-test; reports empty cleanly until Phase 1 registers its first check.

## Architectural decisions

- `DECISION-2026-04-16-001` — additive re-export package for fitters (not physical relocation) keeps Phase 0 blast radius minimal.
- `DECISION-2026-04-16-002` — defer `PowerMeter` abstraction and CI hook (plan items 5, 6) to **Phase 0.5** (TASK-2026-014, issue #4) so Phase 0 stays pure-software.

## Test plan

- [x] `pytest tests/benchmarks/test_schema.py` — 41 passed (6 new `LayerTag` tests)
- [x] `pytest tests/calibration/test_fitters_namespace.py` — 8 passed
- [x] `pytest tests/hardware/test_field_provenance.py` — 11 passed
- [x] `pytest tests/hardware/` — 72 passed
- [x] `pytest tests/calibration/` — 104 passed
- [x] `pytest tests/` (full suite) — **589 passed, 9 skipped, 0 failed**
- [x] `python validation/composition/test_layer_composition.py` — exits 0 with empty-registry report
- [x] `pytest validation/composition/test_layer_composition.py` — 2 passed

## What this PR does *not* do

Items 5 (`PowerMeter`) and 6 (CI hook) — tracked as TASK-2026-014 / issue #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hardware layer classification for benchmark results (ALU, memory tiers, etc.).
  * Introduced confidence-level provenance tracking for hardware resource estimates with field-level attribution.
  * Established unified API for accessing calibration fitters.
  * Added validation framework for bottom-up composition checks to detect coefficient drift across hardware layers.

* **Tests**
  * Added comprehensive test coverage for layer classification, provenance tracking, and validation frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->