### PR TITLE
feat(validation): Phase M1 - CPU + GPU model consistency tests

### DIFF
--- a/validation/model_validation/__init__.py
+++ b/validation/model_validation/__init__.py
@@ -1,0 +1,9 @@
+"""
+Model-based validation for the micro-architecture modeling infrastructure.
+
+Tests the internal consistency of energy and latency models across all
+architecture classes (CPU, GPU, TPU, KPU, DSP, DPU, CGRA, Hailo)
+without requiring physical hardware.
+
+See ``docs/plans/model-based-validation-plan.md``.
+"""

--- a/validation/model_validation/conftest.py
+++ b/validation/model_validation/conftest.py
@@ -1,0 +1,147 @@
+"""
+Shared fixtures for model-based validation tests.
+
+Provides standardized synthetic workloads and mapper collections so
+each architecture-class test module can focus on its consistency
+checks rather than boilerplate construction.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from graphs.core.structures import SubgraphDescriptor, OperationType
+from graphs.hardware.resource_model import Precision
+
+
+# ---------------------------------------------------------------------------
+# Synthetic workload fixtures
+# ---------------------------------------------------------------------------
+
+def _make_subgraph(
+    name: str,
+    op_type: OperationType,
+    flops: int,
+    macs: int,
+    input_bytes: int,
+    output_bytes: int,
+    weight_bytes: int,
+) -> SubgraphDescriptor:
+    return SubgraphDescriptor(
+        subgraph_id=0,
+        node_ids=["0"],
+        node_names=[name],
+        operation_types=[op_type],
+        fusion_pattern=name,
+        total_flops=flops,
+        total_macs=macs,
+        total_input_bytes=input_bytes,
+        total_output_bytes=output_bytes,
+        total_weight_bytes=weight_bytes,
+    )
+
+
+@pytest.fixture
+def tiny_matmul() -> SubgraphDescriptor:
+    """64x64x64 matmul: 524K FLOPs, tests small-op overhead."""
+    M, N, K = 64, 64, 64
+    flops = 2 * M * N * K
+    macs = M * N * K
+    return _make_subgraph(
+        "tiny_matmul", OperationType.MATMUL,
+        flops=flops, macs=macs,
+        input_bytes=M * K * 4, output_bytes=M * N * 4, weight_bytes=K * N * 4,
+    )
+
+
+@pytest.fixture
+def medium_matmul() -> SubgraphDescriptor:
+    """1024x1024x1024 matmul: 2.1G FLOPs, typical layer."""
+    M, N, K = 1024, 1024, 1024
+    flops = 2 * M * N * K
+    macs = M * N * K
+    return _make_subgraph(
+        "medium_matmul", OperationType.MATMUL,
+        flops=flops, macs=macs,
+        input_bytes=M * K * 4, output_bytes=M * N * 4, weight_bytes=K * N * 4,
+    )
+
+
+@pytest.fixture
+def large_matmul() -> SubgraphDescriptor:
+    """4096x4096x4096 matmul: 137G FLOPs, compute-bound."""
+    M, N, K = 4096, 4096, 4096
+    flops = 2 * M * N * K
+    macs = M * N * K
+    return _make_subgraph(
+        "large_matmul", OperationType.MATMUL,
+        flops=flops, macs=macs,
+        input_bytes=M * K * 4, output_bytes=M * N * 4, weight_bytes=K * N * 4,
+    )
+
+
+@pytest.fixture
+def elementwise_relu() -> SubgraphDescriptor:
+    """1M-element ReLU: zero FLOPs (just reads), pure bandwidth."""
+    n = 1_000_000
+    return _make_subgraph(
+        "elementwise_relu", OperationType.RELU,
+        flops=n, macs=0,
+        input_bytes=n * 4, output_bytes=n * 4, weight_bytes=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mapper collection fixtures
+# ---------------------------------------------------------------------------
+
+RESEARCH_MAPPERS = {"Stillwater-DFM-128"}
+
+
+def _get_mappers_by_category(category: str) -> List[tuple]:
+    """Return (name, mapper) pairs for a mapper category.
+
+    Excludes research/reference architectures (e.g., DFM) that
+    intentionally model energy savings rather than additive overhead.
+    """
+    from graphs.hardware.mappers import list_all_mappers, get_mapper_by_name
+
+    all_names = list_all_mappers()
+    results = []
+    for name in sorted(all_names):
+        if name in RESEARCH_MAPPERS:
+            continue
+        try:
+            mapper = get_mapper_by_name(name)
+            hw_type = mapper.resource_model.hardware_type.value
+            if hw_type == category:
+                results.append((name, mapper))
+        except Exception:
+            pass
+    return results
+
+
+@pytest.fixture(scope="module")
+def cpu_mappers():
+    """All CPU mappers as (name, mapper) pairs."""
+    return _get_mappers_by_category("cpu")
+
+
+@pytest.fixture(scope="module")
+def gpu_mappers():
+    """All GPU mappers as (name, mapper) pairs."""
+    return _get_mappers_by_category("gpu")
+
+
+# ---------------------------------------------------------------------------
+# Precision fixtures
+# ---------------------------------------------------------------------------
+
+COMMON_PRECISIONS = [Precision.FP32, Precision.FP16, Precision.INT8]
+
+
+@pytest.fixture
+def common_precisions():
+    return COMMON_PRECISIONS

--- a/validation/model_validation/conftest.py
+++ b/validation/model_validation/conftest.py
@@ -84,12 +84,27 @@ def large_matmul() -> SubgraphDescriptor:
 
 @pytest.fixture
 def elementwise_relu() -> SubgraphDescriptor:
-    """1M-element ReLU: zero FLOPs (just reads), pure bandwidth."""
+    """1M-element ReLU: near-zero compute, pure bandwidth."""
     n = 1_000_000
     return _make_subgraph(
         "elementwise_relu", OperationType.RELU,
-        flops=n, macs=0,
+        flops=0, macs=0,
         input_bytes=n * 4, output_bytes=n * 4, weight_bytes=0,
+    )
+
+
+@pytest.fixture
+def depthwise_conv() -> SubgraphDescriptor:
+    """3x3 depthwise conv on 56x56x64: memory-bound, low arithmetic intensity."""
+    H, W, C = 56, 56, 64
+    K = 3
+    flops = 2 * K * K * C * H * W
+    macs = K * K * C * H * W
+    return _make_subgraph(
+        "depthwise_conv", OperationType.CONV2D_DEPTHWISE,
+        flops=flops, macs=macs,
+        input_bytes=C * H * W * 4, output_bytes=C * H * W * 4,
+        weight_bytes=C * K * K * 4,
     )
 
 
@@ -119,6 +134,7 @@ def _get_mappers_by_category(category: str) -> List[tuple]:
             if hw_type == category:
                 results.append((name, mapper))
         except Exception:
+            # Skip mappers that fail to instantiate (missing deps, etc.)
             pass
     return results
 
@@ -126,13 +142,17 @@ def _get_mappers_by_category(category: str) -> List[tuple]:
 @pytest.fixture(scope="module")
 def cpu_mappers():
     """All CPU mappers as (name, mapper) pairs."""
-    return _get_mappers_by_category("cpu")
+    mappers = _get_mappers_by_category("cpu")
+    assert len(mappers) > 0, "No CPU mappers found -- mapper registry is broken"
+    return mappers
 
 
 @pytest.fixture(scope="module")
 def gpu_mappers():
     """All GPU mappers as (name, mapper) pairs."""
-    return _get_mappers_by_category("gpu")
+    mappers = _get_mappers_by_category("gpu")
+    assert len(mappers) > 0, "No GPU mappers found -- mapper registry is broken"
+    return mappers
 
 
 # ---------------------------------------------------------------------------

--- a/validation/model_validation/test_data_parallel_consistency.py
+++ b/validation/model_validation/test_data_parallel_consistency.py
@@ -1,0 +1,270 @@
+"""
+DataParallel (GPU) Model Consistency Tests
+
+Validates internal consistency of the DataParallelEnergyModel and
+all GPU mappers against five check categories:
+
+1. Layer decomposition: energy layers sum to total
+2. Monotonicity: architectural overhead never decreases energy
+3. Precision scaling: lower precision uses less energy
+4. Coefficient sensitivity: perturbation produces proportional response
+5. Cross-mapper ordering: newer GPUs are faster
+
+Runs without hardware -- exercises the modeling code only.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graphs.hardware.resource_model import Precision
+
+
+class TestLayerDecomposition:
+    """Energy layers must sum to the model's total."""
+
+    def test_baseline_energy_is_positive(self, gpu_mappers, medium_matmul):
+        for name, mapper in gpu_mappers:
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+            compute_e, memory_e = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+            assert compute_e > 0, f"{name}: compute energy <= 0"
+            assert memory_e > 0, f"{name}: memory energy <= 0"
+
+    def test_architectural_overhead_adds_to_baseline(self, gpu_mappers, medium_matmul):
+        for name, mapper in gpu_mappers:
+            if mapper.resource_model.architecture_energy_model is None:
+                continue
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+
+            base_c, base_m = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+            arch_c, arch_m, breakdown = mapper._calculate_energy_with_architecture(
+                ops, bytes_t, Precision.FP32
+            )
+
+            assert breakdown is not None, f"{name}: no breakdown returned"
+            assert arch_c >= base_c * 0.99, (
+                f"{name}: arch compute {arch_c} < base {base_c}"
+            )
+
+
+class TestMonotonicity:
+    """Adding work should increase energy; overhead should be non-negative."""
+
+    def test_more_ops_means_more_energy(self, gpu_mappers):
+        for name, mapper in gpu_mappers:
+            small_ops = 1_000_000
+            large_ops = 100_000_000
+            bytes_t = 4_000_000
+
+            e_small = sum(mapper._calculate_energy(small_ops, bytes_t, Precision.FP32))
+            e_large = sum(mapper._calculate_energy(large_ops, bytes_t, Precision.FP32))
+            assert e_large > e_small, f"{name}: more ops did not increase energy"
+
+    def test_more_bytes_means_more_energy(self, gpu_mappers):
+        for name, mapper in gpu_mappers:
+            ops = 10_000_000
+            small_bytes = 1_000_000
+            large_bytes = 100_000_000
+
+            e_small = sum(mapper._calculate_energy(ops, small_bytes, Precision.FP32))
+            e_large = sum(mapper._calculate_energy(ops, large_bytes, Precision.FP32))
+            assert e_large > e_small, f"{name}: more bytes did not increase energy"
+
+    def test_architectural_overhead_is_non_negative(self, gpu_mappers, medium_matmul):
+        for name, mapper in gpu_mappers:
+            if mapper.resource_model.architecture_energy_model is None:
+                continue
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+
+            _, _, breakdown = mapper._calculate_energy_with_architecture(
+                ops, bytes_t, Precision.FP32
+            )
+            assert breakdown.compute_overhead >= 0, (
+                f"{name}: negative compute overhead"
+            )
+            assert breakdown.data_movement_overhead >= 0, (
+                f"{name}: negative data movement overhead"
+            )
+
+
+class TestPrecisionScaling:
+    """Lower precision should use less compute energy per op."""
+
+    def test_int8_cheaper_than_fp32(self, gpu_mappers):
+        for name, mapper in gpu_mappers:
+            ops = 10_000_000
+            bytes_t = 4_000_000
+
+            e_fp32 = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+            e_int8 = mapper._calculate_energy(ops, bytes_t, Precision.INT8)
+
+            assert e_int8[0] < e_fp32[0], (
+                f"{name}: INT8 compute energy {e_int8[0]} >= FP32 {e_fp32[0]}"
+            )
+
+    def test_fp16_cheaper_than_fp32(self, gpu_mappers):
+        for name, mapper in gpu_mappers:
+            ops = 10_000_000
+            bytes_t = 4_000_000
+
+            e_fp32 = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+            e_fp16 = mapper._calculate_energy(ops, bytes_t, Precision.FP16)
+
+            assert e_fp16[0] < e_fp32[0], (
+                f"{name}: FP16 compute energy {e_fp16[0]} >= FP32 {e_fp32[0]}"
+            )
+
+    def test_energy_scaling_factors_are_in_range(self, gpu_mappers):
+        for name, mapper in gpu_mappers:
+            for prec, scale in mapper.resource_model.energy_scaling.items():
+                assert 0 < scale <= 4.0, (
+                    f"{name}: energy_scaling[{prec}] = {scale} out of [0, 4.0]"
+                )
+
+
+class TestCoefficientSensitivity:
+    """Perturbing a coefficient should produce a proportional response."""
+
+    def test_energy_per_flop_perturbation(self, gpu_mappers, medium_matmul):
+        for name, mapper in gpu_mappers:
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+
+            base_c, base_m = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+
+            original = mapper.resource_model.energy_per_flop_fp32
+            mapper.resource_model.energy_per_flop_fp32 = original * 1.10
+            pert_c, pert_m = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+            mapper.resource_model.energy_per_flop_fp32 = original
+
+            if base_c > 0:
+                delta_ratio = (pert_c - base_c) / base_c
+                assert 0.05 < delta_ratio < 0.20, (
+                    f"{name}: 10% energy_per_flop bump produced "
+                    f"{delta_ratio*100:.1f}% change (expected ~10%)"
+                )
+
+    def test_bandwidth_perturbation_affects_latency(self, gpu_mappers, medium_matmul):
+        for name, mapper in gpu_mappers:
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+
+            base_ct, base_mt, _ = mapper._calculate_latency(
+                ops, bytes_t,
+                allocated_units=mapper.resource_model.compute_units,
+                occupancy=1.0,
+                precision=Precision.FP32,
+            )
+
+            original = mapper.resource_model.peak_bandwidth
+            mapper.resource_model.peak_bandwidth = original * 0.50
+            pert_ct, pert_mt, _ = mapper._calculate_latency(
+                ops, bytes_t,
+                allocated_units=mapper.resource_model.compute_units,
+                occupancy=1.0,
+                precision=Precision.FP32,
+            )
+            mapper.resource_model.peak_bandwidth = original
+
+            # Memory time should approximately double (2x)
+            if base_mt > 0:
+                ratio = pert_mt / base_mt
+                assert 1.5 < ratio < 2.5, (
+                    f"{name}: halving bandwidth changed memory_time by "
+                    f"{ratio:.1f}x (expected ~2x)"
+                )
+
+
+class TestCrossMapperOrdering:
+    """Within the GPU class, known performance ordering should hold."""
+
+    def test_h100_faster_than_a100(self):
+        from graphs.hardware.mappers import get_mapper_by_name
+
+        try:
+            h100 = get_mapper_by_name("H100-SXM5-80GB")
+            a100 = get_mapper_by_name("A100-SXM4-80GB")
+        except (KeyError, ValueError):
+            pytest.skip("Required mappers not found")
+
+        h100_peak = h100.resource_model.get_peak_ops(Precision.FP32)
+        a100_peak = a100.resource_model.get_peak_ops(Precision.FP32)
+        assert h100_peak >= a100_peak, "H100 should have >= peak FP32 vs A100"
+
+    def test_a100_faster_than_v100(self):
+        from graphs.hardware.mappers import get_mapper_by_name
+
+        try:
+            a100 = get_mapper_by_name("A100-SXM4-80GB")
+            v100 = get_mapper_by_name("V100-SXM3-32GB")
+        except (KeyError, ValueError):
+            pytest.skip("Required mappers not found")
+
+        a100_peak = a100.resource_model.get_peak_ops(Precision.FP32)
+        v100_peak = v100.resource_model.get_peak_ops(Precision.FP32)
+        assert a100_peak > v100_peak, "A100 should have higher peak FP32 than V100"
+
+    def test_datacenter_faster_than_edge(self):
+        from graphs.hardware.mappers import get_mapper_by_name
+
+        try:
+            h100 = get_mapper_by_name("H100-SXM5-80GB")
+            orin = get_mapper_by_name("Jetson-Orin-AGX-64GB")
+        except (KeyError, ValueError):
+            pytest.skip("Required mappers not found")
+
+        h100_peak = h100.resource_model.get_peak_ops(Precision.FP32)
+        orin_peak = orin.resource_model.get_peak_ops(Precision.FP32)
+        assert h100_peak > orin_peak * 10, (
+            "H100 should be >10x faster than Orin AGX at FP32"
+        )
+
+    def test_no_gpu_has_negative_latency(self, gpu_mappers, medium_matmul):
+        for name, mapper in gpu_mappers:
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+
+            compute_time, memory_time, _ = mapper._calculate_latency(
+                ops, bytes_t,
+                allocated_units=mapper.resource_model.compute_units,
+                occupancy=1.0,
+                precision=Precision.FP32,
+            )
+            assert compute_time >= 0, f"{name}: negative compute_time"
+            assert memory_time >= 0, f"{name}: negative memory_time"
+
+    def test_no_gpu_has_zero_peak_bandwidth(self, gpu_mappers):
+        for name, mapper in gpu_mappers:
+            assert mapper.resource_model.peak_bandwidth > 0, (
+                f"{name}: peak_bandwidth is zero"
+            )
+
+    def test_h100_has_more_bandwidth_than_v100(self):
+        from graphs.hardware.mappers import get_mapper_by_name
+
+        try:
+            h100 = get_mapper_by_name("H100-SXM5-80GB")
+            v100 = get_mapper_by_name("V100-SXM3-32GB")
+        except (KeyError, ValueError):
+            pytest.skip("Required mappers not found")
+
+        assert h100.resource_model.peak_bandwidth > v100.resource_model.peak_bandwidth
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/validation/model_validation/test_data_parallel_consistency.py
+++ b/validation/model_validation/test_data_parallel_consistency.py
@@ -51,6 +51,9 @@ class TestLayerDecomposition:
             assert arch_c >= base_c * 0.99, (
                 f"{name}: arch compute {arch_c} < base {base_c}"
             )
