### PR TITLE
feat(benchmarks): PowerMeter backends + CI composition gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,11 @@ jobs:
         run: bash ci/check_no_legacy_json_reads.sh
 
   # Job 8: Bottom-Up Composition Check
+  # Runs unconditionally (not path-gated) because:
+  # - Fast (<5s with the current registry; grows slowly as phases add checks)
+  # - A regression in resource_model.py can be triggered by code that doesn't
+  #   touch hardware/models/ directly (e.g., a change in calibration fitters)
+  # - Skipped jobs in GitHub Actions break the ci-success needs gate
   composition-check:
     name: Composition Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,25 +282,56 @@ jobs:
       - name: Check no legacy measurement JSON reads
         run: bash ci/check_no_legacy_json_reads.sh
 
-  # Job 8: Summary
+  # Job 8: Bottom-Up Composition Check
+  composition-check:
+    name: Composition Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          pip install -e .
+
+      - name: Run composition validation
+        run: |
+          python validation/composition/test_layer_composition.py --verbose
+
+  # Job 9: Summary
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [package-check, test, cli-tools, examples, lint, hardware-tests, data-hygiene]
+    needs: [package-check, test, cli-tools, examples, lint, hardware-tests, data-hygiene, composition-check]
     steps:
       - name: All checks passed
         run: |
           echo "=================================================="
-          echo "✅ All CI checks passed successfully!"
+          echo "All CI checks passed successfully!"
           echo "=================================================="
           echo ""
           echo "Summary:"
-          echo "  ✅ Package installation verified"
-          echo "  ✅ Tests passed on Python 3.9, 3.10, 3.11, 3.12"
-          echo "  ✅ CLI tools working correctly"
-          echo "  ✅ Examples validated"
-          echo "  ✅ Code quality checked"
-          echo "  ✅ Hardware tests completed"
-          echo "  ✅ Data hygiene verified"
+          echo "  Package installation verified"
+          echo "  Tests passed on Python 3.9, 3.10, 3.11, 3.12"
+          echo "  CLI tools working correctly"
+          echo "  Examples validated"
+          echo "  Code quality checked"
+          echo "  Hardware tests completed"
+          echo "  Data hygiene verified"
+          echo "  Composition check passed"
           echo ""
           echo "Ready to merge!"

--- a/src/graphs/benchmarks/__init__.py
+++ b/src/graphs/benchmarks/__init__.py
@@ -11,9 +11,20 @@ Migrated from graphs.hardware.calibration.benchmarks (deprecated).
 from .matmul_bench import calibrate_matmul
 from .memory_bench import calibrate_memory_bandwidth
 from .matmul_bench_multi import calibrate_matmul_all_precisions
+from .power_meter import (
+    RAPLPowerCollector,
+    TegrastatsPowerCollector,
+    NoOpPowerCollector,
+    auto_select_power_collector,
+)
 
 __all__ = [
     'calibrate_matmul',
     'calibrate_memory_bandwidth',
     'calibrate_matmul_all_precisions',
+    # Power measurement backends (Phase 0.5)
+    'RAPLPowerCollector',
+    'TegrastatsPowerCollector',
+    'NoOpPowerCollector',
+    'auto_select_power_collector',
 ]

