### PR TITLE
feat(benchmarks): Layer 1 ALU throughput and energy benchmarks

### DIFF
--- a/src/graphs/benchmarks/layer1_alu/__init__.py
+++ b/src/graphs/benchmarks/layer1_alu/__init__.py
@@ -1,0 +1,18 @@
+"""
+Layer 1 - ALU / MAC / Tensor-Core Microbenchmarks
+
+Isolates per-ALU throughput and energy in tight FMA loops with
+empty-loop subtraction, for every supported precision. Results
+feed ``layer1_alu_fitter`` to calibrate ``ComputeFabric``
+coefficients from measurement rather than datasheet values.
+
+See ``docs/plans/bottom-up-microbenchmark-plan.md`` Phase 1.
+"""
+
+from .fma_rate import run_fma_rate_benchmark
+from .precision_sweep import run_precision_sweep
+
+__all__ = [
+    "run_fma_rate_benchmark",
+    "run_precision_sweep",
+]

--- a/src/graphs/benchmarks/layer1_alu/fma_rate.py
+++ b/src/graphs/benchmarks/layer1_alu/fma_rate.py
@@ -1,0 +1,230 @@
+"""
+FMA Rate Microbenchmark — Layer 1 ALU Isolation
+
+Measures per-precision throughput (ops/sec) and optionally energy
+(pJ/op) in a tight FMA loop. Empty-loop subtraction removes timer
+and loop-control overhead so the residual is pure ALU time.
+
+Defense against dead-code elimination (DCE):
+  The accumulator is written to a module-level ``_sink`` after each
+  trial. Because ``_sink`` is read by ``get_sink_value()`` (called
+  in tests), the compiler cannot prove the loop is side-effect-free.
+
+Usage:
+    from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+    result = run_fma_rate_benchmark(
+        device="cpu",
+        precision="fp32",
+        num_elements=4096,
+        num_iterations=1000,
+    )
+    print(f"{result.gflops:.1f} GFLOPS, {result.energy_joules} J")
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime
+from typing import Optional
+
+import torch
+
+from graphs.benchmarks.schema import BenchmarkResult, LayerTag, TimingStats
+
+_sink: float = 0.0
+
+
+def get_sink_value() -> float:
+    """Read the accumulator sink (prevents DCE of the benchmark loop)."""
+    return _sink
+
+
+def _get_torch_dtype(precision: str) -> torch.dtype:
+    _MAP = {
+        "fp64": torch.float64,
+        "fp32": torch.float32,
+        "fp16": torch.float16,
+        "bf16": torch.bfloat16,
+    }
+    return _MAP.get(precision, torch.float32)
+
+
+def _run_fma_loop(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    c: torch.Tensor,
+    num_iterations: int,
+    device: str,
+) -> float:
+    """Run the FMA loop and return wall-clock seconds."""
+    if device.startswith("cuda") and torch.cuda.is_available():
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(num_iterations):
+            torch.addcmul(a, b, c, value=1.0, out=a)
+        end.record()
+        torch.cuda.synchronize()
+        return start.elapsed_time(end) / 1000.0
+    else:
+        start = time.perf_counter()
+        for _ in range(num_iterations):
+            torch.addcmul(a, b, c, value=1.0, out=a)
+        return time.perf_counter() - start
+
+
+def _run_empty_loop(num_iterations: int, device: str) -> float:
+    """Measure overhead of the loop + timer without any FMA work."""
+    if device.startswith("cuda") and torch.cuda.is_available():
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(num_iterations):
+            pass
+        end.record()
+        torch.cuda.synchronize()
+        return start.elapsed_time(end) / 1000.0
+    else:
+        start = time.perf_counter()
+        for _ in range(num_iterations):
+            pass
+        return time.perf_counter() - start
+
+
+def run_fma_rate_benchmark(
+    device: str = "cpu",
+    precision: str = "fp32",
+    num_elements: int = 4096,
+    num_iterations: int = 5000,
+    warmup_iterations: int = 200,
+    num_trials: int = 5,
+    power_collector: Optional[object] = None,
+) -> BenchmarkResult:
+    """
+    Measure FMA throughput for a single precision on a single device.
+
+    Each trial runs ``num_iterations`` of element-wise FMA
+    (``a = a + b * c``) on vectors of ``num_elements``. The vector
+    size is chosen small enough to fit in L1 / registers so memory
+    is not the bottleneck, but large enough to fill the SIMD lanes
+    (4096 FP32 = 16 KB, well within any L1).
+
+    Empty-loop subtraction removes per-iteration overhead.
+
+    Args:
+        device: "cpu" or "cuda" / "cuda:0"
+        precision: "fp64", "fp32", "fp16", "bf16"
+        num_elements: vector length (should fit in L1)
+        num_iterations: FMA ops per trial
+        warmup_iterations: warmup before measurement
+        num_trials: how many measurement trials (for statistics)
+        power_collector: optional MeasurementCollector (from power_meter)
+
+    Returns:
+        BenchmarkResult tagged with LayerTag.ALU
+    """
+    global _sink
+
+    dtype = _get_torch_dtype(precision)
+    a = torch.randn(num_elements, dtype=dtype, device=device)
+    b = torch.randn(num_elements, dtype=dtype, device=device)
+    c = torch.randn(num_elements, dtype=dtype, device=device)
+
+    # 2 FLOPs per element per iteration (multiply + add)
+    flops_per_iter = 2 * num_elements
+    total_flops = flops_per_iter * num_iterations
+
+    # Warmup
+    for _ in range(warmup_iterations):
+        torch.addcmul(a, b, c, value=1.0, out=a)
+    _sink = float(a.sum().item())
+
+    # Measure empty-loop overhead (median of 3)
+    empty_times = [_run_empty_loop(num_iterations, device) for _ in range(3)]
+    empty_overhead = sorted(empty_times)[1]
+
+    # Start power collection if available
+    if power_collector is not None:
+        try:
+            power_collector.start()
+        except Exception:
+            power_collector = None
+
+    # Measurement trials
+    trial_times_ms = []
+    for _ in range(num_trials):
+        a.normal_()
+        raw_seconds = _run_fma_loop(a, b, c, num_iterations, device)
+        net_seconds = max(raw_seconds - empty_overhead, 1e-9)
+        trial_times_ms.append(net_seconds * 1000.0)
+    _sink = float(a.sum().item())
+
+    # Stop power collection
+    energy_joules = None
+    avg_power_watts = None
+    peak_power_watts = None
+    if power_collector is not None:
+        try:
+            power_collector.stop()
+            from graphs.benchmarks.collectors import PowerMeasurement
+            measurement = power_collector.get_measurement()
+            if isinstance(measurement, PowerMeasurement) and measurement.success:
+                energy_joules = measurement.energy_joules
+                avg_power_watts = measurement.avg_power_watts
+                peak_power_watts = measurement.peak_power_watts
+        except Exception:
+            pass
+
+    # Statistics
+    sorted_t = sorted(trial_times_ms)
+    n = len(sorted_t)
+    mean_ms = sum(sorted_t) / n
+    median_ms = sorted_t[n // 2]
+    import statistics
+    std_ms = statistics.stdev(sorted_t) if n > 1 else 0.0
+
+    timing = TimingStats(
+        mean_ms=mean_ms,
+        std_ms=std_ms,
+        min_ms=sorted_t[0],
+        max_ms=sorted_t[-1],
+        median_ms=median_ms,
+        p95_ms=sorted_t[int(n * 0.95)] if n >= 20 else sorted_t[-1],
+        p99_ms=sorted_t[int(n * 0.99)] if n >= 100 else sorted_t[-1],
+        num_iterations=n,
+    )
+
+    gflops = (total_flops / 1e9) / (mean_ms / 1000.0)
+
+    pj_per_op = None
+    if energy_joules is not None and energy_joules > 0:
+        total_ops_all_trials = total_flops * num_trials
+        pj_per_op = (energy_joules / total_ops_all_trials) * 1e12
+
+    return BenchmarkResult(
+        spec_name=f"layer1_fma_rate_{precision}_{device}",
+        timestamp=datetime.now().isoformat(),
+        device=device,
+        device_name=device,
+        precision=precision,
+        timing=timing,
+        throughput_ops_per_sec=total_flops / (mean_ms / 1000.0),
+        gflops=gflops,
+        energy_joules=energy_joules,
+        avg_power_watts=avg_power_watts,
+        peak_power_watts=peak_power_watts,
+        layer=LayerTag.ALU,
+        success=True,
+        extra={
+            "num_elements": num_elements,
+            "num_iterations": num_iterations,
+            "num_trials": num_trials,
+            "flops_per_iteration": flops_per_iter,
+            "total_flops_per_trial": total_flops,
+            "empty_loop_overhead_ms": empty_overhead * 1000.0,
+            "pj_per_op": pj_per_op,
+            "sink_value": _sink,
+        },
+    )

--- a/src/graphs/benchmarks/layer1_alu/fma_rate.py
+++ b/src/graphs/benchmarks/layer1_alu/fma_rate.py
@@ -150,6 +150,7 @@ def run_fma_rate_benchmark(
         try:
             power_collector.start()
         except Exception:
+            # Runtime start failure (e.g., RAPL perms); proceed without power.
             power_collector = None
 
     # Measurement trials
@@ -175,6 +176,7 @@ def run_fma_rate_benchmark(
                 avg_power_watts = measurement.avg_power_watts
                 peak_power_watts = measurement.peak_power_watts
         except Exception:
+            # Power collection is best-effort; don't abort the benchmark.
             pass
 
     # Statistics

--- a/src/graphs/benchmarks/layer1_alu/fma_rate.py
+++ b/src/graphs/benchmarks/layer1_alu/fma_rate.py
@@ -1,5 +1,5 @@
 """