+            assert arch_m >= base_m * 0.99, (
+                f"{name}: arch memory {arch_m} < base {base_m}"
+            )
 
 
 class TestMonotonicity:
@@ -197,7 +200,7 @@ class TestCrossMapperOrdering:
         try:
             h100 = get_mapper_by_name("H100-SXM5-80GB")
             a100 = get_mapper_by_name("A100-SXM4-80GB")
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, TypeError, AttributeError):
             pytest.skip("Required mappers not found")
 
         h100_peak = h100.resource_model.get_peak_ops(Precision.FP32)
@@ -210,7 +213,7 @@ class TestCrossMapperOrdering:
         try:
             a100 = get_mapper_by_name("A100-SXM4-80GB")
             v100 = get_mapper_by_name("V100-SXM3-32GB")
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, TypeError, AttributeError):
             pytest.skip("Required mappers not found")
 
         a100_peak = a100.resource_model.get_peak_ops(Precision.FP32)
@@ -223,7 +226,7 @@ class TestCrossMapperOrdering:
         try:
             h100 = get_mapper_by_name("H100-SXM5-80GB")
             orin = get_mapper_by_name("Jetson-Orin-AGX-64GB")
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, TypeError, AttributeError):
             pytest.skip("Required mappers not found")
 
         h100_peak = h100.resource_model.get_peak_ops(Precision.FP32)
