### PR TITLE
feat(benchmarks): Layer 2 register/SIMD width benchmarks

### DIFF
--- a/cli/benchmark_layers.py
+++ b/cli/benchmark_layers.py
@@ -3,11 +3,11 @@
 Run Layer 1-2 empirical benchmarks and print results.
 
 Usage:
-    python cli/run_layer_benchmarks.py
-    python cli/run_layer_benchmarks.py --layers 1
-    python cli/run_layer_benchmarks.py --layers 1 2
-    python cli/run_layer_benchmarks.py --device cpu --precision fp32
-    python cli/run_layer_benchmarks.py --output results.json
+    python cli/benchmark_layers.py
+    python cli/benchmark_layers.py --layers 1
+    python cli/benchmark_layers.py --layers 1 2
+    python cli/benchmark_layers.py --device cpu --precision fp32
+    python cli/benchmark_layers.py --output results.json
 
 RAPL power measurement requires read access to
 /sys/class/powercap/intel-rapl:*/energy_uj. To enable:

--- a/cli/benchmark_layers.py
+++ b/cli/benchmark_layers.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from datetime import datetime
 from pathlib import Path
 
 
@@ -49,7 +48,7 @@ def run_layer1(device: str, precision: str, verbose: bool) -> list:
 
     for r in results:
         pj = r.extra.get("pj_per_op")
-        pj_str = f"{pj:.2f} pJ/op" if pj else "(no power measurement)"
+        pj_str = f"{pj:.2f} pJ/op" if pj is not None else "(no power measurement)"
         clamped = r.extra.get("clamped_trials", 0)
         print(f"  {r.precision:6s}  {r.gflops:8.1f} GFLOPS  {pj_str}")
         if clamped > 0:
@@ -157,7 +156,7 @@ def run_fitter(layer1_results: list, layer2_results: list, device: str) -> None:
         for prec, throughput in fit1.measured_throughput.items():
             ops_clk = fit1.ops_per_clock_per_core.get(prec, 0)
             pj = fit1.measured_pj_per_op.get(prec)
-            pj_str = f"{pj:.2f} pJ/op" if pj else "N/A"
+            pj_str = f"{pj:.2f} pJ/op" if pj is not None else "N/A"
             print(f"  Layer 1 [{prec}]: {throughput/1e9:.1f} GOPS, "
                   f"{ops_clk:.2f} ops/clk/core, energy={pj_str}")
 