--- a/src/graphs/benchmarks/power_meter.py
+++ b/src/graphs/benchmarks/power_meter.py
@@ -1,0 +1,311 @@
+"""
+Power Measurement Backends for Bottom-Up Benchmarks
+
+Extends the existing MeasurementCollector ecosystem (see collectors.py)
+with platform-specific energy measurement backends:
+
+- RAPLPowerCollector: Intel RAPL energy counters (x86 Linux)
+- TegrastatsPowerCollector: Jetson tegrastats daemon (Orin Nano / AGX)
+- NoOpPowerCollector: fallback when no power domain is available
+- auto_select_power_collector: probes available backends, returns best
+
+The existing PowerCollector (NVML/nvidia-smi for discrete GPUs) is
+preferred when a CUDA device is the target. These new collectors cover
+the CPU-side and edge-device measurement gaps.
+
+Usage:
+    collector = auto_select_power_collector("cpu")
+    collector.start()
+    # ... run benchmark ...
+    collector.stop()
+    measurement = collector.get_measurement()
+    print(f"Energy: {measurement.energy_joules:.6f} J")
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .collectors import (
+    MeasurementCollector,
+    PowerCollector,
+    PowerMeasurement,
+)
+
+MIN_MEASUREMENT_DURATION_MS = 100.0
+
+
+def _rapl_available() -> bool:
+    """Check if Intel RAPL sysfs interface is readable."""
+    energy_path = Path("/sys/class/powercap/intel-rapl:0/energy_uj")
+    try:
+        energy_path.read_text()
+        return True
+    except (PermissionError, FileNotFoundError, OSError):
+        return False
+
+
+def _tegrastats_available() -> bool:
+    """Check if tegrastats binary exists (Jetson platforms)."""
+    try:
+        result = subprocess.run(
+            ["which", "tegrastats"],
+            capture_output=True, timeout=2.0,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _nvml_available() -> bool:
+    """Check if pynvml can initialize (discrete NVIDIA GPU present)."""
+    try:
+        import pynvml
+        pynvml.nvmlInit()
+        pynvml.nvmlShutdown()
+        return True
+    except Exception:
+        return False
+
+
+class RAPLPowerCollector(MeasurementCollector):
+    """
+    Intel RAPL energy counter collector.
+
+    Reads /sys/class/powercap/intel-rapl:N/energy_uj before and after
+    the measurement scope. The delta divided by wall-clock time gives
+    average power. No background thread needed -- just two reads.
+
+    Requires read access to /sys/class/powercap/intel-rapl:*/energy_uj.
+    On most distros this is readable by default; if not, run:
+        sudo chmod a+r /sys/class/powercap/intel-rapl:*/energy_uj
+
+    RAPL domains (typical desktop/server):
+        intel-rapl:0        package-0 (entire socket)
+        intel-rapl:0:0      core (CPU cores only)
+        intel-rapl:0:1      uncore (memory controller, L3, etc.)
+        intel-rapl:0:2      dram
+
+    By default this collector reads package-0 (the whole socket) which
+    is the most useful single number for bottom-up validation.
+    """
+
+    def __init__(self, domain: str = "intel-rapl:0"):
+        super().__init__()
+        self._domain = domain
+        self._energy_path = Path(f"/sys/class/powercap/{domain}/energy_uj")
+        self._energy_start_uj: int = 0
+        self._energy_end_uj: int = 0
+        self._max_energy_uj: Optional[int] = None
+
+        max_path = Path(f"/sys/class/powercap/{domain}/max_energy_range_uj")
+        try:
+            self._max_energy_uj = int(max_path.read_text().strip())
+        except (FileNotFoundError, PermissionError, OSError, ValueError):
+            pass
+
+    def _read_energy_uj(self) -> int:
+        return int(self._energy_path.read_text().strip())
+
+    def start(self) -> None:
+        self._energy_start_uj = self._read_energy_uj()
+        self._start_time = time.perf_counter()
+        self._running = True
+
+    def stop(self) -> None:
+        self._end_time = time.perf_counter()
+        self._energy_end_uj = self._read_energy_uj()
+        self._running = False
+
+    def get_measurement(self) -> PowerMeasurement:
+        duration_ms = self.duration_ms
+        delta_uj = self._energy_end_uj - self._energy_start_uj
+
+        # Handle counter wrap-around
+        if delta_uj < 0 and self._max_energy_uj is not None:
+            delta_uj += self._max_energy_uj
+
+        energy_j = delta_uj * 1e-6
+        duration_s = duration_ms / 1000.0
+        avg_power = energy_j / duration_s if duration_s > 0 else 0.0
+
+        return PowerMeasurement(
+            duration_ms=duration_ms,
+            avg_power_watts=avg_power,
+            peak_power_watts=avg_power,
+            energy_joules=energy_j,
+            sampling_interval_ms=0.0,
+            success=True,
+        )
+
+    def reset(self) -> None:
+        super().reset()
+        self._energy_start_uj = 0
+        self._energy_end_uj = 0
+
+
+class TegrastatsPowerCollector(MeasurementCollector):
+    """
+    Jetson tegrastats power collector.
+
+    Launches ``tegrastats --interval <ms>`` in a background thread and
+    parses the VDD_CPU, VDD_GPU, and VDD_SOC power rails. Summing
+    these gives total SoC power.
+
+    tegrastats output format (Orin):
+        ... VDD_GPU_SOC 2596mW/2596mW VDD_CPU_CV 1534mW/1534mW ...
+
+    Requires tegrastats to be in PATH (standard on JetPack).
+    """
+
+    _POWER_RAIL_RE = re.compile(
+        r"(VDD_\w+)\s+(\d+)mW/(\d+)mW"
+    )
+
+    def __init__(self, interval_ms: int = 100):
+        super().__init__()
+        self._interval_ms = interval_ms
+        self._process: Optional[subprocess.Popen] = None
+        self._reader_thread: Optional[threading.Thread] = None
+        self._samples: List[float] = []
+        self._lock = threading.Lock()
+
+    def _reader_loop(self) -> None:
+        assert self._process is not None
+        assert self._process.stdout is not None
+        for raw_line in self._process.stdout:
+            if not self._running:
+                break
+            line = raw_line.decode("utf-8", errors="replace")
+            total_mw = 0.0
+            for match in self._POWER_RAIL_RE.finditer(line):
+                total_mw += float(match.group(2))
+            if total_mw > 0:
+                with self._lock:
+                    self._samples.append(total_mw / 1000.0)
+
+    def start(self) -> None:
+        self._samples = []
+        self._running = True
+        self._start_time = time.perf_counter()
+        try:
+            self._process = subprocess.Popen(
+                ["tegrastats", "--interval", str(self._interval_ms)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+            )
+            self._reader_thread = threading.Thread(
+                target=self._reader_loop, daemon=True,
+            )
+            self._reader_thread.start()
+        except FileNotFoundError:
+            self._running = False
+
+    def stop(self) -> None:
+        self._running = False
+        self._end_time = time.perf_counter()
+        if self._process is not None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+            self._process = None
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=2.0)
+            self._reader_thread = None
+
+    def get_measurement(self) -> PowerMeasurement:
+        with self._lock:
+            samples = self._samples.copy()
+
+        if not samples:
+            return PowerMeasurement(
+                duration_ms=self.duration_ms,
+                success=False,
+                error_message="No tegrastats power samples collected",
+                sampling_interval_ms=float(self._interval_ms),
+            )
+
+        return PowerMeasurement(
+            duration_ms=self.duration_ms,
+            samples=samples,
+            sampling_interval_ms=float(self._interval_ms),
+            success=True,
+        )
+
+    def reset(self) -> None:
+        super().reset()
+        self._samples = []
+
+
+class NoOpPowerCollector(MeasurementCollector):
+    """
+    Fallback collector when no power measurement backend is available.
+
+    Returns a PowerMeasurement with success=False and a descriptive
+    message so callers can distinguish "no power domain" from "power
+    measurement failed."
+    """
+
+    def start(self) -> None:
+        self._start_time = time.perf_counter()
+        self._running = True
+
+    def stop(self) -> None:
+        self._end_time = time.perf_counter()
+        self._running = False
+
+    def get_measurement(self) -> PowerMeasurement:
+        return PowerMeasurement(
+            duration_ms=self.duration_ms,
+            success=False,
+            error_message="No power measurement backend available on this host",
+        )
+
+
+def auto_select_power_collector(
+    device: str = "cpu",
+    sampling_interval_ms: float = 100.0,
+) -> MeasurementCollector:
+    """
+    Probe available power-measurement backends and return the best one.
+
+    Selection priority:
+    1. CUDA device requested + NVML available -> existing PowerCollector
+    2. x86 Linux + RAPL readable -> RAPLPowerCollector
+    3. Jetson + tegrastats in PATH -> TegrastatsPowerCollector
+    4. Nothing available -> NoOpPowerCollector
+
+    Args:
+        device: Target device string ("cpu", "cuda", "cuda:0", etc.)
+        sampling_interval_ms: Sampling interval for thread-based collectors
+
+    Returns:
+        A MeasurementCollector subclass ready to start()
+    """
+    if device.startswith("cuda") and _nvml_available():
+        device_index = 0
+        if ":" in device:
+            try:
+                device_index = int(device.split(":")[1])
+            except (IndexError, ValueError):
+                pass
+        return PowerCollector(
+            device_index=device_index,
+            sampling_interval_ms=sampling_interval_ms,
+        )
+
+    if _rapl_available():
+        return RAPLPowerCollector()
+
+    if _tegrastats_available():
+        return TegrastatsPowerCollector(interval_ms=int(sampling_interval_ms))
+
+    return NoOpPowerCollector()

--- a/src/graphs/benchmarks/power_meter.py
+++ b/src/graphs/benchmarks/power_meter.py
@@ -24,13 +24,12 @@ Usage:
 
 from __future__ import annotations
 
-import os
 import re
 import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from .collectors import (
     MeasurementCollector,
@@ -108,6 +107,8 @@ class RAPLPowerCollector(MeasurementCollector):
         try:
             self._max_energy_uj = int(max_path.read_text().strip())
         except (FileNotFoundError, PermissionError, OSError, ValueError):
+            # max_energy_range_uj is optional; without it we cannot
+            # detect counter wrap-around, but normal measurements work.
             pass
 
     def _read_energy_uj(self) -> int:
@@ -127,9 +128,17 @@ class RAPLPowerCollector(MeasurementCollector):
         duration_ms = self.duration_ms
         delta_uj = self._energy_end_uj - self._energy_start_uj
 
-        # Handle counter wrap-around
+        # Handle counter wrap-around (requires max_energy_range_uj)
         if delta_uj < 0 and self._max_energy_uj is not None:
             delta_uj += self._max_energy_uj
+
+        # If still negative (wrap without max range), report failure
+        if delta_uj < 0:
+            return PowerMeasurement(
+                duration_ms=duration_ms,
+                success=False,
+                error_message="RAPL counter wrapped without max_energy_range_uj",
+            )
 
         energy_j = delta_uj * 1e-6
         duration_s = duration_ms / 1000.0
@@ -290,17 +299,26 @@ def auto_select_power_collector(
     Returns:
         A MeasurementCollector subclass ready to start()
     """