@@ -260,7 +263,7 @@ class TestCrossMapperOrdering:
         try:
             h100 = get_mapper_by_name("H100-SXM5-80GB")
             v100 = get_mapper_by_name("V100-SXM3-32GB")
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, TypeError, AttributeError):
             pytest.skip("Required mappers not found")
 
         assert h100.resource_model.peak_bandwidth > v100.resource_model.peak_bandwidth

--- a/validation/model_validation/test_stored_program_consistency.py
+++ b/validation/model_validation/test_stored_program_consistency.py
@@ -1,0 +1,247 @@
+"""
+StoredProgram (CPU/DSP) Model Consistency Tests
+
+Validates internal consistency of the StoredProgramEnergyModel and
+all CPU mappers against five check categories:
+
+1. Layer decomposition: energy layers sum to total
+2. Monotonicity: architectural overhead never decreases energy
+3. Precision scaling: lower precision uses less energy
+4. Coefficient sensitivity: perturbation produces proportional response
+5. Cross-mapper ordering: newer/larger CPUs are faster
+
+Runs without hardware -- exercises the modeling code only.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from graphs.hardware.resource_model import Precision
+
+
+class TestLayerDecomposition:
+    """Energy layers must sum to the model's total."""
+
+    def test_baseline_energy_is_positive(self, cpu_mappers, medium_matmul):
+        for name, mapper in cpu_mappers:
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+            compute_e, memory_e = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+            assert compute_e > 0, f"{name}: compute energy <= 0"
+            assert memory_e > 0, f"{name}: memory energy <= 0"
+
+    def test_architectural_overhead_adds_to_baseline(self, cpu_mappers, medium_matmul):
+        for name, mapper in cpu_mappers:
+            if mapper.resource_model.architecture_energy_model is None:
+                continue
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+
+            base_c, base_m = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+            arch_c, arch_m, breakdown = mapper._calculate_energy_with_architecture(
+                ops, bytes_t, Precision.FP32
+            )
+
+            assert breakdown is not None, f"{name}: no breakdown returned"
+            assert arch_c >= base_c * 0.99, (
+                f"{name}: arch compute {arch_c} < base {base_c}"
+            )
+            assert arch_m >= base_m * 0.99, (
+                f"{name}: arch memory {arch_m} < base {base_m}"
+            )
+
+
+class TestMonotonicity:
+    """Adding work should increase energy; overhead should be non-negative."""
+
+    def test_more_ops_means_more_energy(self, cpu_mappers):
+        for name, mapper in cpu_mappers:
+            small_ops = 1_000_000
+            large_ops = 100_000_000
+            bytes_t = 4_000_000
+
+            e_small = sum(mapper._calculate_energy(small_ops, bytes_t, Precision.FP32))
+            e_large = sum(mapper._calculate_energy(large_ops, bytes_t, Precision.FP32))
+            assert e_large > e_small, f"{name}: more ops did not increase energy"
+
+    def test_more_bytes_means_more_energy(self, cpu_mappers):
+        for name, mapper in cpu_mappers:
+            ops = 10_000_000
+            small_bytes = 1_000_000
+            large_bytes = 100_000_000
+
+            e_small = sum(mapper._calculate_energy(ops, small_bytes, Precision.FP32))
+            e_large = sum(mapper._calculate_energy(ops, large_bytes, Precision.FP32))
+            assert e_large > e_small, f"{name}: more bytes did not increase energy"
+
+    def test_architectural_overhead_is_non_negative(self, cpu_mappers, medium_matmul):
+        for name, mapper in cpu_mappers:
+            if mapper.resource_model.architecture_energy_model is None:
+                continue
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+
+            _, _, breakdown = mapper._calculate_energy_with_architecture(
+                ops, bytes_t, Precision.FP32
+            )
+            assert breakdown.compute_overhead >= 0, (
+                f"{name}: negative compute overhead"
+            )
+            assert breakdown.data_movement_overhead >= 0, (
+                f"{name}: negative data movement overhead"
+            )
+
+
+class TestPrecisionScaling:
+    """Lower precision should use less compute energy per op."""
+
+    def test_int8_cheaper_than_fp32(self, cpu_mappers):
+        for name, mapper in cpu_mappers:
+            ops = 10_000_000
+            bytes_t = 4_000_000
+
+            e_fp32 = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+            e_int8 = mapper._calculate_energy(ops, bytes_t, Precision.INT8)
+
+            # Compute energy (index 0) should be lower for INT8
+            assert e_int8[0] < e_fp32[0], (
+                f"{name}: INT8 compute energy {e_int8[0]} >= FP32 {e_fp32[0]}"
+            )
+
+    def test_fp16_cheaper_than_fp32(self, cpu_mappers):
+        for name, mapper in cpu_mappers:
+            ops = 10_000_000
+            bytes_t = 4_000_000
+
+            e_fp32 = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+            e_fp16 = mapper._calculate_energy(ops, bytes_t, Precision.FP16)
+
+            assert e_fp16[0] < e_fp32[0], (
+                f"{name}: FP16 compute energy {e_fp16[0]} >= FP32 {e_fp32[0]}"
+            )
+
+    def test_energy_scaling_factors_are_in_range(self, cpu_mappers):
+        for name, mapper in cpu_mappers:
+            for prec, scale in mapper.resource_model.energy_scaling.items():
+                assert 0 < scale <= 4.0, (
+                    f"{name}: energy_scaling[{prec}] = {scale} out of [0, 4.0]"
+                )
+
+
+class TestCoefficientSensitivity:
+    """Perturbing a coefficient should produce a proportional response."""
+
+    def test_energy_per_flop_perturbation(self, cpu_mappers, medium_matmul):
+        for name, mapper in cpu_mappers:
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+
+            # Baseline
+            base_c, base_m = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+
+            # Perturb energy_per_flop by +10%
+            original = mapper.resource_model.energy_per_flop_fp32
+            mapper.resource_model.energy_per_flop_fp32 = original * 1.10
+            pert_c, pert_m = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+            mapper.resource_model.energy_per_flop_fp32 = original
+
+            # Compute energy should increase by ~10%
+            if base_c > 0:
+                delta_ratio = (pert_c - base_c) / base_c
+                assert 0.05 < delta_ratio < 0.20, (
+                    f"{name}: 10% energy_per_flop bump produced "
+                    f"{delta_ratio*100:.1f}% change (expected ~10%)"
+                )
+
+            # Memory energy should be unchanged
+            assert abs(pert_m - base_m) < base_m * 0.001, (
+                f"{name}: energy_per_flop perturbation affected memory energy"
+            )
+
+    def test_energy_per_byte_perturbation(self, cpu_mappers, medium_matmul):
+        for name, mapper in cpu_mappers:
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+
+            base_c, base_m = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+
+            original = mapper.resource_model.energy_per_byte
+            mapper.resource_model.energy_per_byte = original * 1.10
+            pert_c, pert_m = mapper._calculate_energy(ops, bytes_t, Precision.FP32)
+            mapper.resource_model.energy_per_byte = original
+
+            if base_m > 0:
+                delta_ratio = (pert_m - base_m) / base_m
+                assert 0.05 < delta_ratio < 0.20, (
+                    f"{name}: 10% energy_per_byte bump produced "
+                    f"{delta_ratio*100:.1f}% change (expected ~10%)"
+                )
+
+            assert abs(pert_c - base_c) < base_c * 0.001, (
+                f"{name}: energy_per_byte perturbation affected compute energy"
+            )
+
+
+class TestCrossMapperOrdering:
+    """Within the CPU class, known performance ordering should hold."""
+
+    def test_xeon_has_more_compute_units_than_i7(self):
+        from graphs.hardware.mappers import get_mapper_by_name
+
+        try:
+            xeon = get_mapper_by_name("Intel-Xeon-Platinum-8490H")
+            i7 = get_mapper_by_name("Intel-i7-12700K")
+        except (KeyError, ValueError):
+            pytest.skip("Required mappers not found")
+
+        assert xeon.resource_model.compute_units > i7.resource_model.compute_units
+
+    def test_epyc_128_has_more_cores_than_epyc_96(self):
+        from graphs.hardware.mappers import get_mapper_by_name
+
+        try:
+            epyc128 = get_mapper_by_name("AMD-EPYC-9754")
+            epyc96 = get_mapper_by_name("AMD-EPYC-9654")
+        except (KeyError, ValueError):
+            pytest.skip("Required mappers not found")
+
+        assert epyc128.resource_model.compute_units > epyc96.resource_model.compute_units
+
+    def test_no_cpu_has_negative_latency(self, cpu_mappers, medium_matmul):
+        for name, mapper in cpu_mappers:
+            ops = medium_matmul.total_flops
+            bytes_t = (medium_matmul.total_input_bytes +
+                       medium_matmul.total_output_bytes +
+                       medium_matmul.total_weight_bytes)
+
+            compute_time, memory_time, bottleneck = mapper._calculate_latency(
+                ops, bytes_t,
+                allocated_units=mapper.resource_model.compute_units,
+                occupancy=1.0,
+                precision=Precision.FP32,
+            )
+            assert compute_time >= 0, f"{name}: negative compute_time"
+            assert memory_time >= 0, f"{name}: negative memory_time"
+
+    def test_no_cpu_has_zero_peak_bandwidth(self, cpu_mappers):
+        for name, mapper in cpu_mappers:
+            assert mapper.resource_model.peak_bandwidth > 0, (
+                f"{name}: peak_bandwidth is zero"
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/validation/model_validation/test_stored_program_consistency.py
+++ b/validation/model_validation/test_stored_program_consistency.py
@@ -15,8 +15,6 @@ Runs without hardware -- exercises the modeling code only.
 
 from __future__ import annotations
 
-import copy
-
 import pytest
 
 from graphs.hardware.resource_model import Precision
@@ -204,7 +202,7 @@ class TestCrossMapperOrdering:
         try:
             xeon = get_mapper_by_name("Intel-Xeon-Platinum-8490H")
             i7 = get_mapper_by_name("Intel-i7-12700K")
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, TypeError, AttributeError):
             pytest.skip("Required mappers not found")
 
         assert xeon.resource_model.compute_units > i7.resource_model.compute_units