-FMA Rate Microbenchmark — Layer 1 ALU Isolation
+FMA Rate Microbenchmark - Layer 1 ALU Isolation
 
 Measures per-precision throughput (ops/sec) and optionally energy
 (pJ/op) in a tight FMA loop. Empty-loop subtraction removes timer
@@ -154,11 +154,18 @@ def run_fma_rate_benchmark(
             power_collector = None
 
     # Measurement trials
+    # NOTE: power window also covers a.normal_() and the sink read.
+    # Their energy is small relative to num_iterations * num_elements FMAs
+    # but will slightly inflate pJ/op for very small num_iterations.
     trial_times_ms = []
+    clamped_trials = 0
     for _ in range(num_trials):
         a.normal_()
         raw_seconds = _run_fma_loop(a, b, c, num_iterations, device)
-        net_seconds = max(raw_seconds - empty_overhead, 1e-9)
+        net_seconds = raw_seconds - empty_overhead
+        if net_seconds <= 0:
+            clamped_trials += 1
+            net_seconds = 1e-9
         trial_times_ms.append(net_seconds * 1000.0)
     _sink = float(a.sum().item())
 
@@ -226,6 +233,7 @@ def run_fma_rate_benchmark(
             "flops_per_iteration": flops_per_iter,
             "total_flops_per_trial": total_flops,
             "empty_loop_overhead_ms": empty_overhead * 1000.0,
+            "clamped_trials": clamped_trials,
             "pj_per_op": pj_per_op,
             "sink_value": _sink,
         },

--- a/src/graphs/benchmarks/layer1_alu/precision_sweep.py
+++ b/src/graphs/benchmarks/layer1_alu/precision_sweep.py
@@ -68,6 +68,7 @@ def run_precision_sweep(
                 from graphs.benchmarks.power_meter import auto_select_power_collector
                 collector = auto_select_power_collector(device)
             except Exception:
+                # PowerMeter unavailable; proceed without energy measurement.
                 pass
 
         try:

--- a/src/graphs/benchmarks/layer1_alu/precision_sweep.py
+++ b/src/graphs/benchmarks/layer1_alu/precision_sweep.py
@@ -1,0 +1,97 @@
+"""
+Precision Sweep — Layer 1 ALU Energy Characterization
+
+Runs the FMA-rate benchmark across all supported precisions on a
+single device, collecting throughput (GFLOPS) and energy (pJ/op via
+PowerMeter) for each. The result set feeds ``layer1_alu_fitter``
+to fit per-precision ``ComputeFabric.energy_scaling`` and
+``ops_per_unit_per_clock``.
+
+Usage:
+    from graphs.benchmarks.layer1_alu import run_precision_sweep
+    results = run_precision_sweep(device="cpu")
+    for r in results:
+        pj = r.extra.get("pj_per_op")
+        print(f"{r.precision}: {r.gflops:.1f} GFLOPS, {pj} pJ/op")
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from graphs.benchmarks.schema import BenchmarkResult
+from .fma_rate import run_fma_rate_benchmark
+
+DEFAULT_PRECISIONS_CPU = ["fp64", "fp32", "fp16", "bf16"]
+DEFAULT_PRECISIONS_CUDA = ["fp64", "fp32", "fp16", "bf16"]
+
+
+def run_precision_sweep(
+    device: str = "cpu",
+    precisions: Optional[List[str]] = None,
+    num_elements: int = 4096,
+    num_iterations: int = 5000,
+    warmup_iterations: int = 200,
+    num_trials: int = 5,
+    enable_power: bool = True,
+) -> List[BenchmarkResult]:
+    """
+    Sweep FMA rate across precisions on one device.
+
+    For each precision, optionally attaches a PowerMeter so pJ/op
+    is recorded in ``result.extra["pj_per_op"]``.
+
+    Args:
+        device: target device
+        precisions: list of precision strings; None = auto-detect
+        num_elements: vector length per FMA call
+        num_iterations: FMA iterations per trial
+        warmup_iterations: warmup count
+        num_trials: measurement trials per precision
+        enable_power: attach PowerMeter (RAPL / NVML / tegrastats)
+
+    Returns:
+        One BenchmarkResult per precision, all tagged LayerTag.ALU
+    """
+    if precisions is None:
+        precisions = (
+            DEFAULT_PRECISIONS_CUDA
+            if device.startswith("cuda")
+            else DEFAULT_PRECISIONS_CPU
+        )
+
+    results: List[BenchmarkResult] = []
+    for prec in precisions:
+        collector = None
+        if enable_power:
+            try:
+                from graphs.benchmarks.power_meter import auto_select_power_collector
+                collector = auto_select_power_collector(device)
+            except Exception:
+                pass
+
+        try:
+            result = run_fma_rate_benchmark(
+                device=device,
+                precision=prec,
+                num_elements=num_elements,
+                num_iterations=num_iterations,
+                warmup_iterations=warmup_iterations,
+                num_trials=num_trials,
+                power_collector=collector,
+            )
+        except Exception as exc:
+            from datetime import datetime
+            from graphs.benchmarks.schema import LayerTag
+            result = BenchmarkResult(
+                spec_name=f"layer1_fma_rate_{prec}_{device}",
+                timestamp=datetime.now().isoformat(),
+                device=device,
+                precision=prec,
+                layer=LayerTag.ALU,
+                success=False,
+                error_message=str(exc),
+            )
+        results.append(result)
+
+    return results

--- a/src/graphs/benchmarks/layer1_alu/precision_sweep.py
+++ b/src/graphs/benchmarks/layer1_alu/precision_sweep.py
@@ -1,5 +1,5 @@
 """
-Precision Sweep — Layer 1 ALU Energy Characterization
+Precision Sweep - Layer 1 ALU Energy Characterization
 
 Runs the FMA-rate benchmark across all supported precisions on a
 single device, collecting throughput (GFLOPS) and energy (pJ/op via

--- a/src/graphs/benchmarks/specs/layer1/fma_rate.yaml
+++ b/src/graphs/benchmarks/specs/layer1/fma_rate.yaml
@@ -1,0 +1,32 @@
+# Layer 1 ALU FMA Rate Benchmark Spec
+#
+# Op counts sized to:
+#   - Fit in L1 cache (num_elements * 4B = 16 KB for FP32)
+#   - Amortize timer resolution (num_iterations * num_elements * 2 FLOPs
+#     at ~50 GFLOPS FP32 on i7-12700K = ~0.4 ms per trial, well above
+#     perf_counter resolution)
+#   - Total measurement time > 100 ms for RAPL (5 trials * ~0.4 ms * 5000
+#     iters = ~2 s per precision)
+
+name: "layer1_fma_rate"
+description: "ALU FMA throughput and energy per precision"
+category: "microbenchmark"
+layer: "alu"
+tags: ["layer1", "alu", "fma", "throughput", "energy"]
+
+# Per-precision sweep runs all of these
+precisions: ["fp64", "fp32", "fp16", "bf16"]
+devices: ["auto"]
+
+# Benchmark parameters
+num_elements: 4096        # 16 KB at FP32 - fits in L1
+num_iterations: 5000      # iterations per trial
+warmup_iterations: 200
+num_trials: 5             # trials for statistics
+
+execution:
+  warmup_iterations: 200
+  measurement_iterations: 5000
+  min_duration_ms: 100.0
+  sync_before_timing: true
+  clear_cache: false      # L1-resident - no need to flush

--- a/src/graphs/calibration/fitters/__init__.py
+++ b/src/graphs/calibration/fitters/__init__.py
@@ -120,4 +120,12 @@ __all__ = [
     'create_typical_compute_curve',
     'create_typical_memory_curve',
     'interpolate_utilization',
+    # Layer 1 ALU fitter (Phase 1)
+    'Layer1ALUFitter',
+    'ALUFitResult',
 ]
+
+from graphs.calibration.fitters.layer1_alu_fitter import (
+    Layer1ALUFitter,
+    ALUFitResult,
+)

--- a/src/graphs/calibration/fitters/layer1_alu_fitter.py
+++ b/src/graphs/calibration/fitters/layer1_alu_fitter.py
@@ -1,0 +1,158 @@
+"""
+Layer 1 ALU Fitter - Fit ComputeFabric Coefficients from FMA Benchmarks
+
+Consumes BenchmarkResult objects from the Layer 1 FMA-rate benchmark
+and fits:
+  - ops_per_clock: measured throughput / sustained_clock_hz / num_cores
+  - pJ_per_op: measured energy / total_ops (from RAPL or other PowerMeter)
+
+Writes EstimationConfidence(CALIBRATED) into
+HardwareResourceModel.field_provenance for the fitted fields.
+
+Usage:
+    from graphs.calibration.fitters.layer1_alu_fitter import Layer1ALUFitter
+    fitter = Layer1ALUFitter()
+    fit_result = fitter.fit(benchmark_results)
+    fitter.apply_to_model(resource_model, fit_result)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from graphs.benchmarks.schema import BenchmarkResult, LayerTag
+from graphs.core.confidence import EstimationConfidence
+
+
+@dataclass
+class ALUFitResult:
+    """Result of fitting Layer 1 ALU coefficients from measurement."""
+
+    hardware_name: str = ""
+
+    # Per-precision measured throughput (ops/sec)
+    measured_throughput: Dict[str, float] = field(default_factory=dict)
+
+    # Per-precision measured pJ/op (None if PowerMeter was unavailable)
+    measured_pj_per_op: Dict[str, Optional[float]] = field(default_factory=dict)
+
+    # Derived: ops per clock per core (throughput / clock / cores)
+    ops_per_clock_per_core: Dict[str, float] = field(default_factory=dict)
+
+    # Metadata
+    num_results_used: int = 0
+    precisions_fitted: List[str] = field(default_factory=list)
+
+
+class Layer1ALUFitter:
+    """
+    Fit ComputeFabric coefficients from Layer 1 FMA-rate measurements.
+
+    The fitter takes a list of BenchmarkResults (from
+    ``run_precision_sweep`` or individual ``run_fma_rate_benchmark``
+    calls), all tagged ``LayerTag.ALU``, and produces an
+    ``ALUFitResult`` containing per-precision throughput and energy
+    coefficients.
+
+    ``apply_to_model`` then writes these into a
+    ``HardwareResourceModel``'s ``field_provenance`` as CALIBRATED.
+    """
+
+    def fit(
+        self,
+        results: List[BenchmarkResult],
+        sustained_clock_hz: float = 4.5e9,
+        num_cores: int = 10,
+        hardware_name: str = "",
+    ) -> ALUFitResult:
+        """
+        Fit per-precision ALU coefficients from benchmark results.
+
+        Args:
+            results: BenchmarkResults from Layer 1 benchmarks
+                     (must have layer==ALU and success==True)
+            sustained_clock_hz: all-core sustained clock for ops_per_clock
+            num_cores: effective core count (P + 0.6*E for hybrid)
+            hardware_name: SKU name for the fit record
+
+        Returns:
+            ALUFitResult with per-precision coefficients
+        """
+        alu_results = [
+            r for r in results
+            if r.layer is LayerTag.ALU and r.success
+        ]
+
+        fit = ALUFitResult(
+            hardware_name=hardware_name,
+            num_results_used=len(alu_results),
+        )
+
+        for r in alu_results:
+            prec = r.precision
+            throughput = r.throughput_ops_per_sec
+            if throughput <= 0:
+                continue
+
+            fit.measured_throughput[prec] = throughput
+            fit.precisions_fitted.append(prec)
+
+            if sustained_clock_hz > 0 and num_cores > 0:
+                fit.ops_per_clock_per_core[prec] = (
+                    throughput / sustained_clock_hz / num_cores
+                )
+
+            pj = r.extra.get("pj_per_op")
+            fit.measured_pj_per_op[prec] = pj
+
+        return fit
+
+    @staticmethod
+    def apply_to_model(
+        resource_model: object,
+        fit_result: ALUFitResult,
+    ) -> None:
+        """
+        Write fitted coefficients into a HardwareResourceModel's
+        field_provenance as CALIBRATED.
+
+        Does NOT overwrite the actual ComputeFabric fields (those are
+        used by the mapper for peak calculation). Instead, records the
+        measured values in provenance so callers can compare measured
+        vs. analytical and the aggregate_confidence reflects Layer 1
+        calibration status.
+        """
+        if not hasattr(resource_model, 'set_provenance'):
+            return
+
+        for prec in fit_result.precisions_fitted:
+            throughput = fit_result.measured_throughput.get(prec)
+            ops_clk = fit_result.ops_per_clock_per_core.get(prec)
+            pj = fit_result.measured_pj_per_op.get(prec)
+
+            source_parts = [f"layer1_alu_fitter/{fit_result.hardware_name}"]
+            if throughput:
+                source_parts.append(f"{throughput/1e9:.1f} GOPS")
+            if ops_clk:
+                source_parts.append(f"{ops_clk:.1f} ops/clk/core")
+            if pj:
+                source_parts.append(f"{pj:.2f} pJ/op")
+            source = ", ".join(source_parts)
+
+            resource_model.set_provenance(
+                f"compute_fabric.ops_per_clock.{prec}",
+                EstimationConfidence.calibrated(
+                    score=0.90,
+                    source=source,
+                ),
+            )
+
+            if pj is not None:
+                resource_model.set_provenance(
+                    f"energy_per_op.{prec}",
+                    EstimationConfidence.calibrated(
+                        score=0.85,
+                        source=source,
+                    ),
+                )

--- a/src/graphs/calibration/fitters/layer1_alu_fitter.py
+++ b/src/graphs/calibration/fitters/layer1_alu_fitter.py
@@ -62,8 +62,8 @@ class Layer1ALUFitter:
     def fit(
         self,
         results: List[BenchmarkResult],
-        sustained_clock_hz: float = 4.5e9,
-        num_cores: int = 10,
+        sustained_clock_hz: float,
+        num_cores: int,
         hardware_name: str = "",
     ) -> ALUFitResult:
         """
@@ -96,7 +96,8 @@ class Layer1ALUFitter:
                 continue
 
             fit.measured_throughput[prec] = throughput
-            fit.precisions_fitted.append(prec)
+            if prec not in fit.precisions_fitted:
+                fit.precisions_fitted.append(prec)
 
             if sustained_clock_hz > 0 and num_cores > 0:
                 fit.ops_per_clock_per_core[prec] = (

--- a/tests/benchmarks/test_layer1_alu.py
+++ b/tests/benchmarks/test_layer1_alu.py
@@ -196,7 +196,7 @@ class TestLayer1ALUFitter:
             success=False,
         )
         fitter = Layer1ALUFitter()
-        fit = fitter.fit(good + [bad])
+        fit = fitter.fit(good + [bad], sustained_clock_hz=4.5e9, num_cores=10)
         assert fit.num_results_used == 2
 
 
@@ -234,16 +234,42 @@ class TestCompositionCheck:
         )
         predicted_gflops = result.gflops * 0.70
 
+        # 8% off should still pass at 10% tolerance
         check_result = check_layer1_to_gemm(
             layer1_results=[result],
-            measured_gemm_gflops=predicted_gflops,
+            measured_gemm_gflops=predicted_gflops * 1.08,
             precision="fp32",
             hardware="test",
             gemm_efficiency=0.70,
             tolerance=0.10,
         )
         assert check_result.status is CheckStatus.PASSED
-        assert check_result.max_relative_error < 0.01
+        assert check_result.max_relative_error > 0.01
+
+    def test_check_fails_when_beyond_tolerance(self):
+        from validation.composition.layer1_to_layer3_gemm import (
+            check_layer1_to_gemm,
+        )
+        from validation.composition.test_layer_composition import CheckStatus
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+
+        result = run_fma_rate_benchmark(
+            device="cpu", precision="fp32",
+            num_elements=1024, num_iterations=100,
+            warmup_iterations=10, num_trials=3,
+        )
+        predicted_gflops = result.gflops * 0.70
+
+        # 12% off should fail at 10% tolerance
+        check_result = check_layer1_to_gemm(
+            layer1_results=[result],
+            measured_gemm_gflops=predicted_gflops * 1.12,
+            precision="fp32",
+            hardware="test",
+            gemm_efficiency=0.70,
+            tolerance=0.10,
+        )
+        assert check_result.status is CheckStatus.FAILED
 
     def test_check_skips_when_no_layer1_data(self):
         from validation.composition.layer1_to_layer3_gemm import (

--- a/tests/benchmarks/test_layer1_alu.py
+++ b/tests/benchmarks/test_layer1_alu.py
@@ -1,0 +1,282 @@
+"""
+Tests for Layer 1 ALU microbenchmarks.
+
+Tests cover:
+- FMA rate benchmark runs on CPU and produces valid results
+- Precision sweep returns results for all requested precisions
+- DCE sink defense is exercised
+- Layer1ALUFitter fits coefficients from results
+- Layer1ALUFitter.apply_to_model writes provenance
+- Composition check logic (predict + compare)
+
+All tests run on CPU with small vectors to complete in <1s.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graphs.benchmarks.schema import BenchmarkResult, LayerTag
+
+
+class TestFMARateBenchmark:
+    """Tests for the core FMA-rate benchmark."""
+
+    def test_runs_fp32_on_cpu(self):
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+        result = run_fma_rate_benchmark(
+            device="cpu",
+            precision="fp32",
+            num_elements=1024,
+            num_iterations=100,
+            warmup_iterations=10,
+            num_trials=3,
+        )
+        assert result.success
+        assert result.layer is LayerTag.ALU
+        assert result.gflops > 0
+        assert result.precision == "fp32"
+        assert result.extra["num_elements"] == 1024
+        assert result.extra["total_flops_per_trial"] == 2 * 1024 * 100
+
+    def test_runs_fp64_on_cpu(self):
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+        result = run_fma_rate_benchmark(
+            device="cpu",
+            precision="fp64",
+            num_elements=1024,
+            num_iterations=100,
+            warmup_iterations=10,
+            num_trials=3,
+        )
+        assert result.success
+        assert result.gflops > 0
+
+    def test_empty_loop_subtraction_is_positive(self):
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+        result = run_fma_rate_benchmark(
+            device="cpu",
+            precision="fp32",
+            num_elements=1024,
+            num_iterations=100,
+            warmup_iterations=10,
+            num_trials=3,
+        )
+        assert result.extra["empty_loop_overhead_ms"] >= 0
+
+    def test_sink_is_written(self):
+        from graphs.benchmarks.layer1_alu.fma_rate import (
+            run_fma_rate_benchmark,
+            get_sink_value,
+        )
+        run_fma_rate_benchmark(
+            device="cpu", precision="fp32",
+            num_elements=256, num_iterations=10,
+            warmup_iterations=5, num_trials=2,
+        )
+        sink = get_sink_value()
+        assert isinstance(sink, float)
+
+    def test_result_serializes_to_json(self):
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+        result = run_fma_rate_benchmark(
+            device="cpu", precision="fp32",
+            num_elements=256, num_iterations=10,
+            warmup_iterations=5, num_trials=2,
+        )
+        restored = BenchmarkResult.from_json(result.to_json())
+        assert restored.layer is LayerTag.ALU
+        assert restored.gflops > 0
+
+
+class TestPrecisionSweep:
+    """Tests for the multi-precision sweep."""
+
+    def test_sweeps_multiple_precisions(self):
+        from graphs.benchmarks.layer1_alu.precision_sweep import run_precision_sweep
+        results = run_precision_sweep(
+            device="cpu",
+            precisions=["fp32", "fp64"],
+            num_elements=512,
+            num_iterations=50,
+            warmup_iterations=5,
+            num_trials=2,
+            enable_power=False,
+        )
+        assert len(results) == 2
+        assert all(r.layer is LayerTag.ALU for r in results)
+        precs = {r.precision for r in results}
+        assert "fp32" in precs
+        assert "fp64" in precs
+
+    def test_handles_unsupported_precision_gracefully(self):
+        from graphs.benchmarks.layer1_alu.precision_sweep import run_precision_sweep
+        results = run_precision_sweep(
+            device="cpu",
+            precisions=["fp32"],
+            num_elements=256,
+            num_iterations=10,
+            warmup_iterations=5,
+            num_trials=2,
+            enable_power=False,
+        )
+        assert len(results) == 1
+        assert results[0].success
+
+
+class TestLayer1ALUFitter:
+    """Tests for the coefficient fitter."""
+
+    def _make_results(self) -> list:
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+        return [
+            run_fma_rate_benchmark(
+                device="cpu", precision=p,
+                num_elements=256, num_iterations=10,
+                warmup_iterations=5, num_trials=2,
+            )
+            for p in ["fp32", "fp64"]
+        ]
+
+    def test_fit_produces_per_precision_throughput(self):
+        from graphs.calibration.fitters.layer1_alu_fitter import Layer1ALUFitter
+        results = self._make_results()
+        fitter = Layer1ALUFitter()
+        fit = fitter.fit(
+            results,
+            sustained_clock_hz=4.5e9,
+            num_cores=10,
+            hardware_name="test-sku",
+        )
+        assert fit.num_results_used == 2
+        assert "fp32" in fit.measured_throughput
+        assert "fp64" in fit.measured_throughput
+        assert fit.measured_throughput["fp32"] > 0
+        assert "fp32" in fit.ops_per_clock_per_core
+
+    def test_apply_writes_provenance(self):
+        from graphs.calibration.fitters.layer1_alu_fitter import Layer1ALUFitter
+        from graphs.hardware.resource_model import (
+            HardwareResourceModel, HardwareType,
+        )
+        from graphs.core.confidence import ConfidenceLevel
+
+        model = HardwareResourceModel(
+            name="test",
+            hardware_type=HardwareType.CPU,
+            compute_units=10,
+            threads_per_unit=1,
+            warps_per_unit=1,
+            peak_bandwidth=75e9,
+            l1_cache_per_unit=32768,
+            l2_cache_total=25 * 1024 * 1024,
+            main_memory=64 * 1024**3,
+            energy_per_flop_fp32=1.5e-12,
+            energy_per_byte=25e-12,
+        )
+
+        results = self._make_results()
+        fitter = Layer1ALUFitter()
+        fit = fitter.fit(results, sustained_clock_hz=4.5e9, num_cores=10)
+        fitter.apply_to_model(model, fit)
+
+        prov = model.get_provenance("compute_fabric.ops_per_clock.fp32")
+        assert prov.level is ConfidenceLevel.CALIBRATED
+        assert "GOPS" in prov.source
+
+    def test_fit_ignores_failed_results(self):
+        from graphs.calibration.fitters.layer1_alu_fitter import Layer1ALUFitter
+        good = self._make_results()
+        bad = BenchmarkResult(
+            spec_name="bad",
+            timestamp="2026-04-17T00:00:00Z",
+            device="cpu",
+            precision="fp32",
+            layer=LayerTag.ALU,
+            success=False,
+        )
+        fitter = Layer1ALUFitter()
+        fit = fitter.fit(good + [bad])
+        assert fit.num_results_used == 2
+
+
+class TestCompositionCheck:
+    """Tests for the Layer 1 -> Layer 3 GEMM composition logic."""
+
+    def test_predict_gemm_from_layer1(self):
+        from validation.composition.layer1_to_layer3_gemm import (
+            predict_gemm_gflops_from_layer1,
+        )
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+        result = run_fma_rate_benchmark(
+            device="cpu", precision="fp32",
+            num_elements=1024, num_iterations=100,
+            warmup_iterations=10, num_trials=3,
+        )
+        predicted = predict_gemm_gflops_from_layer1(
+            [result], precision="fp32", gemm_efficiency=0.70,
+        )
+        assert predicted is not None
+        assert predicted > 0
+        assert predicted < result.gflops
+
+    def test_check_passes_when_within_tolerance(self):
+        from validation.composition.layer1_to_layer3_gemm import (
+            check_layer1_to_gemm,
+        )
+        from validation.composition.test_layer_composition import CheckStatus
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+
+        result = run_fma_rate_benchmark(
+            device="cpu", precision="fp32",
+            num_elements=1024, num_iterations=100,
+            warmup_iterations=10, num_trials=3,
+        )
+        predicted_gflops = result.gflops * 0.70
+
+        check_result = check_layer1_to_gemm(
+            layer1_results=[result],
+            measured_gemm_gflops=predicted_gflops,
+            precision="fp32",
+            hardware="test",
+            gemm_efficiency=0.70,
+            tolerance=0.10,
+        )
+        assert check_result.status is CheckStatus.PASSED
+        assert check_result.max_relative_error < 0.01
+
+    def test_check_skips_when_no_layer1_data(self):
+        from validation.composition.layer1_to_layer3_gemm import (
+            check_layer1_to_gemm,
+        )
+        from validation.composition.test_layer_composition import CheckStatus
+
+        check_result = check_layer1_to_gemm(
+            layer1_results=[],
+            measured_gemm_gflops=100.0,
+            precision="fp32",
+        )
+        assert check_result.status is CheckStatus.SKIPPED
+
+    def test_check_skips_when_no_measured_gemm(self):
+        from validation.composition.layer1_to_layer3_gemm import (
+            check_layer1_to_gemm,
+        )
+        from validation.composition.test_layer_composition import CheckStatus
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+
+        result = run_fma_rate_benchmark(
+            device="cpu", precision="fp32",
+            num_elements=256, num_iterations=10,
+            warmup_iterations=5, num_trials=2,
+        )
+        check_result = check_layer1_to_gemm(
+            layer1_results=[result],
+            measured_gemm_gflops=0.0,
+            precision="fp32",
+        )
+        assert check_result.status is CheckStatus.SKIPPED
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/validation/composition/layer1_to_layer3_gemm.py
+++ b/validation/composition/layer1_to_layer3_gemm.py
@@ -1,0 +1,139 @@
+"""
+Composition Check: Layer 1 ALU -> Layer 3 GEMM Throughput Prediction
+
+Validates that the per-ALU throughput measured in Layer 1 (FMA-rate
+benchmark) predicts the large-GEMM throughput (Layer 3) within
+tolerance on the same SKU.
+
+Prediction model:
+    predicted_gemm_gflops = ops_per_clock_per_core * clock_hz * num_cores
+                          * gemm_efficiency_factor
+
+    gemm_efficiency_factor accounts for the fact that a real GEMM
+    has overhead beyond pure FMA (address calculation, loop control,
+    cache management). For large GEMMs (M=N=K>=2048) on modern CPUs,
+    this factor is typically 0.60-0.80.
+
+Registration:
+    This module is imported by the composition test runner. To
+    register the check, import this module after Layer 1 results
+    exist on disk.
+
+Usage (manual):
+    python validation/composition/layer1_to_layer3_gemm.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from graphs.benchmarks.schema import BenchmarkResult, LayerTag
+
+
+def predict_gemm_gflops_from_layer1(
+    layer1_results: List[BenchmarkResult],
+    precision: str = "fp32",
+    gemm_efficiency: float = 0.70,
+) -> Optional[float]:
+    """
+    Predict large-GEMM GFLOPS from Layer 1 FMA throughput.
+
+    Args:
+        layer1_results: FMA-rate benchmark results (LayerTag.ALU)
+        precision: which precision to use for the prediction
+        gemm_efficiency: ratio of GEMM throughput to raw FMA throughput
+                        (0.70 is a reasonable default for large GEMMs
+                        on AVX2 CPUs with good BLAS libraries)
+
+    Returns:
+        Predicted GFLOPS for large GEMM, or None if no matching result
+    """
+    for r in layer1_results:
+        if (
+            r.layer is LayerTag.ALU
+            and r.success
+            and r.precision == precision
+            and r.gflops > 0
+        ):
+            return r.gflops * gemm_efficiency
+    return None
+
+
+def check_layer1_to_gemm(
+    layer1_results: List[BenchmarkResult],
+    measured_gemm_gflops: float,
+    precision: str = "fp32",
+    hardware: str = "unknown",
+    gemm_efficiency: float = 0.70,
+    tolerance: float = 0.10,
+) -> "CompositionCheckResult":
+    """
+    Compare predicted GEMM throughput against measured.
+
+    Args:
+        layer1_results: Layer 1 FMA-rate results
+        measured_gemm_gflops: actual large-GEMM GFLOPS on same SKU
+        precision: precision to check
+        hardware: SKU name for reporting
+        gemm_efficiency: FMA-to-GEMM efficiency factor
+        tolerance: max allowed relative error (0.10 = 10%)
+
+    Returns:
+        CompositionCheckResult
+    """
+    from validation.composition.test_layer_composition import (
+        CheckStatus,
+        CompositionCheckResult,
+    )
+
+    predicted = predict_gemm_gflops_from_layer1(
+        layer1_results, precision, gemm_efficiency,
+    )
+
+    if predicted is None:
+        return CompositionCheckResult(
+            name=f"layer1_to_gemm_{precision}",
+            hardware=hardware,
+            predicts_layer=LayerTag.SCRATCHPAD,
+            from_layers=[LayerTag.ALU],
+            status=CheckStatus.SKIPPED,
+            tolerance=tolerance,
+            details=f"No Layer 1 result for precision={precision}",
+        )
+
+    if measured_gemm_gflops <= 0:
+        return CompositionCheckResult(
+            name=f"layer1_to_gemm_{precision}",
+            hardware=hardware,
+            predicts_layer=LayerTag.SCRATCHPAD,
+            from_layers=[LayerTag.ALU],
+            status=CheckStatus.SKIPPED,
+            tolerance=tolerance,
+            details="No measured GEMM baseline available",
+        )
+
+    relative_error = abs(predicted - measured_gemm_gflops) / measured_gemm_gflops
+    passed = relative_error <= tolerance
+
+    return CompositionCheckResult(
+        name=f"layer1_to_gemm_{precision}",
+        hardware=hardware,
+        predicts_layer=LayerTag.SCRATCHPAD,
+        from_layers=[LayerTag.ALU],
+        status=CheckStatus.PASSED if passed else CheckStatus.FAILED,
+        max_relative_error=relative_error,
+        tolerance=tolerance,
+        details=(
+            f"predicted={predicted:.1f} GFLOPS, "
+            f"measured={measured_gemm_gflops:.1f} GFLOPS, "
+            f"error={relative_error*100:.1f}%"
+        ),
+    )
+
+
+if __name__ == "__main__":
+    print("Layer 1 -> Layer 3 GEMM composition check")
+    print("Run via: python validation/composition/test_layer_composition.py")
+    print("This module provides check_layer1_to_gemm() for programmatic use.")

--- a/validation/composition/layer1_to_layer3_gemm.py
+++ b/validation/composition/layer1_to_layer3_gemm.py
@@ -94,7 +94,7 @@ def check_layer1_to_gemm(
         return CompositionCheckResult(
             name=f"layer1_to_gemm_{precision}",
             hardware=hardware,
-            predicts_layer=LayerTag.SCRATCHPAD,
+            predicts_layer=LayerTag.COMPOSITE,
             from_layers=[LayerTag.ALU],
             status=CheckStatus.SKIPPED,
             tolerance=tolerance,
@@ -105,7 +105,7 @@ def check_layer1_to_gemm(
         return CompositionCheckResult(
             name=f"layer1_to_gemm_{precision}",
             hardware=hardware,
-            predicts_layer=LayerTag.SCRATCHPAD,
+            predicts_layer=LayerTag.COMPOSITE,
             from_layers=[LayerTag.ALU],
             status=CheckStatus.SKIPPED,
             tolerance=tolerance,
@@ -118,7 +118,7 @@ def check_layer1_to_gemm(
     return CompositionCheckResult(
         name=f"layer1_to_gemm_{precision}",
         hardware=hardware,
-        predicts_layer=LayerTag.SCRATCHPAD,
+        predicts_layer=LayerTag.COMPOSITE,
         from_layers=[LayerTag.ALU],
         status=CheckStatus.PASSED if passed else CheckStatus.FAILED,
         max_relative_error=relative_error,

--- a/validation/composition/layer1_to_layer3_gemm.py
+++ b/validation/composition/layer1_to_layer3_gemm.py
@@ -25,8 +25,6 @@ Usage (manual):
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from typing import List, Optional
 
 from graphs.benchmarks.schema import BenchmarkResult, LayerTag


### PR DESCRIPTION
## Summary

Phase 1 of the bottom-up validation plan (TASK-2026-015). First layer of the six-layer microbenchmark hierarchy — isolates per-ALU FMA throughput and energy from all higher-level effects (caches, memory, scheduling).

Resolves #5

## Changes

### Benchmarks (`src/graphs/benchmarks/layer1_alu/`)
- **`fma_rate.py`** — tight FMA loop (`torch.addcmul`) with empty-loop subtraction removing timer/loop overhead. Result-sink defense against DCE. Small vectors (4096 elements = 16 KB FP32) to stay in L1.
- **`precision_sweep.py`** — runs `fma_rate` across FP64/FP32/FP16/BF16 with optional PowerMeter (RAPL) for pJ/op per precision.
- **`specs/layer1/fma_rate.yaml`** — benchmark specification

### Fitter (`src/graphs/calibration/fitters/`)
- **`layer1_alu_fitter.py`** — `Layer1ALUFitter` consumes sweep results, fits per-precision `ops_per_clock_per_core` and `pJ_per_op`, writes `CALIBRATED` provenance via `set_provenance()`. Does *not* overwrite analytical `ComputeFabric` fields — records measured values in provenance for comparison.

### Composition check (`validation/composition/`)
- **`layer1_to_layer3_gemm.py`** — predicts large-GEMM throughput from Layer 1 FMA rate x `gemm_efficiency_factor`, compares against measured GEMM baseline. Tolerance 10%.

### Tests
- **`tests/benchmarks/test_layer1_alu.py`** — 14 tests covering FMA rate, precision sweep, fitter fit + apply_to_model, and composition check logic. All run on CPU, complete in <1s.

## Test plan

- [x] `pytest tests/benchmarks/test_layer1_alu.py` — 14 passed
- [x] `pytest tests/benchmarks/` — 155 passed, 5 skipped
- [x] `pytest tests/` (full suite) — **623 passed, 9 skipped, 0 failed**

## Acceptance criteria (from issue #5)

- [ ] Measured pJ/op for FP32 on i7-12700K within 20% of `get_base_alu_energy(10, 'standard_cell')` — *requires running the benchmark with RAPL on the dev machine; CI has no power domain*
- [x] `ComputeFabric` fields gain `field_provenance.CALIBRATED` — confirmed in `test_apply_writes_provenance`
- [ ] Composition test Layer 1 -> Layer 3 GEMM rate within 10% — *requires a measured GEMM baseline; the check logic is tested with synthetic data*

## What this unblocks

Issue #7 (Phase 2: Layer-2 register/SIMD/warp/systolic fill benchmarks)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **ALU Benchmarking**: Added Layer 1 ALU microbenchmarks to measure FMA (Fused Multiply-Add) throughput across multiple precision modes (fp64, fp32, fp16, bf16).
* **Precision Sweep**: Automated precision sweep functionality for comprehensive performance characterization.
* **Energy Measurement**: Optional power and energy-per-operation tracking during benchmarks.
* **Calibration**: New ALU fitter for extracting ops-per-clock metrics from benchmark results.
* **Validation**: Layer 1 to GEMM composition checks for cross-layer performance validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->