-    if device.startswith("cuda") and _nvml_available():
-        device_index = 0
-        if ":" in device:
-            try:
-                device_index = int(device.split(":")[1])
-            except (IndexError, ValueError):
-                pass
-        return PowerCollector(
-            device_index=device_index,
-            sampling_interval_ms=sampling_interval_ms,
-        )
+    if device.startswith("cuda"):
+        if _nvml_available():
+            device_index = 0
+            if ":" in device:
+                try:
+                    device_index = int(device.split(":")[1])
+                except (IndexError, ValueError):
+                    # Malformed device string like "cuda:"; default to GPU 0.
+                    pass
+            return PowerCollector(
+                device_index=device_index,
+                sampling_interval_ms=sampling_interval_ms,
+            )
+        # NVML unavailable for a CUDA target: RAPL measures the CPU
+        # socket, not the GPU, so returning it would attribute the
+        # wrong power domain. Fall through to tegrastats (covers
+        # Jetson integrated GPUs) or NoOp.
+        if _tegrastats_available():
+            return TegrastatsPowerCollector(interval_ms=int(sampling_interval_ms))
+        return NoOpPowerCollector()
 
     if _rapl_available():
         return RAPLPowerCollector()

--- a/src/graphs/benchmarks/runner.py
+++ b/src/graphs/benchmarks/runner.py
@@ -226,6 +226,7 @@ class PyTorchRunner(BenchmarkRunner):
                 result.avg_power_watts = measurement.avg_power_watts
                 result.peak_power_watts = measurement.peak_power_watts
         except Exception:
+            # Power measurement is best-effort; never abort the benchmark.
             pass
         return result
 
@@ -252,10 +253,15 @@ class PyTorchRunner(BenchmarkRunner):
             config=self.config,
         )
 
-        # Start power collection (wraps the entire measurement scope)
+        # Start power collection (wraps the entire measurement scope).
+        # start() can fail at runtime (e.g., RAPL perms changed between
+        # probe and read, tegrastats races); treat as best-effort.
         power_collector = self._get_power_collector(device)
         if power_collector is not None:
-            power_collector.start()
+            try:
+                power_collector.start()
+            except Exception:
+                power_collector = None
 
         try:
             # Dispatch to appropriate handler

--- a/src/graphs/benchmarks/runner.py
+++ b/src/graphs/benchmarks/runner.py
@@ -32,6 +32,7 @@ from .schema import (
     DeviceType,
     Precision,
 )
+from .collectors import MeasurementCollector, PowerMeasurement
 
 
 # Precision to PyTorch dtype mapping
@@ -184,11 +185,49 @@ class PyTorchRunner(BenchmarkRunner):
 
     Supports CPU and CUDA devices with proper synchronization
     and timing using CUDA events for GPU accuracy.
+
+    When ``enable_power_measurement`` is True (the default), the runner
+    auto-selects a power collector via ``auto_select_power_collector``
+    and populates ``energy_joules``, ``avg_power_watts``, and
+    ``peak_power_watts`` on every ``BenchmarkResult``.  If no backend
+    is available the fields are left as None (NoOp fallback).
     """
 
-    def __init__(self, config: Optional[ExecutionConfig] = None):
+    def __init__(
+        self,
+        config: Optional[ExecutionConfig] = None,
+        enable_power_measurement: bool = True,
+    ):
         super().__init__(config)
         self._operation_cache: Dict[str, Callable] = {}
+        self._enable_power = enable_power_measurement
+
+    def _get_power_collector(self, device: str) -> Optional[MeasurementCollector]:
+        if not self._enable_power:
+            return None
+        try:
+            from .power_meter import auto_select_power_collector
+            return auto_select_power_collector(device)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _attach_power(
+        result: BenchmarkResult,
+        collector: Optional[MeasurementCollector],
+    ) -> BenchmarkResult:
+        """Populate energy fields on *result* from the collector's measurement."""
+        if collector is None:
+            return result
+        try:
+            measurement = collector.get_measurement()
+            if isinstance(measurement, PowerMeasurement) and measurement.success:
+                result.energy_joules = measurement.energy_joules
+                result.avg_power_watts = measurement.avg_power_watts
+                result.peak_power_watts = measurement.peak_power_watts
+        except Exception:
+            pass
+        return result
 
     def run(
         self,
@@ -213,17 +252,28 @@ class PyTorchRunner(BenchmarkRunner):
             config=self.config,
         )
 