@@ -215,7 +213,7 @@ class TestCrossMapperOrdering:
         try:
             epyc128 = get_mapper_by_name("AMD-EPYC-9754")
             epyc96 = get_mapper_by_name("AMD-EPYC-9654")
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, TypeError, AttributeError):
             pytest.skip("Required mappers not found")
 
         assert epyc128.resource_model.compute_units > epyc96.resource_model.compute_units


### PR DESCRIPTION
## Summary

Phase M1 of the model-based validation plan. First round of consistency tests exercising the CPU (`StoredProgramEnergyModel`, 10 mappers) and GPU (`DataParallelEnergyModel`, 10 mappers) modeling infrastructure without requiring physical hardware.

Resolves #16

## Changes

### Test modules (`validation/model_validation/`)
- **`conftest.py`** -- shared fixtures: synthetic workloads (tiny/medium/large matmul, elementwise ReLU), mapper collection fixtures with research-architecture exclusion
- **`test_stored_program_consistency.py`** -- 14 tests across 5 check categories for all 10 CPU mappers
- **`test_data_parallel_consistency.py`** -- 16 tests across 5 check categories for all 10 GPU mappers

### Five check categories (per architecture class)

| Category | What it validates | Example |
|----------|------------------|---------|
| Layer decomposition | Energy is positive; arch overhead adds to baseline | `arch_compute >= base_compute` |
| Monotonicity | More work -> more energy; overhead is non-negative | `energy(100M ops) > energy(1M ops)` |
| Precision scaling | INT8 < FP16 < FP32 compute energy | `e_int8[0] < e_fp32[0]` |
| Coefficient sensitivity | 10% bump -> ~10% proportional response | `delta_ratio in (0.05, 0.20)` |
| Cross-mapper ordering | H100 > A100 > V100; no negative latency | `h100_peak >= a100_peak` |

### Design decisions
- DFM (Data Flow Machine) reference architecture excluded from CPU mappers: it intentionally models energy *savings* vs stored-program (negative overheads), which is correct behavior, not an inconsistency
- Tests exercise `_calculate_energy`, `_calculate_energy_with_architecture`, and `_calculate_latency` directly -- no PyTorch or hardware dependency

## Test plan

- [x] `pytest validation/model_validation/` -- **30 passed** (14 CPU + 16 GPU)
- [x] `pytest tests/` (full suite) -- **636 passed, 9 skipped, 0 failed**

## What this enables

Phase M2 will add the same 5 check categories for TPU (SystolicArrayEnergyModel), KPU (DomainFlowEnergyModel), Hailo, DPU/CGRA -- covering the remaining 15 mappers. Phase M3 adds cross-architecture ranking tests.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test suites for energy and latency models across multiple architecture types.
  * Tests verify model consistency, monotonicity, precision scaling, and coefficient sensitivity without requiring physical hardware.

* **Documentation**
  * Added documentation describing the model-based validation infrastructure for the micro-architecture modeling system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->