--- a/cli/run_layer_benchmarks.py
+++ b/cli/run_layer_benchmarks.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+Run Layer 1-2 empirical benchmarks and print results.
+
+Usage:
+    python cli/run_layer_benchmarks.py
+    python cli/run_layer_benchmarks.py --layers 1
+    python cli/run_layer_benchmarks.py --layers 1 2
+    python cli/run_layer_benchmarks.py --device cpu --precision fp32
+    python cli/run_layer_benchmarks.py --output results.json
+
+RAPL power measurement requires read access to
+/sys/class/powercap/intel-rapl:*/energy_uj. To enable:
+    sudo chmod a+r /sys/class/powercap/intel-rapl:*/energy_uj
+
+NOTE: These benchmarks measure PyTorch-level throughput, not raw ALU
+rate. Per-call dispatch overhead (~5-50us) dominates for small vectors.
+The measured GFLOPS reflects achievable throughput through the PyTorch
+runtime, not the micro-architectural peak. For true ALU-level
+characterization, C/C++ microbenchmarks with intrinsics are needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def run_layer1(device: str, precision: str, verbose: bool) -> list:
+    """Run Layer 1 FMA rate benchmark."""
+    from graphs.benchmarks.layer1_alu import run_precision_sweep
+
+    print("=" * 70)
+    print("Layer 1: ALU / FMA Throughput")
+    print("=" * 70)
+
+    results = run_precision_sweep(
+        device=device,
+        precisions=[precision],
+        num_elements=4096,
+        num_iterations=5000,
+        warmup_iterations=200,
+        num_trials=5,
+        enable_power=True,
+    )
+
+    for r in results:
+        pj = r.extra.get("pj_per_op")
+        pj_str = f"{pj:.2f} pJ/op" if pj else "(no power measurement)"
+        clamped = r.extra.get("clamped_trials", 0)
+        print(f"  {r.precision:6s}  {r.gflops:8.1f} GFLOPS  {pj_str}")
+        if clamped > 0:
+            print(f"           WARNING: {clamped}/{r.extra['num_trials']} trials clamped")
+        if verbose:
+            print(f"           elements={r.extra['num_elements']}, "
+                  f"iters={r.extra['num_iterations']}, "
+                  f"overhead={r.extra['empty_loop_overhead_ms']:.3f} ms")
+
+    print()
+    return results
+
+
+def run_layer2(device: str, precision: str, verbose: bool) -> list:
+    """Run Layer 2 SIMD width + register pressure benchmarks."""
+    from graphs.benchmarks.layer2_register_simd import (
+        run_simd_width_sweep,
+        run_register_pressure_benchmark,
+    )
+
+    print("=" * 70)
+    print("Layer 2: SIMD Width Scaling")
+    print("=" * 70)
+
+    widths = [1, 4, 8, 16, 64, 256, 1024, 4096]
+    width_results = run_simd_width_sweep(
+        device=device,
+        precision=precision,
+        widths=widths,
+        num_iterations=5000,
+        warmup_iterations=200,
+        num_trials=5,
+    )
+
+    for r in width_results:
+        w = r.extra["vector_width"]
+        clamped = r.extra.get("clamped_trials", 0)
+        flag = " (clamped)" if clamped > 0 else ""
+        print(f"  width={w:5d}  {r.gflops:8.1f} GFLOPS{flag}")
+
+    # Derive SIMD efficiency
+    if len(width_results) >= 2:
+        narrow = width_results[0]
+        wide = width_results[-1]
+        if narrow.gflops > 0:
+            speedup = wide.gflops / narrow.gflops
+            width_ratio = widths[-1] / widths[0]
+            efficiency = speedup / width_ratio
+            print(f"\n  SIMD efficiency: {efficiency:.3f} "
+                  f"(speedup={speedup:.1f}x over {width_ratio}x width)")
+        else:
+            print("\n  SIMD efficiency: N/A (narrow vector throughput too low)")
+
+    print()
+    print("=" * 70)
+    print("Layer 2: Register Pressure (ILP)")
+    print("=" * 70)
+
+    rp = run_register_pressure_benchmark(
+        device=device,
+        precision=precision,
+        num_elements=4096,
+        num_iterations=2000,
+        warmup_iterations=200,
+        num_trials=5,
+    )
+
+    print(f"  independent: {rp.extra['independent_gflops']:8.1f} GFLOPS")
+    print(f"  dependent:   {rp.extra['dependent_gflops']:8.1f} GFLOPS")
+    print(f"  ILP ratio:   {rp.extra['ilp_ratio']:.2f}x")
+    print()
+
+    return width_results + [rp]
+
+
+def run_fitter(layer1_results: list, layer2_results: list, device: str) -> None:
+    """Run fitters on collected results and show provenance."""
+    from graphs.calibration.fitters.layer1_alu_fitter import Layer1ALUFitter
+    from graphs.calibration.fitters.layer2_register_fitter import Layer2RegisterFitter
+    from graphs.hardware.resource_model import HardwareResourceModel, HardwareType
+
+    print("=" * 70)
+    print("Fitter Results")
+    print("=" * 70)
+
+    # Create a minimal model to receive provenance
+    model = HardwareResourceModel(
+        name=device,
+        hardware_type=HardwareType.CPU,
+        compute_units=10, threads_per_unit=1, warps_per_unit=1,
+        peak_bandwidth=75e9, l1_cache_per_unit=32768,
+        l2_cache_total=25*1024*1024, main_memory=64*1024**3,
+        energy_per_flop_fp32=1.5e-12, energy_per_byte=25e-12,
+    )
+
+    if layer1_results:
+        fitter1 = Layer1ALUFitter()
+        fit1 = fitter1.fit(
+            layer1_results,
+            sustained_clock_hz=4.5e9,
+            num_cores=10,
+            hardware_name=device,
+        )
+        fitter1.apply_to_model(model, fit1)
+        for prec, throughput in fit1.measured_throughput.items():
+            ops_clk = fit1.ops_per_clock_per_core.get(prec, 0)
+            pj = fit1.measured_pj_per_op.get(prec)
+            pj_str = f"{pj:.2f} pJ/op" if pj else "N/A"
+            print(f"  Layer 1 [{prec}]: {throughput/1e9:.1f} GOPS, "
+                  f"{ops_clk:.2f} ops/clk/core, energy={pj_str}")
+
+    if layer2_results:
+        fitter2 = Layer2RegisterFitter()
+        fit2 = fitter2.fit(layer2_results, hardware_name=device)
+        fitter2.apply_to_model(model, fit2)
+        if fit2.simd_efficiency is not None:
+            print(f"  Layer 2 SIMD efficiency: {fit2.simd_efficiency:.3f}")
+        if fit2.ilp_ratio is not None:
+            print(f"  Layer 2 ILP ratio: {fit2.ilp_ratio:.2f}x")
+
+    print(f"\n  Aggregate confidence: {model.aggregate_confidence()}")
+    print()
+
+
+def check_power_availability() -> None:
+    """Report power measurement status."""
+    from graphs.benchmarks.power_meter import (
+        _rapl_available, _tegrastats_available, _nvml_available,
+        auto_select_power_collector,
+    )
+
+    print("=" * 70)
+    print("Power Measurement Status")
+    print("=" * 70)
+    print(f"  RAPL:       {'available' if _rapl_available() else 'unavailable (chmod a+r /sys/class/powercap/intel-rapl:*/energy_uj)'}")
+    print(f"  tegrastats: {'available' if _tegrastats_available() else 'unavailable (Jetson only)'}")
+    print(f"  NVML:       {'available' if _nvml_available() else 'unavailable (no discrete GPU or pynvml not installed)'}")
+    collector = auto_select_power_collector("cpu")
+    print(f"  Selected:   {type(collector).__name__}")
+    print()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run Layer 1-2 empirical benchmarks",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--layers", nargs="+", type=int, default=[1, 2],
+        help="Which layers to run (default: 1 2)",
+    )
+    parser.add_argument(
+        "--device", default="cpu",
+        help="Target device (default: cpu)",
+    )
+    parser.add_argument(
+        "--precision", default="fp32",
+        help="Precision (default: fp32)",
+    )
+    parser.add_argument(
+        "--output", type=str, default=None,
+        help="Save results to JSON file",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true",
+        help="Show extra detail per trial",
+    )
+    args = parser.parse_args()
+
+    check_power_availability()
+
+    all_results = []
+    layer1_results = []
+    layer2_results = []
+
+    if 1 in args.layers:
+        layer1_results = run_layer1(args.device, args.precision, args.verbose)
+        all_results.extend(layer1_results)
+
+    if 2 in args.layers:
+        layer2_results = run_layer2(args.device, args.precision, args.verbose)
+        all_results.extend(layer2_results)
+
+    if layer1_results or layer2_results:
+        run_fitter(layer1_results, layer2_results, args.device)
+
+    if args.output:
+        path = Path(args.output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump([r.to_dict() for r in all_results], f, indent=2)
+        print(f"Results saved to {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/assessments/empirical-vs-model-based-validation.md
+++ b/docs/assessments/empirical-vs-model-based-validation.md
@@ -83,7 +83,7 @@ The empirical infrastructure we built is NOT wasted:
 | Aspect | Empirical (Phases 1-2) | Model-based (Phases 1-6 retrofit) |
 |--------|----------------------|-----------------------------------|
 | Data source | Real hardware (RAPL, CUDA events) | Analytical model predictions |
-| Coverage | Only SKUs we can physically access | All 50+ hardware mappers |
+| Coverage | Only SKUs we can physically access | All 45 hardware mappers |
 | What it validates | Model vs silicon | Model vs itself (internal consistency) |
 | Hardware needed | i7-12700K, Orin Nano, etc. | None (runs in CI) |
 | TPU/KPU coverage | None (no silicon) | Full (exercises the model code paths) |

--- a/docs/assessments/empirical-vs-model-based-validation.md
+++ b/docs/assessments/empirical-vs-model-based-validation.md
@@ -1,0 +1,102 @@
+# Assessment: Empirical vs Model-Based Validation
+
+**Date:** 2026-04-17
+**Context:** Phases 0-2 of the bottom-up benchmark plan (M4.5) have
+been implemented as empirical execution benchmarks. This assessment
+captures what we learned and motivates the pivot to model-based
+validation for the remaining phases.
+
+---
+
+## What We Built (Phases 0-2 Empirical)
+
+| Phase | What it does | Status |
+|-------|-------------|--------|
+| 0 | LayerTag, field_provenance, fitters subpackage, composition scaffold | Merged (PR #1) |
+| 0.5 | PowerMeter (RAPL, tegrastats, NVML, NoOp), CI composition gate | Merged (PR #13) |
+| 1 | FMA-rate benchmark, precision sweep, Layer1ALUFitter, Layer 1 -> GEMM composition check | Merged (PR #14) |
+| 2 | SIMD width sweep, register pressure, Layer2RegisterFitter, Layer 1+2 -> GEMM composition check, CLI runner | PR #15 (open) |
+
+## What We Learned
+
+### PyTorch is the wrong measurement layer for micro-architecture
+
+Running `cli/run_layer_benchmarks.py` on the i7-12700K (the target
+SKU) produced:
+
+| Metric | Measured | Analytical | Ratio | Root cause |
+|--------|----------|-----------|-------|------------|
+| FP32 GFLOPS | 6.8 | 720 (peak) / 360 (50% eff) | 0.01-0.02x | PyTorch dispatch overhead (~5-50 us per `addcmul` call) dominates the ~1 ns FMA |
+| pJ/op | 6040 | 2.1 | 2876x | RAPL measures entire socket (idle cores, memory controller, PCH) during a mostly-idle single-core workload |
+| SIMD efficiency | 0.698 | 0.70 (model constant) | ~1.0x | Coincidence: PyTorch's internal SIMD at large vectors is ~70%, not the per-lane efficiency we intended |
+| ILP ratio | 0.98 | >1.5 expected | ~0.65x | PyTorch collapses the dependency chain into one kernel per call; Python-level ILP is invisible |
+
+### What would fix empirical Layer 1-2
+
+True micro-architectural isolation requires:
+- **C/C++ microbenchmarks** with inline ASM or intrinsics
+- **rdtsc** timing (sub-nanosecond) instead of `time.perf_counter`
+- **Core affinity** (`sched_setaffinity`) to pin to one core
+- **Power gating** of idle cores before RAPL measurement
+- This is ~2-4 weeks of C development per SKU family, not a Python
+  script change
+
+### The actual goal is different
+
+The bottom-up plan's purpose is to validate the *modeling
+infrastructure* (CPU/GPU/TPU/KPU energy and latency models), not to
+characterize *real silicon*. The four architecture models
+(`StoredProgramEnergyModel`, `DataParallelEnergyModel`,
+`SystolicArrayEnergyModel`, `DomainFlowEnergyModel`) make layered
+predictions that should compose consistently. A bug in one layer's
+coefficients can cancel against a bug in another layer and still
+produce a reasonable composite -- that's the mis-cancellation risk.
+
+Model-based validation catches this without any physical hardware:
+take each model's Layer-N prediction in isolation, compose upward,
+and verify the result matches the model's own composite prediction.
+If it doesn't, the coefficients are internally inconsistent.
+
+---
+
+## What Stays Valuable
+
+The empirical infrastructure we built is NOT wasted:
+
+1. **Phase 0 scaffolding** (LayerTag, field_provenance, composition
+   registry, fitters subpackage) is exactly what model-based tests
+   will use. No changes needed.
+2. **Phase 0.5 PowerMeter** will be used when we eventually
+   characterize real hardware (Jetson Orin Nano, rental AGX). It's
+   just not the bottleneck.
+3. **Composition check pattern** (predict from layers 1..N, diff
+   against layer N+1) is the same pattern for model-based checks --
+   just replace "measured GFLOPS" with "model's composite prediction."
+4. **CLI runner** (`cli/run_layer_benchmarks.py`) is useful for
+   end-to-end smoke tests on real hardware.
+5. **Fitter pattern** (consume results, write provenance) carries
+   over; model-based fitters validate analytical coefficients rather
+   than fitting from measurements.
+
+## What Changes
+
+| Aspect | Empirical (Phases 1-2) | Model-based (Phases 1-6 retrofit) |
+|--------|----------------------|-----------------------------------|
+| Data source | Real hardware (RAPL, CUDA events) | Analytical model predictions |
+| Coverage | Only SKUs we can physically access | All 50+ hardware mappers |
+| What it validates | Model vs silicon | Model vs itself (internal consistency) |
+| Hardware needed | i7-12700K, Orin Nano, etc. | None (runs in CI) |
+| TPU/KPU coverage | None (no silicon) | Full (exercises the model code paths) |
+| Mis-cancellation detection | Only at boundaries with measurement | At every layer independently |
+| Effort to add a new SKU | Run benchmarks on hardware | Write no code (SKU already has a model) |
+
+---
+
+## Recommendation
+
+Pivot Phases 3-6 to model-based validation. Retroactively add
+model-based checks for Layers 1-2 so every architecture class has
+coverage. Keep the empirical benchmarks as an optional overlay for
+the SKUs where we have hardware access.
+
+See [`docs/plans/model-based-validation-plan.md`](../plans/model-based-validation-plan.md).

--- a/docs/plans/model-based-validation-plan.md
+++ b/docs/plans/model-based-validation-plan.md
@@ -1,0 +1,284 @@
+# Plan: Model-Based Validation of the Micro-Architecture Modeling Infrastructure
+
+**Status:** Draft
+**Date:** 2026-04-17
+**Supersedes:** Phases 3-6 of `docs/plans/bottom-up-microbenchmark-plan.md`
+**Companion:** `docs/assessments/empirical-vs-model-based-validation.md`
+
+## Motivation
+
+The original bottom-up plan called for empirical execution benchmarks
+on real hardware at each of six physical layers. Phases 0-2 revealed
+that:
+
+1. PyTorch-level benchmarks cannot isolate micro-architectural ALU
+   behavior (dispatch overhead is ~1000x larger than the signal).
+2. True empirical Layer 1-2 characterization requires C/C++
+   microbenchmarks -- a significant effort orthogonal to validating
+   the modeling code.
+3. The actual goal is to validate the **modeling infrastructure**
+   (CPU/GPU/TPU/KPU energy and latency models), not to characterize
+   real silicon.
+4. We have 45 hardware mappers across 8 architecture classes. Only
+   2-3 SKUs have physical hardware available. Model-based validation
+   covers all 45 without hardware access.
+
+## What Model-Based Validation Means
+
+Each architecture energy model
+(`StoredProgramEnergyModel`, `DataParallelEnergyModel`,
+`SystolicArrayEnergyModel`, `DomainFlowEnergyModel`, etc.)
+makes layered predictions:
+
+```
+Layer 1: ALU energy = ops x energy_per_op(precision)
+Layer 2: Register/SIMD = Layer 1 + instruction_fetch + register_rw + simd_overhead
+Layer 3: Tile/scratchpad = Layer 2 + L1/L2 cache or scratchpad energy
+Layer 4: On-chip = Layer 3 + L3/LLC/NoC energy
+Layer 5: DRAM = Layer 4 + off-chip memory energy
+Layer 6: Cluster = Layer 5 + inter-chip communication
+```
+
+A model-based test extracts each layer's contribution independently,
+composes them, and verifies:
+
+1. **Internal consistency:** Layer 1 + Layer 2 + Layer 3 + ... = the
+   model's own total. If not, the model has an accounting bug.
+2. **Cross-layer monotonicity:** Adding a layer should only increase
+   energy/latency. A negative contribution signals a coefficient
+   sign error.
+3. **Cross-architecture plausibility:** For the same workload, the
+   models should rank architectures consistently with known physics:
+   TPU < KPU < GPU < CPU for matrix energy at large batch.
+4. **Coefficient sensitivity:** Perturbing one coefficient by +/-10%
+   should produce a proportional change in the affected layer's
+   output, not a disproportionate swing (which indicates coupling).
+5. **Composition accuracy:** The layered prediction should match the
+   model's end-to-end `_calculate_energy` / `_calculate_latency`
+   within numerical tolerance (< 0.1%).
+
+## Architecture Coverage Matrix
+
+| Architecture class | Energy model | Tile model | Mapper count | Representative SKUs |
+|--------------------|-------------|------------|-------------|---------------------|
+| STORED_PROGRAM | `StoredProgramEnergyModel` | -- | 11 | i7-12700K, Xeon 8490H, EPYC 9654, AmpereOne, Orin CPU |
+| DATA_PARALLEL | `DataParallelEnergyModel` | -- | 10 | H100, A100, V100, B100, Jetson Orin AGX/NX/Nano |
+| SYSTOLIC_ARRAY | `SystolicArrayEnergyModel` | `TPUTileEnergyModel` | 6 | TPU v1/v3/v4/v5p, Coral, TPU Edge Pro |
+| DOMAIN_FLOW | `DomainFlowEnergyModel` | `KPUTileEnergyModel` | 3 | KPU T64/T256/T768 |
+| SPATIAL_PARTITION | `SpatialPartitionEnergyModel` | -- | 2 | Hailo-8, Hailo-10H |
+| ADAPTIVE_DATAPATH | `AdaptiveDatapathEnergyModel` | -- | 2 | Xilinx Vitis AI DPU, Stanford Plasticine CGRA |
+| DATA_FLOW_MACHINE | `DataFlowMachineEnergyModel` | -- | 1 | DFM (reference) |
+
+**Total: 7 architecture classes, 10 energy/tile models, 45 mappers.**
+
+## Test Structure
+
+### Per-Architecture-Class Test Module
+
+One test module per architecture class under
+`validation/model_validation/`:
+
+```
+validation/model_validation/
+    __init__.py
+    test_stored_program_consistency.py      # CPU / DSP
+    test_data_parallel_consistency.py       # GPU
+    test_systolic_array_consistency.py      # TPU
+    test_domain_flow_consistency.py         # KPU
+    test_spatial_partition_consistency.py   # Hailo
+    test_adaptive_datapath_consistency.py   # FPGA / CGRA / DPU
+    test_cross_architecture_ranking.py     # Cross-class comparisons
+    conftest.py                            # Shared fixtures (workloads, mappers)
+```
+
+### Five Check Categories Per Architecture
+
+Each test module exercises these five categories:
+
+**1. Layer decomposition (internal consistency)**
+
+```python
+def test_energy_layers_sum_to_total(mapper, workload):
+    """
+    Decompose energy into layers (ALU, register, cache, DRAM, etc.)
+    via the architectural energy model, then verify they sum to the
+    model's total within 0.1%.
+    """
+    total = mapper._calculate_energy(ops, bytes, precision)
+    arch = mapper._calculate_energy_with_architecture(ops, bytes, precision, ctx)
+    layered_sum = arch.compute_overhead + arch.data_movement_overhead + arch.control_overhead + base_compute + base_memory
+    assert abs(layered_sum - total_with_arch) / total_with_arch < 0.001
+```
+
+**2. Monotonicity**
+
+```python
+def test_energy_increases_with_layers(mapper, workload):
+    """Adding architectural overhead should not decrease energy."""
+    base_compute, base_memory = mapper._calculate_energy(ops, bytes, prec)
+    with_arch_compute, with_arch_memory, breakdown = mapper._calculate_energy_with_architecture(ops, bytes, prec)
+    assert with_arch_compute >= base_compute
+    assert with_arch_memory >= base_memory
+```
+
+**3. Precision scaling**
+
+```python
+def test_lower_precision_uses_less_energy(mapper, workload):
+    """INT8 should use less energy than FP32 for the same op count."""
+    e_fp32 = mapper._calculate_energy(ops, bytes, Precision.FP32)
+    e_int8 = mapper._calculate_energy(ops, bytes, Precision.INT8)
+    assert sum(e_int8) < sum(e_fp32)
+```
+
+**4. Coefficient perturbation (sensitivity)**
+
+```python
+def test_alu_energy_scales_with_coefficient(energy_model, workload):
+    """10% increase in energy_per_flop should produce ~10% increase in
+    compute energy, not a 50% swing."""
+    baseline = energy_model.compute_architectural_energy(ops, bytes, ce, de, ctx)
+    # Perturb
+    original = energy_model.alu_energy_per_op
+    energy_model.alu_energy_per_op *= 1.10
+    perturbed = energy_model.compute_architectural_energy(ops, bytes, ce, de, ctx)
+    energy_model.alu_energy_per_op = original
+    # Check proportionality
+    delta = abs(perturbed.compute_overhead - baseline.compute_overhead)
+    expected_delta = baseline.compute_overhead * 0.10
+    assert abs(delta - expected_delta) / expected_delta < 0.50  # within 50% of expected
+```
+
+**5. Cross-mapper consistency (within same architecture class)**
+
+```python
+def test_h100_faster_than_v100(workload):
+    """H100 should produce lower latency than V100 for same workload."""
+    h100 = get_mapper_by_name('H100-SXM5-80GB')
+    v100 = get_mapper_by_name('V100-SXM3-32GB')
+    lat_h100 = h100.map_subgraph(workload, ...).estimated_latency
+    lat_v100 = v100.map_subgraph(workload, ...).estimated_latency
+    assert lat_h100 < lat_v100
+```
+
+### Cross-Architecture Ranking Test
+
+`test_cross_architecture_ranking.py` verifies the taxonomy ordering
+for a reference workload (e.g., 1024x1024 GEMM at INT8):
+
+```python
+def test_energy_ranking_for_large_matmul():
+    """
+    For a large INT8 matmul, energy should follow:
+    TPU < KPU < GPU < CPU
+    (within architecture-class representatives at comparable TDP)
+    """
+    ...
+```
+
+### Workload Fixtures
+
+`conftest.py` provides standardized `SubgraphDescriptor` fixtures:
+
+- **tiny_matmul**: M=N=K=64, 524K FLOPs (tests small-op overhead)
+- **medium_matmul**: M=N=K=1024, 2.1G FLOPs (typical layer)
+- **large_matmul**: M=N=K=4096, 137G FLOPs (compute-bound)
+- **depthwise_conv**: 3x3 depthwise, 56x56x64 (memory-bound)
+- **elementwise**: 1M-element ReLU (zero-compute, pure bandwidth)
+
+## Integration with Existing Infrastructure
+
+### Reuse from Phases 0-2
+
+- **`LayerTag`** — model-based checks use `LayerTag.COMPOSITE` since
+  they test the full model, not a single physical layer.
+- **`field_provenance`** — model-based tests that pass write
+  `THEORETICAL` (confirmed-consistent) provenance; failing tests
+  flag the field as needing investigation.
+- **Composition registry** — model-based checks register via
+  `register_layer_check()` and run in the CI composition gate.
+- **`graphs.calibration.fitters`** — model-based "fitters" verify
+  analytical coefficients rather than fitting from measurements.
+  Same `apply_to_model` pattern.
+
+### CI Integration
+
+All model-based tests run in the existing "Composition Check" CI job
+(added in Phase 0.5). No hardware needed. Tests that touch
+architectural energy models are automatically gated.
+
+## Phasing
+
+### Phase M1: Core consistency tests (1-2 weeks)
+
+Stand up `validation/model_validation/` with:
+- `conftest.py` (workload fixtures, mapper fixtures)
+- `test_stored_program_consistency.py` (CPU: 11 mappers)
+- `test_data_parallel_consistency.py` (GPU: 10 mappers)
+
+Five check categories for each. This alone covers 21 of 45 mappers
+and the two most-used architecture classes.
+
+### Phase M2: Accelerator consistency tests (1 week)
+
+- `test_systolic_array_consistency.py` (TPU: 6 mappers)
+- `test_domain_flow_consistency.py` (KPU: 3 mappers)
+- `test_spatial_partition_consistency.py` (Hailo: 2 mappers)
+- `test_adaptive_datapath_consistency.py` (DPU/CGRA: 2 mappers)
+
+Covers remaining 14 mappers + the DFM reference.
+
+### Phase M3: Cross-architecture ranking (1 week)
+
+- `test_cross_architecture_ranking.py`
+- Taxonomy ordering checks for energy and latency
+- TDP-normalized comparisons (energy per inference per watt)
+- Known-physics invariants (e.g., systolic array should beat stored
+  program for large regular matmuls)
+
+### Phase M4: Sensitivity and regression (1 week)
+
+- Coefficient perturbation tests (10% bump -> proportional response)
+- Snapshot-based regression: record model outputs for a reference
+  workload set, fail if any output changes by > 1% without a
+  corresponding coefficient update
+- Provenance audit: every mapper's field_provenance map should have
+  entries for at least {peak_bandwidth, energy_per_flop_fp32,
+  energy_per_byte}
+
+### Phase M5 (optional): Empirical overlay
+
+When C/C++ microbenchmarks or hardware rental becomes available:
+- Run empirical benchmarks on i7-12700K, Orin Nano
+- Compare against the model-based predictions
+- Upgrade provenance from THEORETICAL to CALIBRATED for fields
+  where measurement and model agree within tolerance
+- File issues for fields where they disagree
+
+## Effort Estimate
+
+- Phase M1: 1-2 weeks (CPU + GPU, most mappers)
+- Phase M2: 1 week (accelerators, fewer mappers but more exotic)
+- Phase M3: 1 week (cross-architecture, mostly fixture wiring)
+- Phase M4: 1 week (sensitivity, snapshot infrastructure)
+- **Total: 4-5 weeks** (vs 13 weeks for the original empirical plan)
+
+The effort is lower because:
+1. No hardware access needed (runs anywhere, including CI)
+2. No C/C++ microbenchmark development
+3. No power-measurement plumbing per SKU
+4. Test patterns are reusable across architecture classes (same 5
+   check categories, different mapper fixtures)
+
+## Definition of Done
+
+1. Every architecture class has a consistency test module exercising
+   all 5 check categories.
+2. All 45 mappers are covered by at least one test.
+3. `test_cross_architecture_ranking.py` verifies the taxonomy
+   ordering for at least 3 workload types.
+4. CI composition gate runs all model-based tests and fails on
+   regression.
+5. No mapper produces negative energy, latency, or utilization.
+6. `field_provenance` is populated for every mapper's core fields
+   after the test suite runs.

--- a/src/graphs/benchmarks/layer2_register_simd/__init__.py
+++ b/src/graphs/benchmarks/layer2_register_simd/__init__.py
@@ -1,0 +1,18 @@
+"""
+Layer 2 - Register File / SIMD Width / Warp / Systolic Fill Benchmarks
+
+Measures the cost of feeding operands into the ALU array beyond the
+pure ALU rate captured in Layer 1. The delta between Layer 1 (raw FMA)
+and Layer 2 (same FMA with SIMD-width and register-pressure variation)
+isolates operand-delivery overhead.
+
+See ``docs/plans/bottom-up-microbenchmark-plan.md`` Phase 2.
+"""
+
+from .simd_width import run_simd_width_sweep
+from .register_pressure import run_register_pressure_benchmark
+
+__all__ = [
+    "run_simd_width_sweep",
+    "run_register_pressure_benchmark",
+]

--- a/src/graphs/benchmarks/layer2_register_simd/register_pressure.py
+++ b/src/graphs/benchmarks/layer2_register_simd/register_pressure.py
@@ -1,0 +1,190 @@
+"""
+Register Pressure Benchmark - Layer 2
+
+Measures the throughput difference between independent FMA chains
+(high ILP, fits in registers) and dependent FMA chains (serial
+dependency, forces pipeline stalls or register spills).
+
+The throughput ratio (independent / dependent) approximates the
+register-delivery overhead: when the CPU can keep all operands in
+registers and exploit ILP, throughput is high; when dependencies
+force stalls or spills to L1, throughput drops.
+
+This benchmark does NOT directly measure register-file energy in
+picojoules (that would require on-die power instrumentation).
+Instead it measures the throughput delta, which the fitter uses
+together with the TechnologyProfile's analytical register energy
+to validate or adjust the model.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+import torch
+
+from graphs.benchmarks.schema import BenchmarkResult, LayerTag, TimingStats
+import statistics
+
+
+@dataclass
+class RegisterPressureResult:
+    """Summary of register-pressure benchmark."""
+    independent_gflops: float
+    dependent_gflops: float
+    ilp_ratio: float
+
+
+def _run_independent_fma(
+    size: int,
+    dtype: torch.dtype,
+    device: str,
+    num_iterations: int,
+) -> float:
+    """Multiple independent accumulations -- high ILP, low register pressure."""
+    a1 = torch.randn(size, dtype=dtype, device=device)
+    a2 = torch.randn(size, dtype=dtype, device=device)
+    a3 = torch.randn(size, dtype=dtype, device=device)
+    a4 = torch.randn(size, dtype=dtype, device=device)
+    b = torch.randn(size, dtype=dtype, device=device)
+    c = torch.randn(size, dtype=dtype, device=device)
+
+    if device.startswith("cuda") and torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    start = time.perf_counter()
+    for _ in range(num_iterations):
+        torch.addcmul(a1, b, c, value=1.0, out=a1)
+        torch.addcmul(a2, b, c, value=1.0, out=a2)
+        torch.addcmul(a3, b, c, value=1.0, out=a3)
+        torch.addcmul(a4, b, c, value=1.0, out=a4)
+
+    if device.startswith("cuda") and torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    elapsed = time.perf_counter() - start
+    # Touch all accumulators to prevent DCE
+    _ = float((a1.sum() + a2.sum() + a3.sum() + a4.sum()).item())
+    return elapsed
+
+
+def _run_dependent_fma(
+    size: int,
+    dtype: torch.dtype,
+    device: str,
+    num_iterations: int,
+) -> float:
+    """Serial dependency chain -- low ILP, high register pressure."""
+    a = torch.randn(size, dtype=dtype, device=device)
+    b = torch.randn(size, dtype=dtype, device=device)
+    c = torch.randn(size, dtype=dtype, device=device)
+
+    if device.startswith("cuda") and torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    start = time.perf_counter()
+    for _ in range(num_iterations):
+        # Each depends on the previous: a = a + b*c, then a = a + b*c, ...
+        torch.addcmul(a, b, c, value=1.0, out=a)
+        torch.addcmul(a, b, c, value=1.0, out=a)
+        torch.addcmul(a, b, c, value=1.0, out=a)
+        torch.addcmul(a, b, c, value=1.0, out=a)
+
+    if device.startswith("cuda") and torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    elapsed = time.perf_counter() - start
+    _ = float(a.sum().item())
+    return elapsed
+
+
+def run_register_pressure_benchmark(
+    device: str = "cpu",
+    precision: str = "fp32",
+    num_elements: int = 4096,
+    num_iterations: int = 2000,
+    warmup_iterations: int = 200,
+    num_trials: int = 5,
+) -> BenchmarkResult:
+    """
+    Measure ILP/register-pressure effect on FMA throughput.
+
+    Runs 4 independent FMA streams vs 4 dependent FMA streams
+    (same total FLOPs) and reports the ILP ratio.
+
+    Returns a BenchmarkResult tagged LayerTag.REGISTER_SIMD with
+    the ILP ratio in extra["ilp_ratio"].
+    """
+    dtype_map = {
+        "fp64": torch.float64,
+        "fp32": torch.float32,
+        "fp16": torch.float16,
+        "bf16": torch.bfloat16,
+    }
+    dtype = dtype_map.get(precision, torch.float32)
+
+    # 4 FMA ops per iteration, 2 FLOPs each = 8 FLOPs/iter/element
+    flops_per_iter = 8 * num_elements
+    total_flops = flops_per_iter * num_iterations
+
+    # Warmup both paths
+    for _ in range(warmup_iterations):
+        _run_independent_fma(num_elements, dtype, device, 1)
+        _run_dependent_fma(num_elements, dtype, device, 1)
+
+    # Measure independent
+    ind_trials = []
+    for _ in range(num_trials):
+        t = _run_independent_fma(num_elements, dtype, device, num_iterations)
+        ind_trials.append(t * 1000.0)
+
+    # Measure dependent
+    dep_trials = []
+    for _ in range(num_trials):
+        t = _run_dependent_fma(num_elements, dtype, device, num_iterations)
+        dep_trials.append(t * 1000.0)
+
+    ind_mean = sum(ind_trials) / len(ind_trials)
+    dep_mean = sum(dep_trials) / len(dep_trials)
+
+    ind_gflops = (total_flops / 1e9) / (ind_mean / 1000.0) if ind_mean > 0 else 0
+    dep_gflops = (total_flops / 1e9) / (dep_mean / 1000.0) if dep_mean > 0 else 0
+    ilp_ratio = ind_gflops / dep_gflops if dep_gflops > 0 else 1.0
+
+    sorted_dep = sorted(dep_trials)
+    n = len(sorted_dep)
+    timing = TimingStats(
+        mean_ms=dep_mean,
+        std_ms=statistics.stdev(dep_trials) if n > 1 else 0.0,
+        min_ms=sorted_dep[0],
+        max_ms=sorted_dep[-1],
+        median_ms=sorted_dep[n // 2],
+        p95_ms=sorted_dep[-1],
+        p99_ms=sorted_dep[-1],
+        num_iterations=n,
+    )
+
+    return BenchmarkResult(
+        spec_name=f"layer2_register_pressure_{precision}_{device}",
+        timestamp=datetime.now().isoformat(),
+        device=device,
+        device_name=device,
+        precision=precision,
+        timing=timing,
+        throughput_ops_per_sec=total_flops / (dep_mean / 1000.0) if dep_mean > 0 else 0,
+        gflops=dep_gflops,
+        layer=LayerTag.REGISTER_SIMD,
+        success=True,
+        extra={
+            "num_elements": num_elements,
+            "num_iterations": num_iterations,
+            "independent_gflops": ind_gflops,
+            "dependent_gflops": dep_gflops,
+            "ilp_ratio": ilp_ratio,
+            "independent_mean_ms": ind_mean,
+            "dependent_mean_ms": dep_mean,
+        },
+    )

--- a/src/graphs/benchmarks/layer2_register_simd/register_pressure.py
+++ b/src/graphs/benchmarks/layer2_register_simd/register_pressure.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
 
 import torch
 

--- a/src/graphs/benchmarks/layer2_register_simd/simd_width.py
+++ b/src/graphs/benchmarks/layer2_register_simd/simd_width.py
@@ -84,7 +84,6 @@ def run_simd_width_sweep(
         # Warmup
         for _ in range(warmup_iterations):
             torch.addcmul(a, b, c, value=1.0, out=a)
-        _dce_guard = float(a.sum().item())  # prevent dead-code elimination
 
         # Empty-loop overhead
         empty_times = [_run_empty_loop(num_iterations, device) for _ in range(3)]

--- a/src/graphs/benchmarks/layer2_register_simd/simd_width.py
+++ b/src/graphs/benchmarks/layer2_register_simd/simd_width.py
@@ -1,0 +1,147 @@
+"""
+SIMD Width Sweep - Layer 2 Operand-Delivery Benchmark
+
+Measures how effective throughput scales with vector length to
+characterize SIMD utilization efficiency. The same FMA kernel from
+Layer 1 is run at different tensor sizes that exercise different
+fractions of the SIMD register width:
+
+- scalar-like: 1 element (no SIMD benefit)
+- narrow: 4 elements (128-bit SSE/NEON width at FP32)
+- medium: 8 elements (256-bit AVX-2 width at FP32)
+- wide: 16 elements (512-bit AVX-512 width at FP32)
+- oversized: 64+ elements (multiple SIMD iterations)
+
+The ratio (wide GFLOPS / narrow GFLOPS) is the measured SIMD
+efficiency -- directly comparable to the 0.70 constant in
+CPUMapper._analyze_vectorization and the 0.90 simd_packed multiplier
+in CIRCUIT_TYPE_MULTIPLIER.
+
+PyTorch selects the SIMD path internally, so we don't force a
+specific instruction set. Instead, we observe the throughput curve
+and infer the effective width from the plateaus.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+import torch
+
+from graphs.benchmarks.schema import BenchmarkResult, LayerTag, TimingStats
+from graphs.benchmarks.layer1_alu.fma_rate import (
+    _run_fma_loop,
+    _run_empty_loop,
+    get_sink_value,
+)
+
+import statistics
+import time
+
+SIMD_WIDTHS = [1, 2, 4, 8, 16, 32, 64, 256, 1024, 4096]
+
+_sink: float = 0.0
+
+
+def run_simd_width_sweep(
+    device: str = "cpu",
+    precision: str = "fp32",
+    widths: Optional[List[int]] = None,
+    num_iterations: int = 10000,
+    warmup_iterations: int = 500,
+    num_trials: int = 5,
+) -> List[BenchmarkResult]:
+    """
+    Sweep FMA throughput across vector lengths on one device/precision.
+
+    Each width uses the same total FLOPs (num_iterations * width * 2)
+    so shorter vectors run more iterations per trial to keep
+    measurement time comparable.
+
+    Returns one BenchmarkResult per width, all tagged LayerTag.REGISTER_SIMD.
+    """
+    global _sink
+
+    if widths is None:
+        widths = SIMD_WIDTHS
+
+    dtype_map = {
+        "fp64": torch.float64,
+        "fp32": torch.float32,
+        "fp16": torch.float16,
+        "bf16": torch.bfloat16,
+    }
+    dtype = dtype_map.get(precision, torch.float32)
+
+    results: List[BenchmarkResult] = []
+
+    for width in widths:
+        a = torch.randn(width, dtype=dtype, device=device)
+        b = torch.randn(width, dtype=dtype, device=device)
+        c = torch.randn(width, dtype=dtype, device=device)
+
+        flops_per_iter = 2 * width
+        total_flops = flops_per_iter * num_iterations
+
+        # Warmup
+        for _ in range(warmup_iterations):
+            torch.addcmul(a, b, c, value=1.0, out=a)
+        _sink = float(a.sum().item())
+
+        # Empty-loop overhead
+        empty_times = [_run_empty_loop(num_iterations, device) for _ in range(3)]
+        empty_overhead = sorted(empty_times)[1]
+
+        # Measurement
+        trial_times_ms = []
+        clamped = 0
+        for _ in range(num_trials):
+            a.normal_()
+            raw_s = _run_fma_loop(a, b, c, num_iterations, device)
+            net_s = raw_s - empty_overhead
+            if net_s <= 0:
+                clamped += 1
+                net_s = 1e-9
+            trial_times_ms.append(net_s * 1000.0)
+        _sink = float(a.sum().item())
+
+        sorted_t = sorted(trial_times_ms)
+        n = len(sorted_t)
+        mean_ms = sum(sorted_t) / n
+        std_ms = statistics.stdev(sorted_t) if n > 1 else 0.0
+
+        timing = TimingStats(
+            mean_ms=mean_ms,
+            std_ms=std_ms,
+            min_ms=sorted_t[0],
+            max_ms=sorted_t[-1],
+            median_ms=sorted_t[n // 2],
+            p95_ms=sorted_t[-1],
+            p99_ms=sorted_t[-1],
+            num_iterations=n,
+        )
+
+        gflops = (total_flops / 1e9) / (mean_ms / 1000.0) if mean_ms > 0 else 0
+
+        results.append(BenchmarkResult(
+            spec_name=f"layer2_simd_width_{width}_{precision}_{device}",
+            timestamp=datetime.now().isoformat(),
+            device=device,
+            device_name=device,
+            precision=precision,
+            timing=timing,
+            throughput_ops_per_sec=total_flops / (mean_ms / 1000.0) if mean_ms > 0 else 0,
+            gflops=gflops,
+            layer=LayerTag.REGISTER_SIMD,
+            success=True,
+            extra={
+                "vector_width": width,
+                "num_iterations": num_iterations,
+                "total_flops": total_flops,
+                "clamped_trials": clamped,
+                "empty_overhead_ms": empty_overhead * 1000.0,
+            },
+        ))
+
+    return results

--- a/src/graphs/benchmarks/layer2_register_simd/simd_width.py
+++ b/src/graphs/benchmarks/layer2_register_simd/simd_width.py
@@ -33,15 +33,11 @@ from graphs.benchmarks.schema import BenchmarkResult, LayerTag, TimingStats
 from graphs.benchmarks.layer1_alu.fma_rate import (
     _run_fma_loop,
     _run_empty_loop,
-    get_sink_value,
 )
 
 import statistics
-import time
 
 SIMD_WIDTHS = [1, 2, 4, 8, 16, 32, 64, 256, 1024, 4096]
-
-_sink: float = 0.0
 
 
 def run_simd_width_sweep(
@@ -55,9 +51,10 @@ def run_simd_width_sweep(
     """
     Sweep FMA throughput across vector lengths on one device/precision.
 
-    Each width uses the same total FLOPs (num_iterations * width * 2)
-    so shorter vectors run more iterations per trial to keep
-    measurement time comparable.
+    Total FLOPs per trial scales with width (num_iterations * width * 2).
+    GFLOPS is normalized per trial so results are comparable across
+    widths. Small widths will have lower absolute GFLOPS due to
+    PyTorch dispatch overhead dominating the per-call cost.
 
     Returns one BenchmarkResult per width, all tagged LayerTag.REGISTER_SIMD.
     """
@@ -87,7 +84,7 @@ def run_simd_width_sweep(
         # Warmup
         for _ in range(warmup_iterations):
             torch.addcmul(a, b, c, value=1.0, out=a)
-        _sink = float(a.sum().item())
+        _dce_guard = float(a.sum().item())  # prevent dead-code elimination
 
         # Empty-loop overhead
         empty_times = [_run_empty_loop(num_iterations, device) for _ in range(3)]
@@ -104,7 +101,7 @@ def run_simd_width_sweep(
                 clamped += 1
                 net_s = 1e-9
             trial_times_ms.append(net_s * 1000.0)
-        _sink = float(a.sum().item())
+        _dce_guard = float(a.sum().item())
 
         sorted_t = sorted(trial_times_ms)
         n = len(sorted_t)

--- a/src/graphs/benchmarks/specs/layer2/simd_width.yaml
+++ b/src/graphs/benchmarks/specs/layer2/simd_width.yaml
@@ -1,0 +1,25 @@
+# Layer 2 SIMD Width Sweep Benchmark Spec
+
+name: "layer2_simd_width"
+description: "SIMD width effective throughput vs scalar"
+category: "microbenchmark"
+layer: "register_simd"
+tags: ["layer2", "simd", "register", "throughput"]
+
+precisions: ["fp32"]
+devices: ["auto"]
+
+# Vector widths to sweep (elements)
+# 1=scalar, 4=SSE/NEON, 8=AVX-2, 16=AVX-512, 64+=multi-iteration
+widths: [1, 2, 4, 8, 16, 32, 64, 256, 1024, 4096]
+
+num_iterations: 10000
+warmup_iterations: 500
+num_trials: 5
+
+execution:
+  warmup_iterations: 500
+  measurement_iterations: 10000
+  min_duration_ms: 50.0
+  sync_before_timing: true
+  clear_cache: false

--- a/src/graphs/calibration/fitters/__init__.py
+++ b/src/graphs/calibration/fitters/__init__.py
@@ -123,9 +123,16 @@ __all__ = [
     # Layer 1 ALU fitter (Phase 1)
     'Layer1ALUFitter',
     'ALUFitResult',
+    # Layer 2 Register/SIMD fitter (Phase 2)
+    'Layer2RegisterFitter',
+    'SIMDFitResult',
 ]
 
 from graphs.calibration.fitters.layer1_alu_fitter import (
     Layer1ALUFitter,
     ALUFitResult,
+)
+from graphs.calibration.fitters.layer2_register_fitter import (
+    Layer2RegisterFitter,
+    SIMDFitResult,
 )

--- a/src/graphs/calibration/fitters/layer2_register_fitter.py
+++ b/src/graphs/calibration/fitters/layer2_register_fitter.py
@@ -113,7 +113,10 @@ class Layer2RegisterFitter:
                     fit.peak_vector_gflops / fit.scalar_gflops
                 )
                 # SIMD efficiency = actual speedup / theoretical speedup
-                fit.simd_efficiency = throughput_ratio / width_ratio
+                # Clamp to [0, 1]: dispatch overhead on small widths
+                # can make the ratio exceed 1.0 or go near 0.
+                raw_eff = throughput_ratio / width_ratio
+                fit.simd_efficiency = max(0.0, min(1.0, raw_eff))
 
         return fit
 

--- a/src/graphs/calibration/fitters/layer2_register_fitter.py
+++ b/src/graphs/calibration/fitters/layer2_register_fitter.py
@@ -1,0 +1,160 @@
+"""
+Layer 2 Register/SIMD Fitter - Fit SIMD Efficiency and Register Overhead
+
+Consumes BenchmarkResult objects from Layer 2 benchmarks (SIMD width
+sweep and register pressure) and fits:
+  - simd_efficiency: ratio of wide-vector throughput to scalar throughput,
+    comparable to the 0.70 constant in CPUMapper._analyze_vectorization
+  - ilp_ratio: independent-vs-dependent FMA throughput ratio, indicating
+    register-delivery overhead
+  - simd_packed_multiplier: measured energy scaling for packed SIMD ops,
+    comparable to the 0.90 in CIRCUIT_TYPE_MULTIPLIER['simd_packed']
+
+Writes EstimationConfidence(CALIBRATED) into
+HardwareResourceModel.field_provenance for the fitted fields.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from graphs.benchmarks.schema import BenchmarkResult, LayerTag
+from graphs.core.confidence import EstimationConfidence
+
+
+@dataclass
+class SIMDFitResult:
+    """Result of fitting Layer 2 SIMD/register coefficients."""
+
+    hardware_name: str = ""
+
+    # Per-width measured throughput (GFLOPS)
+    width_throughput: Dict[int, float] = field(default_factory=dict)
+
+    # Derived SIMD efficiency: wide / scalar throughput
+    # Comparable to CPUMapper's 0.70 vectorization_efficiency
+    simd_efficiency: Optional[float] = None
+
+    # Scalar throughput (width=1) as baseline
+    scalar_gflops: Optional[float] = None
+
+    # Peak vector throughput (largest width with plateau)
+    peak_vector_gflops: Optional[float] = None
+
+    # ILP ratio from register-pressure benchmark
+    ilp_ratio: Optional[float] = None
+
+    # Metadata
+    num_results_used: int = 0
+
+
+class Layer2RegisterFitter:
+    """
+    Fit SIMD efficiency and register-delivery overhead from Layer 2
+    measurements.
+    """
+
+    def fit(
+        self,
+        results: List[BenchmarkResult],
+        hardware_name: str = "",
+    ) -> SIMDFitResult:
+        """
+        Fit SIMD efficiency from width-sweep and register-pressure results.
+
+        Args:
+            results: BenchmarkResults from Layer 2 benchmarks
+                     (layer==REGISTER_SIMD, success==True)
+            hardware_name: SKU name for the fit record
+
+        Returns:
+            SIMDFitResult with derived coefficients
+        """
+        layer2_results = [
+            r for r in results
+            if r.layer is LayerTag.REGISTER_SIMD and r.success
+        ]
+
+        fit = SIMDFitResult(
+            hardware_name=hardware_name,
+            num_results_used=len(layer2_results),
+        )
+
+        # Extract width-sweep data
+        for r in layer2_results:
+            width = r.extra.get("vector_width")
+            if width is not None and r.gflops > 0:
+                fit.width_throughput[width] = r.gflops
+
+        # Extract register-pressure data
+        for r in layer2_results:
+            ilp = r.extra.get("ilp_ratio")
+            if ilp is not None:
+                fit.ilp_ratio = ilp
+
+        # Derive SIMD efficiency
+        if fit.width_throughput:
+            sorted_widths = sorted(fit.width_throughput.keys())
+
+            # Scalar baseline: smallest width
+            fit.scalar_gflops = fit.width_throughput[sorted_widths[0]]
+
+            # Peak vector: largest width (plateau region)
+            fit.peak_vector_gflops = fit.width_throughput[sorted_widths[-1]]
+
+            if fit.scalar_gflops and fit.scalar_gflops > 0:
+                # Efficiency = how much of the SIMD width is effectively used
+                # Normalize by width ratio to get per-lane efficiency
+                max_width = sorted_widths[-1]
+                min_width = sorted_widths[0]
+                width_ratio = max_width / min_width if min_width > 0 else 1.0
+                throughput_ratio = (
+                    fit.peak_vector_gflops / fit.scalar_gflops
+                )
+                # SIMD efficiency = actual speedup / theoretical speedup
+                fit.simd_efficiency = throughput_ratio / width_ratio
+
+        return fit
+
+    @staticmethod
+    def apply_to_model(
+        resource_model: object,
+        fit_result: SIMDFitResult,
+    ) -> None:
+        """
+        Write fitted SIMD coefficients into field_provenance as CALIBRATED.
+        """
+        if not hasattr(resource_model, 'set_provenance'):
+            return
+
+        if fit_result.simd_efficiency is not None:
+            source_parts = [f"layer2_register_fitter/{fit_result.hardware_name}"]
+            source_parts.append(
+                f"simd_eff={fit_result.simd_efficiency:.3f}"
+            )
+            if fit_result.scalar_gflops:
+                source_parts.append(f"scalar={fit_result.scalar_gflops:.1f} GFLOPS")
+            if fit_result.peak_vector_gflops:
+                source_parts.append(f"peak={fit_result.peak_vector_gflops:.1f} GFLOPS")
+            source = ", ".join(source_parts)
+
+            resource_model.set_provenance(
+                "simd_vectorization_efficiency",
+                EstimationConfidence.calibrated(
+                    score=0.85,
+                    source=source,
+                ),
+            )
+
+        if fit_result.ilp_ratio is not None:
+            resource_model.set_provenance(
+                "register_ilp_ratio",
+                EstimationConfidence.calibrated(
+                    score=0.80,
+                    source=(
+                        f"layer2_register_fitter/{fit_result.hardware_name}, "
+                        f"ilp_ratio={fit_result.ilp_ratio:.2f}"
+                    ),
+                ),
+            )

--- a/tests/benchmarks/test_layer2_register_simd.py
+++ b/tests/benchmarks/test_layer2_register_simd.py
@@ -43,10 +43,12 @@ class TestSIMDWidthSweep:
         from graphs.benchmarks.layer2_register_simd.simd_width import (
             run_simd_width_sweep,
         )
+        # Use widths where both are above dispatch-floor (64 vs 4096)
+        # to avoid flakiness from width=1 being dispatch-dominated
         results = run_simd_width_sweep(
             device="cpu",
             precision="fp32",
-            widths=[1, 4096],
+            widths=[64, 4096],
             num_iterations=2000,
             warmup_iterations=100,
             num_trials=3,

--- a/tests/benchmarks/test_layer2_register_simd.py
+++ b/tests/benchmarks/test_layer2_register_simd.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import pytest
 
-from graphs.benchmarks.schema import BenchmarkResult, LayerTag
+from graphs.benchmarks.schema import LayerTag
 
 
 class TestSIMDWidthSweep:

--- a/tests/benchmarks/test_layer2_register_simd.py
+++ b/tests/benchmarks/test_layer2_register_simd.py
@@ -1,0 +1,279 @@
+"""
+Tests for Layer 2 register/SIMD benchmarks.
+
+Tests cover:
+- SIMD width sweep produces results for multiple widths
+- Throughput increases with vector width (validates SIMD is engaged)
+- Register pressure benchmark runs and produces ILP ratio
+- Layer2RegisterFitter fits SIMD efficiency from results
+- Fitter.apply_to_model writes provenance
+- Composition check Layer 1+2 -> GEMM logic
+
+All tests run on CPU with small vectors (<1s total).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graphs.benchmarks.schema import BenchmarkResult, LayerTag
+
+
+class TestSIMDWidthSweep:
+    """Tests for the SIMD width sweep benchmark."""
+
+    def test_sweep_produces_results_per_width(self):
+        from graphs.benchmarks.layer2_register_simd.simd_width import (
+            run_simd_width_sweep,
+        )
+        widths = [4, 64, 1024]
+        results = run_simd_width_sweep(
+            device="cpu",
+            precision="fp32",
+            widths=widths,
+            num_iterations=500,
+            warmup_iterations=50,
+            num_trials=3,
+        )
+        assert len(results) == 3
+        assert all(r.success for r in results)
+        assert all(r.layer is LayerTag.REGISTER_SIMD for r in results)
+
+    def test_wider_vectors_have_higher_throughput(self):
+        from graphs.benchmarks.layer2_register_simd.simd_width import (
+            run_simd_width_sweep,
+        )
+        results = run_simd_width_sweep(
+            device="cpu",
+            precision="fp32",
+            widths=[1, 4096],
+            num_iterations=2000,
+            warmup_iterations=100,
+            num_trials=3,
+        )
+        narrow = results[0]
+        wide = results[1]
+        assert wide.gflops > narrow.gflops
+
+    def test_extra_contains_vector_width(self):
+        from graphs.benchmarks.layer2_register_simd.simd_width import (
+            run_simd_width_sweep,
+        )
+        results = run_simd_width_sweep(
+            device="cpu", precision="fp32",
+            widths=[8], num_iterations=100,
+            warmup_iterations=10, num_trials=2,
+        )
+        assert results[0].extra["vector_width"] == 8
+
+
+class TestRegisterPressure:
+    """Tests for the register pressure benchmark."""
+
+    def test_runs_and_produces_ilp_ratio(self):
+        from graphs.benchmarks.layer2_register_simd.register_pressure import (
+            run_register_pressure_benchmark,
+        )
+        result = run_register_pressure_benchmark(
+            device="cpu",
+            precision="fp32",
+            num_elements=1024,
+            num_iterations=500,
+            warmup_iterations=50,
+            num_trials=3,
+        )
+        assert result.success
+        assert result.layer is LayerTag.REGISTER_SIMD
+        ilp = result.extra["ilp_ratio"]
+        assert ilp > 0
+
+    def test_independent_faster_than_dependent(self):
+        from graphs.benchmarks.layer2_register_simd.register_pressure import (
+            run_register_pressure_benchmark,
+        )
+        result = run_register_pressure_benchmark(
+            device="cpu", precision="fp32",
+            num_elements=4096, num_iterations=1000,
+            warmup_iterations=100, num_trials=3,
+        )
+        ind = result.extra["independent_gflops"]
+        dep = result.extra["dependent_gflops"]
+        # Independent should be at least as fast (usually faster)
+        assert ind >= dep * 0.9
+
+
+class TestLayer2Fitter:
+    """Tests for the SIMD/register fitter."""
+
+    def _make_width_results(self):
+        from graphs.benchmarks.layer2_register_simd.simd_width import (
+            run_simd_width_sweep,
+        )
+        return run_simd_width_sweep(
+            device="cpu", precision="fp32",
+            widths=[4, 64, 4096],
+            num_iterations=500, warmup_iterations=50, num_trials=2,
+        )
+
+    def _make_pressure_result(self):
+        from graphs.benchmarks.layer2_register_simd.register_pressure import (
+            run_register_pressure_benchmark,
+        )
+        return run_register_pressure_benchmark(
+            device="cpu", precision="fp32",
+            num_elements=1024, num_iterations=200,
+            warmup_iterations=50, num_trials=2,
+        )
+
+    def test_fit_extracts_simd_efficiency(self):
+        from graphs.calibration.fitters.layer2_register_fitter import (
+            Layer2RegisterFitter,
+        )
+        results = self._make_width_results()
+        fitter = Layer2RegisterFitter()
+        fit = fitter.fit(results, hardware_name="test-cpu")
+        assert fit.simd_efficiency is not None
+        assert fit.simd_efficiency > 0
+        assert fit.scalar_gflops is not None
+        assert fit.peak_vector_gflops is not None
+
+    def test_fit_extracts_ilp_ratio(self):
+        from graphs.calibration.fitters.layer2_register_fitter import (
+            Layer2RegisterFitter,
+        )
+        pressure = self._make_pressure_result()
+        fitter = Layer2RegisterFitter()
+        fit = fitter.fit([pressure], hardware_name="test-cpu")
+        assert fit.ilp_ratio is not None
+        assert fit.ilp_ratio > 0
+
+    def test_apply_writes_provenance(self):
+        from graphs.calibration.fitters.layer2_register_fitter import (
+            Layer2RegisterFitter,
+        )
+        from graphs.hardware.resource_model import (
+            HardwareResourceModel, HardwareType,
+        )
+        from graphs.core.confidence import ConfidenceLevel
+
+        model = HardwareResourceModel(
+            name="test", hardware_type=HardwareType.CPU,
+            compute_units=10, threads_per_unit=1, warps_per_unit=1,
+            peak_bandwidth=75e9, l1_cache_per_unit=32768,
+            l2_cache_total=25*1024*1024, main_memory=64*1024**3,
+            energy_per_flop_fp32=1.5e-12, energy_per_byte=25e-12,
+        )
+
+        results = self._make_width_results() + [self._make_pressure_result()]
+        fitter = Layer2RegisterFitter()
+        fit = fitter.fit(results, hardware_name="test-cpu")
+        fitter.apply_to_model(model, fit)
+
+        prov = model.get_provenance("simd_vectorization_efficiency")
+        assert prov.level is ConfidenceLevel.CALIBRATED
+
+        prov2 = model.get_provenance("register_ilp_ratio")
+        assert prov2.level is ConfidenceLevel.CALIBRATED
+
+
+class TestCompositionCheck:
+    """Tests for the Layer 1+2 -> GEMM composition check."""
+
+    def test_predict_uses_simd_efficiency(self):
+        from validation.composition.layer1_2_to_layer3_gemm import (
+            predict_gemm_from_layer1_2,
+        )
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+        from graphs.benchmarks.layer2_register_simd.simd_width import (
+            run_simd_width_sweep,
+        )
+
+        layer1 = [run_fma_rate_benchmark(
+            device="cpu", precision="fp32",
+            num_elements=1024, num_iterations=100,
+            warmup_iterations=10, num_trials=2,
+        )]
+        layer2 = run_simd_width_sweep(
+            device="cpu", precision="fp32",
+            widths=[4, 4096], num_iterations=500,
+            warmup_iterations=50, num_trials=2,
+        )
+
+        predicted = predict_gemm_from_layer1_2(layer1, layer2)
+        assert predicted is not None
+        assert predicted > 0
+
+    def test_check_passes_within_tolerance(self):
+        from validation.composition.layer1_2_to_layer3_gemm import (
+            check_layer1_2_to_gemm,
+            predict_gemm_from_layer1_2,
+        )
+        from validation.composition.test_layer_composition import CheckStatus
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+        from graphs.benchmarks.layer2_register_simd.simd_width import (
+            run_simd_width_sweep,
+        )
+
+        layer1 = [run_fma_rate_benchmark(
+            device="cpu", precision="fp32",
+            num_elements=1024, num_iterations=100,
+            warmup_iterations=10, num_trials=2,
+        )]
+        layer2 = run_simd_width_sweep(
+            device="cpu", precision="fp32",
+            widths=[4, 4096], num_iterations=500,
+            warmup_iterations=50, num_trials=2,
+        )
+
+        predicted = predict_gemm_from_layer1_2(layer1, layer2)
+        # 5% off should pass at 8% tolerance
+        check = check_layer1_2_to_gemm(
+            layer1, layer2,
+            measured_gemm_gflops=predicted * 1.05,
+            tolerance=0.08,
+        )
+        assert check.status is CheckStatus.PASSED
+
+    def test_check_fails_beyond_tolerance(self):
+        from validation.composition.layer1_2_to_layer3_gemm import (
+            check_layer1_2_to_gemm,
+            predict_gemm_from_layer1_2,
+        )
+        from validation.composition.test_layer_composition import CheckStatus
+        from graphs.benchmarks.layer1_alu.fma_rate import run_fma_rate_benchmark
+        from graphs.benchmarks.layer2_register_simd.simd_width import (
+            run_simd_width_sweep,
+        )
+
+        layer1 = [run_fma_rate_benchmark(
+            device="cpu", precision="fp32",
+            num_elements=1024, num_iterations=100,
+            warmup_iterations=10, num_trials=2,
+        )]
+        layer2 = run_simd_width_sweep(
+            device="cpu", precision="fp32",
+            widths=[4, 4096], num_iterations=500,
+            warmup_iterations=50, num_trials=2,
+        )
+
+        predicted = predict_gemm_from_layer1_2(layer1, layer2)
+        # 15% off should fail at 8% tolerance
+        check = check_layer1_2_to_gemm(
+            layer1, layer2,
+            measured_gemm_gflops=predicted * 1.15,
+            tolerance=0.08,
+        )
+        assert check.status is CheckStatus.FAILED
+
+    def test_check_skips_when_no_data(self):
+        from validation.composition.layer1_2_to_layer3_gemm import (
+            check_layer1_2_to_gemm,
+        )
+        from validation.composition.test_layer_composition import CheckStatus
+
+        check = check_layer1_2_to_gemm([], [], measured_gemm_gflops=100.0)
+        assert check.status is CheckStatus.SKIPPED
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/validation/composition/layer1_2_to_layer3_gemm.py
+++ b/validation/composition/layer1_2_to_layer3_gemm.py
@@ -51,7 +51,7 @@ def predict_gemm_from_layer1_2(
     if layer1_gflops is None:
         return None
 
-    # Get SIMD efficiency from Layer 2
+    # Get SIMD efficiency from Layer 2 via the fitter (single source of truth)
     simd_efficiency = _extract_simd_efficiency(layer2_results)
     if simd_efficiency is None:
         simd_efficiency = 0.70  # fallback to analytical default
@@ -62,30 +62,11 @@ def predict_gemm_from_layer1_2(
 def _extract_simd_efficiency(
     layer2_results: List[BenchmarkResult],
 ) -> Optional[float]:
-    """Extract SIMD efficiency from width-sweep results."""
-    widths = {}
-    for r in layer2_results:
-        if r.layer is LayerTag.REGISTER_SIMD and r.success:
-            w = r.extra.get("vector_width")
-            if w is not None and r.gflops > 0:
-                widths[w] = r.gflops
-
-    if not widths:
-        return None
-
-    sorted_w = sorted(widths.keys())
-    if len(sorted_w) < 2:
-        return None
-
-    scalar = widths[sorted_w[0]]
-    peak = widths[sorted_w[-1]]
-
-    if scalar <= 0:
-        return None
-
-    width_ratio = sorted_w[-1] / sorted_w[0]
-    throughput_ratio = peak / scalar
-    return throughput_ratio / width_ratio
+    """Extract SIMD efficiency from Layer 2 results via the fitter."""
+    from graphs.calibration.fitters.layer2_register_fitter import Layer2RegisterFitter
+    fitter = Layer2RegisterFitter()
+    fit = fitter.fit(layer2_results)
+    return fit.simd_efficiency
 
 
 def check_layer1_2_to_gemm(

--- a/validation/composition/layer1_2_to_layer3_gemm.py
+++ b/validation/composition/layer1_2_to_layer3_gemm.py
@@ -1,0 +1,162 @@
+"""
+Composition Check: Layer 1+2 -> Layer 3 GEMM Throughput Prediction
+
+Refines the Layer 1 -> GEMM prediction (10% tolerance) by
+incorporating the Layer 2 SIMD efficiency measurement. The
+prediction becomes:
+
+    predicted = layer1_fma_gflops * simd_efficiency * gemm_overhead
+
+where simd_efficiency comes from the Layer 2 width sweep (replacing
+the hardcoded 0.70) and gemm_overhead accounts for GEMM-specific
+overhead beyond SIMD (loop control, address calculation, ~0.85-0.95
+for well-optimized BLAS).
+
+Tolerance: 8% (tighter than Layer 1's 10% because Layer 2 captures
+more of the real operand-delivery cost).
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from graphs.benchmarks.schema import BenchmarkResult, LayerTag
+
+
+def predict_gemm_from_layer1_2(
+    layer1_results: List[BenchmarkResult],
+    layer2_results: List[BenchmarkResult],
+    precision: str = "fp32",
+    gemm_overhead: float = 0.90,
+) -> Optional[float]:
+    """
+    Predict large-GEMM GFLOPS from Layer 1 FMA rate + Layer 2 SIMD efficiency.
+
+    Args:
+        layer1_results: FMA-rate results (LayerTag.ALU)
+        layer2_results: SIMD width sweep results (LayerTag.REGISTER_SIMD)
+        precision: which precision to predict for
+        gemm_overhead: GEMM-specific overhead beyond SIMD (loop control, etc.)
+
+    Returns:
+        Predicted GFLOPS, or None if insufficient data
+    """
+    # Get Layer 1 FMA throughput
+    layer1_gflops = None
+    for r in layer1_results:
+        if r.layer is LayerTag.ALU and r.success and r.precision == precision:
+            layer1_gflops = r.gflops
+            break
+
+    if layer1_gflops is None:
+        return None
+
+    # Get SIMD efficiency from Layer 2
+    simd_efficiency = _extract_simd_efficiency(layer2_results)
+    if simd_efficiency is None:
+        simd_efficiency = 0.70  # fallback to analytical default
+
+    return layer1_gflops * simd_efficiency * gemm_overhead
+
+
+def _extract_simd_efficiency(
+    layer2_results: List[BenchmarkResult],
+) -> Optional[float]:
+    """Extract SIMD efficiency from width-sweep results."""
+    widths = {}
+    for r in layer2_results:
+        if r.layer is LayerTag.REGISTER_SIMD and r.success:
+            w = r.extra.get("vector_width")
+            if w is not None and r.gflops > 0:
+                widths[w] = r.gflops
+
+    if not widths:
+        return None
+
+    sorted_w = sorted(widths.keys())
+    if len(sorted_w) < 2:
+        return None
+
+    scalar = widths[sorted_w[0]]
+    peak = widths[sorted_w[-1]]
+
+    if scalar <= 0:
+        return None
+
+    width_ratio = sorted_w[-1] / sorted_w[0]
+    throughput_ratio = peak / scalar
+    return throughput_ratio / width_ratio
+
+
+def check_layer1_2_to_gemm(
+    layer1_results: List[BenchmarkResult],
+    layer2_results: List[BenchmarkResult],
+    measured_gemm_gflops: float,
+    precision: str = "fp32",
+    hardware: str = "unknown",
+    gemm_overhead: float = 0.90,
+    tolerance: float = 0.08,
+) -> "CompositionCheckResult":
+    """
+    Compare Layer 1+2 GEMM prediction against measured baseline.
+
+    Args:
+        layer1_results: Layer 1 FMA-rate results
+        layer2_results: Layer 2 SIMD width-sweep results
+        measured_gemm_gflops: actual large-GEMM GFLOPS on same SKU
+        precision: precision to check
+        hardware: SKU name
+        gemm_overhead: GEMM overhead factor
+        tolerance: max allowed relative error (0.08 = 8%)
+
+    Returns:
+        CompositionCheckResult
+    """
+    from validation.composition.test_layer_composition import (
+        CheckStatus,
+        CompositionCheckResult,
+    )
+
+    predicted = predict_gemm_from_layer1_2(
+        layer1_results, layer2_results, precision, gemm_overhead,
+    )
+
+    if predicted is None:
+        return CompositionCheckResult(
+            name=f"layer1_2_to_gemm_{precision}",
+            hardware=hardware,
+            predicts_layer=LayerTag.COMPOSITE,
+            from_layers=[LayerTag.ALU, LayerTag.REGISTER_SIMD],
+            status=CheckStatus.SKIPPED,
+            tolerance=tolerance,
+            details="Insufficient Layer 1 or Layer 2 data",
+        )
+
+    if measured_gemm_gflops <= 0:
+        return CompositionCheckResult(
+            name=f"layer1_2_to_gemm_{precision}",
+            hardware=hardware,
+            predicts_layer=LayerTag.COMPOSITE,
+            from_layers=[LayerTag.ALU, LayerTag.REGISTER_SIMD],
+            status=CheckStatus.SKIPPED,
+            tolerance=tolerance,
+            details="No measured GEMM baseline available",
+        )
+
+    relative_error = abs(predicted - measured_gemm_gflops) / measured_gemm_gflops
+    passed = relative_error <= tolerance
+
+    return CompositionCheckResult(
+        name=f"layer1_2_to_gemm_{precision}",
+        hardware=hardware,
+        predicts_layer=LayerTag.COMPOSITE,
+        from_layers=[LayerTag.ALU, LayerTag.REGISTER_SIMD],
+        status=CheckStatus.PASSED if passed else CheckStatus.FAILED,
+        max_relative_error=relative_error,
+        tolerance=tolerance,
+        details=(
+            f"predicted={predicted:.1f} GFLOPS, "
+            f"measured={measured_gemm_gflops:.1f} GFLOPS, "
+            f"error={relative_error*100:.1f}%"
+        ),
+    )


### PR DESCRIPTION
## Summary

Phase 2 of the bottom-up validation plan (TASK-2026-016). Measures operand-delivery overhead (SIMD width scaling, register pressure / ILP) beyond the pure ALU rate captured in Layer 1.

Resolves #7

## Changes

### Benchmarks (`src/graphs/benchmarks/layer2_register_simd/`)
- **`simd_width.py`** -- sweeps vector length from 1 (scalar) to 4096, measuring throughput at each width. The ratio of wide-to-narrow throughput vs width-ratio gives measured SIMD efficiency, comparable to `CPUMapper`'s hardcoded 0.70.
- **`register_pressure.py`** -- 4 independent vs 4 dependent FMA streams. ILP ratio quantifies register-delivery and pipeline-stall overhead.
- **`specs/layer2/simd_width.yaml`** -- benchmark specification

### Fitter (`src/graphs/calibration/fitters/`)
- **`layer2_register_fitter.py`** -- fits `simd_efficiency` and `ilp_ratio`; writes CALIBRATED provenance for `simd_vectorization_efficiency` and `register_ilp_ratio`.

### Composition check (`validation/composition/`)
- **`layer1_2_to_layer3_gemm.py`** -- predicts large-GEMM throughput from Layer 1 FMA rate * Layer 2 SIMD efficiency * gemm_overhead. Tolerance 8% (tighter than Layer 1's 10%).

### Tests
- **`tests/benchmarks/test_layer2_register_simd.py`** -- 12 tests covering width sweep, register pressure, fitter, and composition check with pass/fail boundary tests.

## Test plan

- [x] `pytest tests/benchmarks/test_layer2_register_simd.py` -- 12 passed
- [x] `pytest tests/` (full suite) -- **636 passed, 9 skipped, 0 failed**

## Note on scope

This PR completes the empirical benchmarking approach for Layers 1-2. Per discussion with @Ravenwater, the remaining phases (3-6) will be reframed as model-based composition tests that validate the CPU/GPU/TPU/KPU modeling infrastructure's internal consistency, with empirical benchmarks as an optional overlay when hardware is available.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Layer 2 SIMD width and register pressure benchmarking capabilities
  * Layer 2 calibration fitter extracting SIMD efficiency and instruction-level parallelism metrics
  * Composite validation tool comparing Layer 1+2 predictions against GEMM performance
  * New CLI tool for running layer benchmarks with optional calibration and JSON output

* **Documentation**
  * Assessment comparing empirical vs model-based validation approaches
  * Model-based validation plan for future phases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->