-        # Dispatch to appropriate handler
-        if isinstance(spec, GEMMSpec):
-            return self._run_gemm(spec, ctx)
-        elif isinstance(spec, Conv2dSpec):
-            return self._run_conv2d(spec, ctx)
-        elif isinstance(spec, MemoryBenchSpec):
-            return self._run_memory(spec, ctx)
-        elif isinstance(spec, WorkloadSpec):
-            return self._run_workload(spec, ctx)
-        else:
-            raise ValueError(f"Unsupported spec type: {type(spec)}")
+        # Start power collection (wraps the entire measurement scope)
+        power_collector = self._get_power_collector(device)
+        if power_collector is not None:
+            power_collector.start()
+
+        try:
+            # Dispatch to appropriate handler
+            if isinstance(spec, GEMMSpec):
+                result = self._run_gemm(spec, ctx)
+            elif isinstance(spec, Conv2dSpec):
+                result = self._run_conv2d(spec, ctx)
+            elif isinstance(spec, MemoryBenchSpec):
+                result = self._run_memory(spec, ctx)
+            elif isinstance(spec, WorkloadSpec):
+                result = self._run_workload(spec, ctx)
+            else:
+                raise ValueError(f"Unsupported spec type: {type(spec)}")
+        finally:
+            if power_collector is not None:
+                power_collector.stop()
+
+        return self._attach_power(result, power_collector)
 
     def _run_gemm(self, spec: GEMMSpec, ctx: RunContext) -> BenchmarkResult:
         """Run GEMM benchmark"""

--- a/tests/benchmarks/test_power_meter.py
+++ b/tests/benchmarks/test_power_meter.py
@@ -1,0 +1,239 @@
+"""
+Tests for power measurement backends (power_meter.py).
+
+All tests use mocked system interfaces so they run on any host,
+including CI runners without RAPL, tegrastats, or NVML.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from graphs.benchmarks.collectors import PowerMeasurement
+from graphs.benchmarks.power_meter import (
+    RAPLPowerCollector,
+    TegrastatsPowerCollector,
+    NoOpPowerCollector,
+    auto_select_power_collector,
+    _rapl_available,
+    _tegrastats_available,
+    _nvml_available,
+)
+
+
+class TestNoOpPowerCollector:
+    """NoOp always succeeds start/stop but reports no energy."""
+
+    def test_returns_unsuccessful_measurement(self):
+        c = NoOpPowerCollector()
+        c.start()
+        time.sleep(0.01)
+        c.stop()
+        m = c.get_measurement()
+        assert isinstance(m, PowerMeasurement)
+        assert not m.success
+        assert m.energy_joules == 0.0
+
+    def test_duration_is_positive(self):
+        c = NoOpPowerCollector()
+        c.start()
+        time.sleep(0.01)
+        c.stop()
+        assert c.duration_ms > 0
+
+
+class TestRAPLPowerCollector:
+    """RAPL collector with mocked sysfs reads."""
+
+    def _make_collector(self):
+        with patch("pathlib.Path.read_text", return_value="0"):
+            return RAPLPowerCollector(domain="intel-rapl:0")
+
+    def test_energy_delta(self):
+        collector = self._make_collector()
+
+        reads = iter(["1000000", "2000000"])
+
+        with patch("pathlib.Path.read_text", side_effect=lambda: next(reads)):
+            collector.start()
+            time.sleep(0.01)
+            collector.stop()
+
+        m = collector.get_measurement()
+        assert m.success
+        assert m.energy_joules == pytest.approx(1.0, abs=0.01)
+        assert m.avg_power_watts > 0
+
+    def test_counter_wraparound(self):
+        collector = self._make_collector()
+        collector._max_energy_uj = 10_000_000
+
+        reads = iter(["9000000", "1000000"])
+
+        with patch("pathlib.Path.read_text", side_effect=lambda: next(reads)):
+            collector.start()
+            time.sleep(0.01)
+            collector.stop()
+
+        m = collector.get_measurement()
+        assert m.success
+        assert m.energy_joules == pytest.approx(2.0, abs=0.01)
+
+    def test_reset_clears_state(self):
+        collector = self._make_collector()
+        collector._energy_start_uj = 999
+        collector._energy_end_uj = 999
+        collector.reset()
+        assert collector._energy_start_uj == 0
+        assert collector._energy_end_uj == 0
+
+
+class TestTegrastatsPowerCollector:
+    """Tegrastats collector with mocked subprocess."""
+
+    def test_parses_power_rails(self):
+        sample_line = (
+            b"RAM 3456/7620MB (lfb 1234x4MB) SWAP 0/3810MB "
+            b"VDD_GPU_SOC 2596mW/2596mW VDD_CPU_CV 1534mW/1534mW\n"
+        )
+
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter([sample_line])
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            c = TegrastatsPowerCollector(interval_ms=100)
+            c.start()
+            if c._reader_thread:
+                c._reader_thread.join(timeout=1.0)
+            c.stop()
+
+        m = c.get_measurement()
+        assert m.success
+        expected_watts = (2596 + 1534) / 1000.0
+        assert len(m.samples) >= 1
+        assert m.samples[0] == pytest.approx(expected_watts, abs=0.01)
+
+    def test_no_samples_returns_failure(self):
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter([])
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            c = TegrastatsPowerCollector(interval_ms=100)
+            c.start()
+            c.stop()
+
+        m = c.get_measurement()
+        assert not m.success
+
+
+class TestAutoSelect:
+    """auto_select_power_collector priority logic."""
+
+    def test_cuda_prefers_nvml(self):
+        with patch("graphs.benchmarks.power_meter._nvml_available", return_value=True):
+            from graphs.benchmarks.collectors import PowerCollector
+            c = auto_select_power_collector("cuda:0")
+            assert isinstance(c, PowerCollector)
+
+    def test_cpu_prefers_rapl_when_available(self):
+        with (
+            patch("graphs.benchmarks.power_meter._rapl_available", return_value=True),
+            patch("pathlib.Path.read_text", return_value="0"),
+        ):
+            c = auto_select_power_collector("cpu")
+            assert isinstance(c, RAPLPowerCollector)
+
+    def test_falls_back_to_tegrastats(self):
+        with (
+            patch("graphs.benchmarks.power_meter._rapl_available", return_value=False),
+            patch("graphs.benchmarks.power_meter._tegrastats_available", return_value=True),
+        ):
+            c = auto_select_power_collector("cpu")
+            assert isinstance(c, TegrastatsPowerCollector)
+
+    def test_falls_back_to_noop(self):
+        with (
+            patch("graphs.benchmarks.power_meter._nvml_available", return_value=False),
+            patch("graphs.benchmarks.power_meter._rapl_available", return_value=False),
+            patch("graphs.benchmarks.power_meter._tegrastats_available", return_value=False),
+        ):
+            c = auto_select_power_collector("cpu")
+            assert isinstance(c, NoOpPowerCollector)
+
+
+class TestRunnerPowerIntegration:
+    """PyTorchRunner populates energy fields when power is available."""
+
+    def test_runner_enables_power_by_default(self):
+        from graphs.benchmarks.runner import PyTorchRunner
+        runner = PyTorchRunner()
+        assert runner._enable_power is True
+
+    def test_runner_can_disable_power(self):
+        from graphs.benchmarks.runner import PyTorchRunner
+        runner = PyTorchRunner(enable_power_measurement=False)
+        assert runner._enable_power is False
+
+    def test_attach_power_populates_fields(self):
+        from graphs.benchmarks.runner import PyTorchRunner
+        from graphs.benchmarks.schema import BenchmarkResult
+
+        result = BenchmarkResult(
+            spec_name="test",
+            timestamp="2026-04-16T00:00:00Z",
+            device="cpu",
+        )
+        assert result.energy_joules is None
+
+        mock_collector = MagicMock()
+        mock_collector.get_measurement.return_value = PowerMeasurement(
+            duration_ms=100.0,
+            avg_power_watts=50.0,
+            peak_power_watts=60.0,
+            energy_joules=5.0,
+            success=True,
+        )
+
+        result = PyTorchRunner._attach_power(result, mock_collector)
+        assert result.energy_joules == 5.0
+        assert result.avg_power_watts == 50.0
+        assert result.peak_power_watts == 60.0
+
+    def test_attach_power_noop_on_failure(self):
+        from graphs.benchmarks.runner import PyTorchRunner
+        from graphs.benchmarks.schema import BenchmarkResult
+
+        result = BenchmarkResult(
+            spec_name="test",
+            timestamp="2026-04-16T00:00:00Z",
+            device="cpu",
+        )
+
+        mock_collector = MagicMock()
+        mock_collector.get_measurement.return_value = PowerMeasurement(
+            duration_ms=100.0,
+            success=False,
+            error_message="no power",
+        )
+
+        result = PyTorchRunner._attach_power(result, mock_collector)
+        assert result.energy_joules is None
+
+    def test_attach_power_handles_none_collector(self):
+        from graphs.benchmarks.runner import PyTorchRunner
+        from graphs.benchmarks.schema import BenchmarkResult
+
+        result = BenchmarkResult(
+            spec_name="test",
+            timestamp="2026-04-16T00:00:00Z",
+            device="cpu",
+        )
+        result = PyTorchRunner._attach_power(result, None)
+        assert result.energy_joules is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/benchmarks/test_power_meter.py
+++ b/tests/benchmarks/test_power_meter.py
@@ -18,9 +18,6 @@ from graphs.benchmarks.power_meter import (
     TegrastatsPowerCollector,
     NoOpPowerCollector,
     auto_select_power_collector,
-    _rapl_available,
-    _tegrastats_available,
-    _nvml_available,
 )
 
 
@@ -81,6 +78,21 @@ class TestRAPLPowerCollector:
         m = collector.get_measurement()
         assert m.success
         assert m.energy_joules == pytest.approx(2.0, abs=0.01)
+
+    def test_negative_delta_without_max_reports_failure(self):
+        collector = self._make_collector()
+        collector._max_energy_uj = None
+
+        reads = iter(["5000000", "2000000"])
+
+        with patch("pathlib.Path.read_text", side_effect=lambda: next(reads)):
+            collector.start()
+            time.sleep(0.01)
+            collector.stop()
+
+        m = collector.get_measurement()
+        assert not m.success
+        assert m.energy_joules == 0.0
 
     def test_reset_clears_state(self):
         collector = self._make_collector()
@@ -162,6 +174,22 @@ class TestAutoSelect:
         ):
             c = auto_select_power_collector("cpu")
             assert isinstance(c, NoOpPowerCollector)
+
+    def test_cuda_without_nvml_returns_noop(self):
+        with (
+            patch("graphs.benchmarks.power_meter._nvml_available", return_value=False),
+            patch("graphs.benchmarks.power_meter._tegrastats_available", return_value=False),
+        ):
+            c = auto_select_power_collector("cuda:0")
+            assert isinstance(c, NoOpPowerCollector)
+
+    def test_cuda_without_nvml_prefers_tegrastats_on_jetson(self):
+        with (
+            patch("graphs.benchmarks.power_meter._nvml_available", return_value=False),
+            patch("graphs.benchmarks.power_meter._tegrastats_available", return_value=True),
+        ):
+            c = auto_select_power_collector("cuda")
+            assert isinstance(c, TegrastatsPowerCollector)
 
 
 class TestRunnerPowerIntegration:


### PR DESCRIPTION
## Summary

Phase 0.5 of the bottom-up validation plan (TASK-2026-014). Adds power measurement backends for the benchmark framework and a CI composition-test gate.

Implements the two deferred Phase 0 items per `DECISION-2026-04-16-002`:
- **Item 5**: `PowerMeter` abstraction with 4 backends (RAPL, tegrastats, NVML, NoOp)
- **Item 6**: CI composition-check job gating merges on resource-model regression

Resolves #4

## Changes

- `src/graphs/benchmarks/power_meter.py` — **new**: `RAPLPowerCollector` (Intel x86), `TegrastatsPowerCollector` (Jetson), `NoOpPowerCollector` (fallback), `auto_select_power_collector(device)` factory
- `src/graphs/benchmarks/runner.py` — `PyTorchRunner` gains `enable_power_measurement` flag; `run()` wraps dispatch in power-collection scope; `_attach_power()` populates energy fields on `BenchmarkResult`
- `src/graphs/benchmarks/__init__.py` — export new collectors
- `.github/workflows/ci.yml` — new "Composition Check" job added to `ci-success` needs
- `tests/benchmarks/test_power_meter.py` — **new**: 16 unit tests (all mocked, no hardware required)

## Design decisions

- Builds on the existing `MeasurementCollector` / `PowerCollector` ecosystem in `collectors.py` rather than creating a parallel hierarchy
- RAPL uses delta-based energy counters (two reads, no background thread) — simpler and more accurate than power sampling
- tegrastats uses background thread + regex parsing of VDD_* rails
- `auto_select_power_collector` probes NVML > RAPL > tegrastats > NoOp in priority order
- Runner integration is opt-in (`enable_power_measurement=True` by default) and tolerant of backend failures

## Test plan

- [x] `pytest tests/benchmarks/test_power_meter.py` — 16 passed
- [x] `pytest tests/benchmarks/` — 137 passed, 5 skipped
- [x] `pytest tests/` (full suite) — **606 passed, 9 skipped, 0 failed**
- [x] `python validation/composition/test_layer_composition.py` — exits 0

## What this unblocks

Issue #5 (Phase 1: Layer-1 ALU benchmarks) depends on this for pJ/op measurement via RAPL on the i7-12700K.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added power measurement capability for benchmarks with RAPL, Tegrastats, and automatic backend selection.
  * Extended PyTorchRunner to collect power and energy metrics during benchmark runs (enabled by default).

* **Tests**
  * Added comprehensive test coverage for power measurement backends and runner integration.

* **Chores**
  * Added GitHub Actions composition validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->