### PR TITLE
feat(microarch): M4 Layer 4 L2 cache population

### DIFF
--- a/cli/microarch_validation_report.py
+++ b/cli/microarch_validation_report.py
@@ -73,6 +73,7 @@ from graphs.reporting.layer_panels import (  # noqa: E402
     build_layer1_panel,
     build_layer2_register_panel,
     build_layer3_l1_cache_panel,
+    build_layer4_l2_cache_panel,
 )
 
 
@@ -110,6 +111,7 @@ def build_empty_report_for(sku: str) -> MicroarchReport:
     _populate_layer1_alu(report)
     _populate_layer2_register(report)
     _populate_layer3_l1_cache(report)
+    _populate_layer4_l2_cache(report)
     return report
 
 
@@ -147,6 +149,12 @@ def _populate_layer3_l1_cache(report: MicroarchReport) -> None:
     """Replace the Layer 3 (L1 cache / scratchpad) panel in-place."""
     panel = build_layer3_l1_cache_panel(report.sku)
     _replace_layer_panel(report, LayerTag.L1_CACHE, panel)
+
+
+def _populate_layer4_l2_cache(report: MicroarchReport) -> None:
+    """Replace the Layer 4 (L2 cache) panel in-place."""
+    panel = build_layer4_l2_cache_panel(report.sku)
+    _replace_layer_panel(report, LayerTag.L2_CACHE, panel)
 
 
 def write_json_bundle(reports: List[MicroarchReport], out_dir: Path) -> List[Path]:

--- a/src/graphs/hardware/architectural_energy.py
+++ b/src/graphs/hardware/architectural_energy.py
@@ -458,6 +458,27 @@ class StoredProgramEnergyModel(ArchitecturalEnergyModel):
     l3_hit_rate: float = 0.95                      # 95% L3 hits (of L2 misses)
     # DRAM gets remaining misses
 
+    # M4 Layer 4: per-op-type L2 hit rate. Same shape as the M3 Layer
+    # 3 lookup. Matrix workloads with weight reuse hit L2 ~95% of L1
+    # misses; elementwise streams (no reuse) drop to ~80%; default is
+    # the original 90%. ``l2_hit_rate`` (above) acts as the fallback
+    # when the op-kind is not in this table.
+    l2_hit_rate_by_op: Dict[str, float] = field(
+        default_factory=lambda: {
+            "matrix":      0.95,
+            "elementwise": 0.80,
+            "default":     0.90,
+        }
+    )
+
+    # M4 Layer 4: hardware prefetch effectiveness. Fraction of cache
+    # misses that the hardware prefetcher converts back into hits
+    # before the demand load arrives. Higher on workloads with
+    # regular stride; near-zero on pointer-chasing. THEORETICAL:
+    # not currently consumed by the energy formula but exposed for
+    # downstream models / panel rendering.
+    prefetch_effectiveness: float = 0.85
+
     # ============================================================
     # ALU Energy - Derived from tech_profile in __post_init__
     # ============================================================
@@ -844,6 +865,26 @@ class DataParallelEnergyModel(ArchitecturalEnergyModel):
         }
     )
 
+    # M4 Layer 4: per-op-type L2 hit rate (of L1 misses). Same pattern
+    # as the M3 L1 lookup. Matrix workloads with weight reuse retain
+    # locality at L2 (~95%); elementwise streams that miss L1 don't
+    # have much reuse left (~80%); default keeps the historical 90%.
+    # ``l2_hit_rate`` (above) acts as fallback.
+    l2_hit_rate_by_op: Dict[str, float] = field(
+        default_factory=lambda: {
+            "matrix":      0.95,
+            "elementwise": 0.80,
+            "default":     0.90,
+        }
+    )
+
+    # M4 Layer 4: hardware prefetch effectiveness. Fraction of cache
+    # misses converted to hits by the prefetcher. THEORETICAL: not
+    # currently consumed by the energy formula (GPU prefetch is
+    # implicit in the SIMT memory pipeline) but exposed for
+    # downstream models / panel rendering.
+    prefetch_effectiveness: float = 0.85
+
     # Instruction pipeline stages - derived from tech_profile
     instruction_decode_energy: float = field(init=False)
     instruction_execute_energy: float = field(init=False)
@@ -993,9 +1034,14 @@ class DataParallelEnergyModel(ArchitecturalEnergyModel):
         shared_mem_l1_accesses = int(num_memory_accesses * shared_l1_hit_rate)
         shared_mem_l1_energy = shared_mem_l1_accesses * self.shared_memory_l1_unified_energy_per_byte * 4
 
-        # L2 cache hits (90% of Shared/L1 misses)
+        # L2 cache hits (M4: per-op-type lookup with scalar fallback).
+        # ``op_kind`` is reused from the L1 path above.
+        l2_hit_rate = self.l2_hit_rate_by_op.get(
+            op_kind,
+            self.l2_hit_rate_by_op.get("default", self.l2_hit_rate),
+        )
         shared_l1_misses = num_memory_accesses - shared_mem_l1_accesses
-        l2_accesses = int(shared_l1_misses * self.l2_hit_rate)
+        l2_accesses = int(shared_l1_misses * l2_hit_rate)
         l2_energy = l2_accesses * self.l2_cache_energy_per_byte * 4
 
         # DRAM accesses (remaining L2 misses)
@@ -1065,7 +1111,7 @@ class DataParallelEnergyModel(ArchitecturalEnergyModel):
             f"\n"
             f"3. MEMORY HIERARCHY (NVIDIA Ampere Nomenclature):\n"
             f"   Shared Memory/L1 (unified): {shared_mem_l1_energy*1e12:.2f} pJ ({shared_mem_l1_accesses:,} accesses, {shared_l1_hit_rate*100:.0f}% hit rate, op_kind={op_kind})\n"
-            f"   L2 Cache:                   {l2_energy*1e12:.2f} pJ ({l2_accesses:,} hits, {self.l2_hit_rate*100:.0f}% of Shared/L1 misses)\n"
+            f"   L2 Cache:                   {l2_energy*1e12:.2f} pJ ({l2_accesses:,} hits, {l2_hit_rate*100:.0f}% of Shared/L1 misses, op_kind={op_kind})\n"
             f"   DRAM:                       {dram_energy*1e12:.2f} pJ ({dram_accesses:,} accesses)\n"
             f"\n"
             f"4. SIMT CONTROL OVERHEADS:\n"

--- a/src/graphs/hardware/models/accelerators/kpu_t128.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t128.py
@@ -355,6 +355,11 @@ def kpu_t128_resource_model() -> HardwareResourceModel:
     # compiler stages tiles), so hit rate is deterministic 1.0.
     model.l1_storage_kind = "scratchpad"
 
+    # M4 Layer 4: per-tile L2 SRAM, modeled in M0.5 KPUTileEnergyModel
+    # as 32 KiB. Read directly to avoid drift from the energy model.
+    model.l2_cache_per_unit = tile_energy_model.l2_size_per_tile
+    model.l2_topology = "per-unit"
+
     from graphs.core.confidence import EstimationConfidence
     model.set_provenance(
         "l1_cache_per_unit",
@@ -369,6 +374,24 @@ def kpu_t128_resource_model() -> HardwareResourceModel:
         EstimationConfidence.theoretical(
             score=0.95,
             source="KPU domain-flow architecture: tile-local SRAM, no L1 cache",
+        ),
+    )
+
+    # M4 Layer 4 provenance: per-tile L2 from M0.5 tile energy model
+    model.set_provenance(
+        "l2_cache_per_unit",
+        EstimationConfidence.theoretical(
+            score=0.85,
+            source=("Stillwater KPU-T128: 32 KiB per-tile L2 SRAM, "
+                    "read from KPUTileEnergyModel.l2_size_per_tile "
+                    "(M0.5 abstraction)"),
+        ),
+    )
+    model.set_provenance(
+        "l2_topology",
+        EstimationConfidence.theoretical(
+            score=0.95,
+            source="KPU domain-flow architecture: private per-tile L2",
         ),
     )
 

--- a/src/graphs/hardware/models/accelerators/kpu_t256.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t256.py
@@ -527,6 +527,10 @@ def kpu_t256_resource_model() -> HardwareResourceModel:
     # M0.5 dataflow-tile abstraction.
     model.l1_storage_kind = "scratchpad"
 
+    # M4 Layer 4: per-tile L2 from M0.5 KPUTileEnergyModel.
+    model.l2_cache_per_unit = tile_energy_model.l2_size_per_tile
+    model.l2_topology = "per-unit"
+
     from graphs.core.confidence import EstimationConfidence
     model.set_provenance(
         "l1_cache_per_unit",
@@ -541,6 +545,23 @@ def kpu_t256_resource_model() -> HardwareResourceModel:
         EstimationConfidence.theoretical(
             score=0.95,
             source="KPU domain-flow architecture: tile-local SRAM, no L1 cache",
+        ),
+    )
+
+    # M4 Layer 4 provenance
+    model.set_provenance(
+        "l2_cache_per_unit",
+        EstimationConfidence.theoretical(
+            score=0.85,
+            source=("Stillwater KPU-T256: per-tile L2 SRAM read from "
+                    "KPUTileEnergyModel.l2_size_per_tile (M0.5 abstraction)"),
+        ),
+    )
+    model.set_provenance(
+        "l2_topology",
+        EstimationConfidence.theoretical(
+            score=0.95,
+            source="KPU domain-flow architecture: private per-tile L2",
         ),
     )
 

--- a/src/graphs/hardware/models/accelerators/kpu_t64.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t64.py
@@ -487,6 +487,10 @@ def kpu_t64_resource_model() -> HardwareResourceModel:
     # M0.5 dataflow-tile abstraction.
     model.l1_storage_kind = "scratchpad"
 
+    # M4 Layer 4: per-tile L2 from M0.5 KPUTileEnergyModel.
+    model.l2_cache_per_unit = tile_energy_model.l2_size_per_tile
+    model.l2_topology = "per-unit"
+
     from graphs.core.confidence import EstimationConfidence
     model.set_provenance(
         "l1_cache_per_unit",
@@ -501,6 +505,23 @@ def kpu_t64_resource_model() -> HardwareResourceModel:
         EstimationConfidence.theoretical(
             score=0.95,
             source="KPU domain-flow architecture: tile-local SRAM, no L1 cache",
+        ),
+    )
+
+    # M4 Layer 4 provenance
+    model.set_provenance(
+        "l2_cache_per_unit",
+        EstimationConfidence.theoretical(
+            score=0.85,
+            source=("Stillwater KPU-T64: per-tile L2 SRAM read from "
+                    "KPUTileEnergyModel.l2_size_per_tile (M0.5 abstraction)"),
+        ),
+    )
+    model.set_provenance(
+        "l2_topology",
+        EstimationConfidence.theoretical(
+            score=0.95,
+            source="KPU domain-flow architecture: private per-tile L2",
         ),
     )
 

--- a/src/graphs/hardware/models/edge/coral_edge_tpu.py
+++ b/src/graphs/hardware/models/edge/coral_edge_tpu.py
@@ -221,6 +221,13 @@ def coral_edge_tpu_resource_model() -> HardwareResourceModel:
         # The Coral Edge TPU has a single systolic tile (compute_units=1)
         # exposing 512 KB of L1-equivalent SRAM in this abstraction.
         l1_storage_kind="scratchpad",
+
+        # M4 Layer 4: TPU architectures collapse the conventional L2
+        # into the unified buffer (UB). Modeled as 0 to signal "no
+        # distinct L2 layer"; the ``shared-llc`` topology + the panel
+        # note explain the architectural choice.
+        l2_cache_per_unit=0,
+        l2_topology="shared-llc",
     )
 
     # Attach tile energy model
@@ -252,6 +259,23 @@ def coral_edge_tpu_resource_model() -> HardwareResourceModel:
         EstimationConfidence.theoretical(
             score=0.95,
             source="Edge TPU architectural fact: software-managed UB",
+        ),
+    )
+
+    # M4 Layer 4 provenance: TPU collapses L2 into the unified buffer
+    model.set_provenance(
+        "l2_cache_per_unit",
+        EstimationConfidence.theoretical(
+            score=0.85,
+            source=("Coral Edge TPU has no distinct L2 layer; the "
+                    "unified buffer covers L1 + L2 staging by design"),
+        ),
+    )
+    model.set_provenance(
+        "l2_topology",
+        EstimationConfidence.theoretical(
+            score=0.95,
+            source="TPU architectural fact: UB is the LLC",
         ),
     )
 

--- a/src/graphs/hardware/models/edge/hailo10h.py
+++ b/src/graphs/hardware/models/edge/hailo10h.py
@@ -225,6 +225,12 @@ def hailo10h_resource_model() -> HardwareResourceModel:
         # transformer-optimized; the larger L2 (12 MB) holds the KV
         # cache. L1 still scratchpad-managed by the compiler.
         l1_storage_kind="scratchpad",
+
+        # M4 Layer 4: Hailo-10H expands L2 to 12 MB to hold the
+        # transformer KV cache. 12 MB / 40 dataflow units ~= 307 KiB
+        # per-unit share. LLC by design.
+        l2_cache_per_unit=(12 * 1024 * 1024) // 40,  # ~307 KiB per unit
+        l2_topology="shared-llc",
     )
 
     # M3 Layer 3 provenance
@@ -243,6 +249,24 @@ def hailo10h_resource_model() -> HardwareResourceModel:
         EstimationConfidence.theoretical(
             score=0.95,
             source="Hailo dataflow architecture: software-managed, no L1 cache",
+        ),
+    )
+
+    # M4 Layer 4 provenance for the transformer-sized L2 SRAM layer
+    model.set_provenance(
+        "l2_cache_per_unit",
+        EstimationConfidence.theoretical(
+            score=0.70,
+            source=("Hailo-10H architecture brief: ~12 MB inter-unit "
+                    "shared SRAM (~307 KiB per-unit share), sized to "
+                    "hold the KV cache for transformer inference"),
+        ),
+    )
+    model.set_provenance(
+        "l2_topology",
+        EstimationConfidence.theoretical(
+            score=0.90,
+            source="Hailo dataflow architecture: shared LLC over per-unit L1",
         ),
     )
 

--- a/src/graphs/hardware/models/edge/hailo8.py
+++ b/src/graphs/hardware/models/edge/hailo8.py
@@ -219,6 +219,12 @@ def hailo8_resource_model() -> HardwareResourceModel:
         # dataflow unit. Hailo's compiler statically allocates the
         # working set; no hardware cache.
         l1_storage_kind="scratchpad",
+
+        # M4 Layer 4: Hailo-8's inter-unit shared SRAM acts as the
+        # L2 layer above per-unit L1 partitions. 8 MB shared / 32
+        # units = 256 KiB per-unit share.
+        l2_cache_per_unit=(8 * 1024 * 1024) // 32,  # 256 KiB per unit
+        l2_topology="shared-llc",
     )
 
     # M3 Layer 3 provenance
@@ -236,6 +242,24 @@ def hailo8_resource_model() -> HardwareResourceModel:
         EstimationConfidence.theoretical(
             score=0.95,
             source="Hailo dataflow architecture: software-managed, no L1 cache",
+        ),
+    )
+
+    # M4 Layer 4 provenance for the shared L2 SRAM layer
+    model.set_provenance(
+        "l2_cache_per_unit",
+        EstimationConfidence.theoretical(
+            score=0.70,
+            source=("Hailo-8 architecture brief: ~8 MB inter-unit "
+                    "shared SRAM (256 KiB per-unit share). LLC by "
+                    "design; no DRAM-side cache."),
+        ),
+    )
+    model.set_provenance(
+        "l2_topology",
+        EstimationConfidence.theoretical(
+            score=0.90,
+            source="Hailo dataflow architecture: shared LLC over per-unit L1",
         ),
     )
 

--- a/src/graphs/hardware/models/edge/intel_core_i7_12700k.py
+++ b/src/graphs/hardware/models/edge/intel_core_i7_12700k.py
@@ -261,12 +261,14 @@ def intel_core_i7_12700k_resource_model() -> HardwareResourceModel:
         # / Gracemont core.
         l1_storage_kind="cache",
 
-        # M4 Layer 4: physical L2 per core. Golden Cove P-cores carry
-        # 1.25 MB private L2; Gracemont E-cores share 2 MB per E-core
-        # cluster (4 cores). Reported as the P-core value (P-cores
-        # dominate compute throughput); legacy l2_cache_total still
-        # holds the LLC (= L3 = 25 MB).
-        l2_cache_per_unit=int(1.25 * 1024 * 1024),  # 1.25 MB per P-core
+        # M4 Layer 4: physical L2 capacity. Golden Cove P-cores carry
+        # 1.25 MB private L2 each (8 P x 1.25 MB = 10 MB); Gracemont
+        # E-cores share 2 MB per cluster (4 E in 1 cluster = 2 MB);
+        # physical total = 12 MB. Report as 12 MB / effective_cores so
+        # the Layer 4 cross-SKU chart's per_unit * compute_units
+        # derivation lands on the true physical 12 MB total. Legacy
+        # l2_cache_total still holds the LLC (= L3 = 25 MB).
+        l2_cache_per_unit=(12 * 1024 * 1024) // effective_cores,  # ~1.2 MB
         l2_topology="per-unit",
     )
 
@@ -328,9 +330,11 @@ def intel_core_i7_12700k_resource_model() -> HardwareResourceModel:
         "l2_cache_per_unit",
         EstimationConfidence.theoretical(
             score=0.85,
-            source=("Intel Core i7-12700K datasheet: 1.25 MB private L2 "
-                    "per Golden Cove P-core (Gracemont E-cores share "
-                    "2 MB per cluster; P-core value reported as primary)"),
+            source=("Intel Core i7-12700K datasheet: 12 MB physical L2 "
+                    "(8 P-cores * 1.25 MB private + 4 E-cores * 2 MB / "
+                    "cluster), reported as physical_total / "
+                    "effective_cores so the Layer 4 cross-SKU "
+                    "aggregate matches the datasheet"),
         ),
     )
     model.set_provenance(

--- a/src/graphs/hardware/models/edge/intel_core_i7_12700k.py
+++ b/src/graphs/hardware/models/edge/intel_core_i7_12700k.py
@@ -260,6 +260,14 @@ def intel_core_i7_12700k_resource_model() -> HardwareResourceModel:
         # M3 Layer 3: hardware-managed L1 (split D + I) per Golden Cove
         # / Gracemont core.
         l1_storage_kind="cache",
+
+        # M4 Layer 4: physical L2 per core. Golden Cove P-cores carry
+        # 1.25 MB private L2; Gracemont E-cores share 2 MB per E-core
+        # cluster (4 cores). Reported as the P-core value (P-cores
+        # dominate compute throughput); legacy l2_cache_total still
+        # holds the LLC (= L3 = 25 MB).
+        l2_cache_per_unit=int(1.25 * 1024 * 1024),  # 1.25 MB per P-core
+        l2_topology="per-unit",
     )
 
     # ------------------------------------------------------------------
@@ -312,6 +320,24 @@ def intel_core_i7_12700k_resource_model() -> HardwareResourceModel:
         EstimationConfidence.theoretical(
             score=0.95,
             source="x86 architectural fact: hardware-managed coherent L1",
+        ),
+    )
+
+    # M4 Layer 4 provenance for L2 cache fields
+    model.set_provenance(
+        "l2_cache_per_unit",
+        EstimationConfidence.theoretical(
+            score=0.85,
+            source=("Intel Core i7-12700K datasheet: 1.25 MB private L2 "
+                    "per Golden Cove P-core (Gracemont E-cores share "
+                    "2 MB per cluster; P-core value reported as primary)"),
+        ),
+    )
+    model.set_provenance(
+        "l2_topology",
+        EstimationConfidence.theoretical(
+            score=0.95,
+            source="Alder Lake architectural fact: private per-core L2",
         ),
     )
 

--- a/src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py
+++ b/src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py
@@ -502,6 +502,12 @@ def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
         # configured as shared memory; classified as cache because
         # the dominant deployment uses unified L1 cache mode.
         l1_storage_kind="cache",
+
+        # M4 Layer 4: Orin's L2 is a single 4 MB shared structure.
+        # Ampere SoCs do not have a distinct L3 -- L2 is the LLC.
+        # ``l2_cache_per_unit`` reports the per-SM share (4 MB / 16 SMs).
+        l2_cache_per_unit=(4 * 1024 * 1024) // 16,  # 256 KiB per SM
+        l2_topology="shared-llc",
     )
 
     # M3 Layer 3 provenance for L1 cache fields
@@ -520,6 +526,24 @@ def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
             score=0.80,
             source=("Ampere unified L1: hardware-managed when used as "
                     "L1, software-managed when configured as shared mem"),
+        ),
+    )
+
+    # M4 Layer 4 provenance for L2 (== LLC on Orin AGX)
+    model.set_provenance(
+        "l2_cache_per_unit",
+        EstimationConfidence.theoretical(
+            score=0.85,
+            source=("Jetson Orin AGX datasheet: 4 MB shared L2 across "
+                    "16 Ampere SMs (256 KiB per-SM share)"),
+        ),
+    )
+    model.set_provenance(
+        "l2_topology",
+        EstimationConfidence.theoretical(
+            score=0.90,
+            source=("Ampere SoC architectural fact: L2 is the LLC "
+                    "(no distinct L3 layer)"),
         ),
     )
 

--- a/src/graphs/hardware/models/edge/ryzen_9_8945hs.py
+++ b/src/graphs/hardware/models/edge/ryzen_9_8945hs.py
@@ -199,6 +199,11 @@ def ryzen_9_8945hs_resource_model() -> HardwareResourceModel:
 
         # M3 Layer 3: hardware-managed L1 per Zen 4 core.
         l1_storage_kind="cache",
+
+        # M4 Layer 4: Zen 4 carries 1 MB private L2 per core. Legacy
+        # l2_cache_total holds the 16 MB L3 LLC.
+        l2_cache_per_unit=1 * 1024 * 1024,  # 1 MB per Zen 4 core
+        l2_topology="per-unit",
     )
 
     for prec in (Precision.FP64, Precision.FP32, Precision.FP16,
@@ -244,6 +249,22 @@ def ryzen_9_8945hs_resource_model() -> HardwareResourceModel:
         EstimationConfidence.theoretical(
             score=0.95,
             source="x86 architectural fact: hardware-managed coherent L1",
+        ),
+    )
+
+    # M4 Layer 4 provenance for L2 cache fields
+    model.set_provenance(
+        "l2_cache_per_unit",
+        EstimationConfidence.theoretical(
+            score=0.90,
+            source="AMD Ryzen 9 8945HS (Phoenix, Zen 4): 1 MB private L2 per core",
+        ),
+    )
+    model.set_provenance(
+        "l2_topology",
+        EstimationConfidence.theoretical(
+            score=0.95,
+            source="Zen 4 architectural fact: private per-core L2",
         ),
     )
 

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -824,6 +824,25 @@ class HardwareResourceModel:
     # Provenance: ``l1_storage_kind``.
     l1_storage_kind: Optional[str] = None
 
+    # M4 Layer 4: physical L2 capacity per unit. Distinct from the
+    # legacy ``l2_cache_total`` field, which (per M1 schema convention)
+    # holds the LLC -- on x86 CPUs that's L3, on GPUs / scratchpad
+    # accelerators that's the L2 itself. ``l2_cache_per_unit`` is
+    # always physical L2, so the Layer 4 panel can compare apples to
+    # apples across architectures.
+    # Provenance: ``l2_cache_per_unit``.
+    l2_cache_per_unit: Optional[int] = None
+
+    # M4 Layer 4: L2 topology classifier.
+    # ``"per-unit"`` -- private L2 per core / SM / tile (CPU L2 caches,
+    # KPU tile-local L2, Hailo per-unit L2).
+    # ``"shared"``   -- L2 is a single shared structure (GPU L2 on
+    # discrete GPUs with a distinct L3, multi-GPU systems).
+    # ``"shared-llc"`` -- L2 is shared AND is the last-level cache
+    # (no distinct L3): Ampere SoC GPUs, TPU unified buffer collapse.
+    # Provenance: ``l2_topology``.
+    l2_topology: Optional[str] = None
+
     # Provenance of individual resource-model fields.
     # Maps field name (e.g., "peak_bandwidth", "energy_per_flop_fp32") to
     # the EstimationConfidence that describes where that value came from.

--- a/src/graphs/reporting/layer_panels/__init__.py
+++ b/src/graphs/reporting/layer_panels/__init__.py
@@ -26,6 +26,12 @@ from .layer3_l1_cache import (
     cross_sku_layer3_chart,
     CrossSKULayer3Chart,
 )
+from .layer4_l2_cache import (
+    build_layer4_l2_cache_panel,
+    build_layer4_panels_for_skus,
+    cross_sku_layer4_chart,
+    CrossSKULayer4Chart,
+)
 
 __all__ = [
     "build_layer1_panel",
@@ -40,4 +46,8 @@ __all__ = [
     "build_layer3_panels_for_skus",
     "cross_sku_layer3_chart",
     "CrossSKULayer3Chart",
+    "build_layer4_l2_cache_panel",
+    "build_layer4_panels_for_skus",
+    "cross_sku_layer4_chart",
+    "CrossSKULayer4Chart",
 ]

--- a/src/graphs/reporting/layer_panels/layer4_l2_cache.py
+++ b/src/graphs/reporting/layer_panels/layer4_l2_cache.py
@@ -37,9 +37,6 @@ from graphs.reporting.layer_panels.layer2_register import (
     _process_node_nm,
     _tech_profile_for,
 )
-from graphs.reporting.layer_panels.layer3_l1_cache import (
-    _has_positive_l1,  # used to mirror semantics for L2
-)
 
 
 # Valid topology values for the L2 layer.

--- a/src/graphs/reporting/layer_panels/layer4_l2_cache.py
+++ b/src/graphs/reporting/layer_panels/layer4_l2_cache.py
@@ -1,0 +1,316 @@
+"""
+Layer 4 L2 cache panel builder.
+
+Surfaces per-SKU L2 capacity (per unit + total), L2 read energy
+from the SKU's TechnologyProfile, and the topology classification
+that distinguishes private per-core L2 (CPUs, KPU tile-local L2)
+from shared L2 (discrete GPUs) and shared-LLC (Ampere SoCs, TPU
+unified buffer collapse, Hailo on-chip SRAM).
+
+Crucially, the schema's legacy ``l2_cache_total`` field carries the
+LLC (== L3 on x86), not the physical L2. Layer 4 reads the new
+``l2_cache_per_unit`` field instead, so the panel reports physical
+L2 across architectures consistently. The legacy LLC field is
+reserved for the future Layer 5 panel.
+
+For cache-based SKUs (CPU, GPU L2) the panel surfaces a per-op-type
+hit-rate table from ``DataParallelEnergyModel.l2_hit_rate_by_op``.
+For scratchpad-based SKUs (KPU tile-local L2, Hailo on-chip, TPU
+unified buffer collapse) the hit rate is deterministic 1.0.
+
+KPU SKUs: panel reads ``l2_cache_per_unit`` from the resource model,
+which the SKU factories populate from
+``KPUTileEnergyModel.l2_size_per_tile`` -- no double-counting.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from graphs.benchmarks.schema import LayerTag
+from graphs.core.confidence import ConfidenceLevel
+from graphs.hardware.architectural_energy import DataParallelEnergyModel
+from graphs.hardware.resource_model import HardwareResourceModel
+from graphs.reporting.microarch_schema import LayerPanel
+from graphs.reporting.layer_panels.layer1_alu import resolve_sku_resource_model
+from graphs.reporting.layer_panels.layer2_register import (
+    _process_node_nm,
+    _tech_profile_for,
+)
+from graphs.reporting.layer_panels.layer3_l1_cache import (
+    _has_positive_l1,  # used to mirror semantics for L2
+)
+
+
+# Valid topology values for the L2 layer.
+VALID_L2_TOPOLOGIES = {"per-unit", "shared", "shared-llc"}
+
+
+def _normalize_topology(raw_topo: Optional[str], sku_id: str) -> str:
+    """Normalize ``l2_topology`` to canonical lowercase form.
+
+    Defaults to ``"per-unit"`` (CPU-style) when unset; raises on
+    unknown values so a typo doesn't silently misclassify the layer.
+    """
+    topo = (raw_topo or "per-unit").strip().lower()
+    if topo not in VALID_L2_TOPOLOGIES:
+        raise ValueError(
+            f"Invalid l2_topology '{raw_topo}' for SKU '{sku_id}'. "
+            f"Expected one of: {sorted(VALID_L2_TOPOLOGIES)}."
+        )
+    return topo
+
+
+def _l2_value(model: HardwareResourceModel) -> Optional[int]:
+    """Read the M4 physical L2 per-unit value, treating None as 'absent'.
+
+    A value of 0 is a valid datasheet point (TPU collapses L2 into UB)
+    and should not be confused with 'unset'. The panel rendering
+    differentiates the two cases.
+    """
+    return model.l2_cache_per_unit
+
+
+def _has_l2_field(model: HardwareResourceModel) -> bool:
+    """The M4 field is set (including 0) on this SKU."""
+    return model.l2_cache_per_unit is not None
+
+
+def _default_hit_rate_table() -> Dict[str, float]:
+    """Pull the default per-op-type L2 hit-rate table from the
+    DataParallelEnergyModel dataclass field default."""
+    fld = next(
+        f for f in DataParallelEnergyModel.__dataclass_fields__.values()
+        if f.name == "l2_hit_rate_by_op"
+    )
+    return dict(fld.default_factory())
+
+
+def _format_kib(bytes_value: int) -> str:
+    if bytes_value >= 1024 * 1024:
+        return f"{bytes_value / (1024*1024):.1f}"
+    return f"{bytes_value / 1024:.0f}"
+
+
+def _kib_unit(bytes_value: int) -> str:
+    return "MiB" if bytes_value >= 1024 * 1024 else "KiB"
+
+
+def _format_capacity(bytes_per_unit: int, units: int) -> str:
+    total = bytes_per_unit * units
+    if total >= 1024 * 1024:
+        return f"{total / (1024*1024):.1f} MiB total"
+    return f"{total / 1024:.0f} KiB total"
+
+
+def _provenance_or_theoretical(
+    model: HardwareResourceModel, key: str,
+) -> str:
+    conf = model.get_provenance(key)
+    if conf.level is ConfidenceLevel.UNKNOWN:
+        return ConfidenceLevel.THEORETICAL.value.upper()
+    return conf.level.value.upper()
+
+
+def _l2_energy_pj_per_byte(model: HardwareResourceModel,
+                           sku_id: str) -> float:
+    """L2 energy per byte from the SKU's TechnologyProfile."""
+    tech = _tech_profile_for(model, sku_id)
+    return tech.l2_cache_energy_per_byte_pj
+
+
+# --------------------------------------------------------------------
+# Panel construction
+# --------------------------------------------------------------------
+
+def build_layer4_l2_cache_panel(
+    sku_id: str,
+    model: Optional[HardwareResourceModel] = None,
+) -> LayerPanel:
+    """Build the populated Layer 4 (L2 cache) panel."""
+    if model is None:
+        model = resolve_sku_resource_model(sku_id)
+
+    title = "Layer 4: L2 Cache"
+
+    if model is None or not _has_l2_field(model):
+        return LayerPanel(
+            layer=LayerTag.L2_CACHE,
+            title=title,
+            status="not_populated",
+            summary=f"L2 capacity not reported for {sku_id}.",
+        )
+
+    bytes_per_unit = model.l2_cache_per_unit  # may be 0 (collapsed)
+    units = model.compute_units or 1
+    topology = _normalize_topology(model.l2_topology, sku_id)
+    energy_pj_per_byte = _l2_energy_pj_per_byte(model, sku_id)
+
+    metrics: Dict[str, Dict] = {}
+
+    if bytes_per_unit == 0:
+        # L2 explicitly collapsed (e.g., TPU UB).
+        metrics["L2 status"] = {
+            "value": "collapsed into LLC",
+            "unit":  "",
+            "provenance": _provenance_or_theoretical(
+                model, "l2_cache_per_unit"
+            ),
+        }
+    else:
+        metrics["L2 per unit"] = {
+            "value": _format_kib(bytes_per_unit),
+            "unit":  _kib_unit(bytes_per_unit),
+            "provenance": _provenance_or_theoretical(
+                model, "l2_cache_per_unit"
+            ),
+        }
+        metrics["L2 total"] = {
+            "value": _format_capacity(bytes_per_unit, units),
+            "unit":  "",
+            "provenance": "n/a",
+        }
+
+    metrics["Topology"] = {
+        "value": topology,
+        "unit":  "",
+        "provenance": _provenance_or_theoretical(model, "l2_topology"),
+    }
+
+    metrics["L2 read energy"] = {
+        "value": f"{energy_pj_per_byte:.3f}",
+        "unit":  "pJ/byte",
+        "provenance": "THEORETICAL",
+    }
+
+    metrics["Process / market"] = {
+        "value": f"{_process_node_nm(model)} nm",
+        "unit":  "",
+        "provenance": "n/a",
+    }
+
+    notes: List[str] = []
+
+    # L2-as-LLC annotation for shared-llc topology
+    if topology == "shared-llc":
+        notes.append(
+            "On this SKU L2 is the last-level cache: there is no "
+            "distinct L3 layer between L2 and DRAM. The Layer 5 panel "
+            "(LLC, future M5) will surface zero capacity here."
+        )
+
+    # Hit rate table: cache-managed (per-unit / shared) vs deterministic
+    storage_kind = (model.l1_storage_kind or "").strip().lower()
+    is_cache_managed = (storage_kind == "cache")
+
+    if is_cache_managed and bytes_per_unit > 0:
+        for op_kind, rate in _default_hit_rate_table().items():
+            metrics[f"Hit rate ({op_kind})"] = {
+                "value": f"{rate * 100:.0f}",
+                "unit":  "%",
+                "provenance": "THEORETICAL",
+            }
+        notes.append(
+            "Per-op-type L2 hit rates from "
+            "DataParallelEnergyModel.l2_hit_rate_by_op (M4 lift). "
+            "Matrix workloads with weight reuse retain L2 locality "
+            "(~95% of L1 misses); elementwise streams that miss L1 "
+            "have little reuse left (~80%)."
+        )
+    elif bytes_per_unit > 0:
+        # Scratchpad-managed: deterministic
+        metrics["Hit rate (deterministic)"] = {
+            "value": "100",
+            "unit":  "%",
+            "provenance": "n/a",
+        }
+        notes.append(
+            "Software-managed L2 SRAM: the host compiler stages "
+            "data through this layer, so the hit rate is deterministic "
+            "1.0 by construction. Matches the M0.5 dataflow-tile "
+            "abstraction for KPU SKUs."
+        )
+
+    summary_pieces = [f"L2 layer for {sku_id}: "]
+    if bytes_per_unit == 0:
+        summary_pieces.append(
+            "no distinct L2 layer (collapsed into LLC). "
+        )
+    else:
+        summary_pieces.append(
+            f"{_format_kib(bytes_per_unit)} {_kib_unit(bytes_per_unit)} "
+            f"per unit ({_format_capacity(bytes_per_unit, units)}) at "
+            f"{energy_pj_per_byte:.3f} pJ/byte. "
+        )
+    summary_pieces.append(f"Topology: {topology}.")
+    summary = "".join(summary_pieces)
+
+    return LayerPanel(
+        layer=LayerTag.L2_CACHE,
+        title=title,
+        status="theoretical",
+        summary=summary,
+        metrics=metrics,
+        notes=notes,
+    )
+
+
+def build_layer4_panels_for_skus(
+    sku_ids: List[str],
+) -> Dict[str, LayerPanel]:
+    return {sku: build_layer4_l2_cache_panel(sku) for sku in sku_ids}
+
+
+# --------------------------------------------------------------------
+# Cross-SKU comparison
+# --------------------------------------------------------------------
+
+@dataclass
+class CrossSKULayer4Chart:
+    """Per-SKU L2 capacity, energy, topology classification."""
+    skus: List[str]
+    l2_per_unit_bytes: Dict[str, int]
+    l2_total_bytes: Dict[str, int]
+    topology: Dict[str, str]
+    energy_pj_per_byte: Dict[str, float]
+    provenance: Dict[str, str]
+
+
+def cross_sku_layer4_chart(sku_ids: List[str]) -> CrossSKULayer4Chart:
+    chart = CrossSKULayer4Chart(
+        skus=list(sku_ids),
+        l2_per_unit_bytes={},
+        l2_total_bytes={},
+        topology={},
+        energy_pj_per_byte={},
+        provenance={},
+    )
+
+    models: Dict[str, Optional[HardwareResourceModel]] = {
+        sku: resolve_sku_resource_model(sku) for sku in sku_ids
+    }
+
+    for sku in sku_ids:
+        m = models.get(sku)
+        if m is None or not _has_l2_field(m):
+            continue
+        per_unit = m.l2_cache_per_unit  # may be 0
+        units = m.compute_units or 1
+        chart.l2_per_unit_bytes[sku] = per_unit
+        chart.l2_total_bytes[sku] = per_unit * units
+        chart.topology[sku] = _normalize_topology(m.l2_topology, sku)
+        chart.energy_pj_per_byte[sku] = _l2_energy_pj_per_byte(m, sku)
+        chart.provenance[sku] = _provenance_or_theoretical(
+            m, "l2_cache_per_unit"
+        )
+
+    return chart
+
+
+__all__ = [
+    "build_layer4_l2_cache_panel",
+    "build_layer4_panels_for_skus",
+    "cross_sku_layer4_chart",
+    "CrossSKULayer4Chart",
+    "VALID_L2_TOPOLOGIES",
+]

--- a/src/graphs/reporting/microarch_html_template.py
+++ b/src/graphs/reporting/microarch_html_template.py
@@ -534,6 +534,84 @@ def _render_layer3_cross_sku_table(reports: List[MicroarchReport]) -> str:
 """
 
 
+def _render_layer4_cross_sku_table(reports: List[MicroarchReport]) -> str:
+    """
+    Render an L2 capacity / topology / energy table across SKUs.
+    """
+    try:
+        from graphs.reporting.layer_panels import cross_sku_layer4_chart
+    except Exception:
+        return ""
+
+    sku_ids = [r.sku for r in reports]
+    chart = cross_sku_layer4_chart(sku_ids)
+    if not chart.l2_per_unit_bytes:
+        return ""
+
+    name_lookup = {r.sku: (r.display_name or r.sku) for r in reports}
+    header_cells = "".join(
+        f"<th>{html.escape(name_lookup.get(sku, sku))}</th>"
+        for sku in chart.skus
+    )
+
+    def _kib_str(b):
+        if b is None:
+            return "--"
+        if b == 0:
+            return "collapsed"
+        if b >= 1024 * 1024:
+            return f"{b / (1024*1024):.1f} MiB"
+        return f"{b / 1024:.0f} KiB"
+
+    def _row(label, getter, fmt):
+        cells = [f"<th>{html.escape(label)}</th>"]
+        for sku in chart.skus:
+            v = getter(sku)
+            if v is None:
+                cells.append("<td>--</td>")
+            else:
+                cells.append(f"<td>{fmt(v)}</td>")
+        return "<tr>" + "".join(cells) + "</tr>"
+
+    rows = (
+        _row("L2 per unit",
+             lambda s: chart.l2_per_unit_bytes.get(s), _kib_str)
+        + _row("L2 total",
+               lambda s: chart.l2_total_bytes.get(s), _kib_str)
+        + _row("Topology",
+               lambda s: chart.topology.get(s),
+               lambda v: html.escape(v))
+        + _row("Energy (pJ/byte)",
+               lambda s: chart.energy_pj_per_byte.get(s),
+               lambda v: f"{v:.3f}")
+    )
+
+    badge_cells = []
+    for sku in chart.skus:
+        prov = chart.provenance.get(sku, "UNKNOWN")
+        badge = _safe_status_class(prov.lower())
+        badge_cells.append(
+            f'<td><span class="badge {badge}">{html.escape(prov)}</span></td>'
+        )
+    rows += "<tr><th>Provenance</th>" + "".join(badge_cells) + "</tr>"
+
+    return f"""
+<section>
+  <h3>Layer 4: L2 cache capacity / topology across SKUs</h3>
+  <p class="meta">Physical L2 from
+  <code>l2_cache_per_unit</code> (M4 field). Topology distinguishes
+  private per-core L2 (CPUs, KPU tile-local) from shared L2 and
+  shared-LLC (Ampere SoCs, TPU UB collapse, Hailo on-chip SRAM).
+  &quot;collapsed&quot; means the SKU has no distinct L2 layer
+  -- the unified buffer covers L1 + L2 staging by design.</p>
+  <table class="layer4-cross">
+    <thead><tr><th></th>{header_cells}</tr></thead>
+    <tbody>{rows}</tbody>
+  </table>
+</section>
+"""
+
+
 def render_comparison_page(
     reports: List[MicroarchReport],
     repo_root: Path,
@@ -546,8 +624,9 @@ def render_comparison_page(
       - Layer 1 peak-TOPS-per-precision table (M1)
       - Layer 2 register-energy table (M2)
       - Layer 3 L1-capacity / storage-kind table (M3)
+      - Layer 4 L2-capacity / topology table (M4)
 
-    M4-M8 add later layer comparison sections.
+    M5-M8 add later layer comparison sections.
     """
     assets = _load_logo(repo_root)
     rows = "".join(
@@ -560,6 +639,7 @@ def render_comparison_page(
     layer1_section = _render_layer1_cross_sku_table(reports)
     layer2_section = _render_layer2_cross_sku_table(reports)
     layer3_section = _render_layer3_cross_sku_table(reports)
+    layer4_section = _render_layer4_cross_sku_table(reports)
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -569,8 +649,8 @@ def render_comparison_page(
 table {{ width: 100%; border-collapse: collapse; background: #fff; }}
 table th, table td {{ padding: 10px 12px; border-bottom: 1px solid #e3e6eb; text-align: left; }}
 table th {{ font-size: 12px; text-transform: uppercase; color: #586374; background: #f3f5f8; }}
-table.layer1-cross td, table.layer2-cross td, table.layer3-cross td {{ text-align: right; }}
-table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.layer3-cross th:first-child {{ text-align: left; }}
+table.layer1-cross td, table.layer2-cross td, table.layer3-cross td, table.layer4-cross td {{ text-align: right; }}
+table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.layer3-cross th:first-child, table.layer4-cross th:first-child {{ text-align: left; }}
   </style>
 </head>
 <body>
@@ -579,8 +659,8 @@ table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.laye
   <section class="page-header">
     <h2>Compare across SKUs</h2>
     <div class="meta">
-      Layers 1-3 (ALU, Register File, L1 Cache / Scratchpad) populated;
-      remaining layer comparisons follow at M4-M8.
+      Layers 1-4 (ALU, Register File, L1 Cache / Scratchpad, L2 Cache)
+      populated; remaining layer comparisons follow at M5-M8.
     </div>
   </section>
   {_render_legend()}
@@ -593,6 +673,7 @@ table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.laye
   {layer1_section}
   {layer2_section}
   {layer3_section}
+  {layer4_section}
 </main>
 {_render_brand_footer("microarch-model-delivery-plan.md")}
 </body>

--- a/tests/cli/test_microarch_validation_report.py
+++ b/tests/cli/test_microarch_validation_report.py
@@ -50,20 +50,14 @@ def test_json_bundle_emits_one_file_per_sku(tmp_path: Path, cli_main):
         "soc_data_movement", "external_memory",
     ]
     assert layer_tags == expected
-    # M3: layers 1+2+3 populated; layers 4-7 remain not_populated.
+    # M4: layers 1-4 populated as 'theoretical'; layers 5-7 remain
+    # 'not_populated' until their milestones land.
     layer_status = {p["layer"]: p["status"] for p in payload["layers"]}
-    assert layer_status["alu"] != "not_populated", (
-        f"Layer 1 should be populated at M1, got {layer_status['alu']}"
-    )
-    assert layer_status["register"] != "not_populated", (
-        f"Layer 2 should be populated at M2, got {layer_status['register']}"
-    )
-    assert layer_status["l1_cache"] != "not_populated", (
-        f"Layer 3 should be populated at M3, got {layer_status['l1_cache']}"
-    )
-    assert layer_status["l2_cache"] != "not_populated", (
-        f"Layer 4 should be populated at M4, got {layer_status['l2_cache']}"
-    )
+    for tag in ("alu", "register", "l1_cache", "l2_cache"):
+        assert layer_status[tag] == "theoretical", (
+            f"Layer for {tag} should be 'theoretical' at M4, "
+            f"got {layer_status[tag]!r}"
+        )
     for tag in ("l3_cache", "soc_data_movement", "external_memory"):
         assert layer_status[tag] == "not_populated"
 

--- a/tests/cli/test_microarch_validation_report.py
+++ b/tests/cli/test_microarch_validation_report.py
@@ -1,7 +1,8 @@
 """Smoke tests for cli/microarch_validation_report.py.
 
 M0 shipped empty panels; M1 populates Layer 1 (ALU); M2 populates
-Layer 2 (Register File); M3 populates Layer 3 (L1 cache / scratchpad).
+Layer 2 (Register File); M3 populates Layer 3 (L1 cache / scratchpad);
+M4 populates Layer 4 (L2 cache).
 """
 from __future__ import annotations
 
@@ -60,8 +61,10 @@ def test_json_bundle_emits_one_file_per_sku(tmp_path: Path, cli_main):
     assert layer_status["l1_cache"] != "not_populated", (
         f"Layer 3 should be populated at M3, got {layer_status['l1_cache']}"
     )
-    for tag in ("l2_cache", "l3_cache",
-                "soc_data_movement", "external_memory"):
+    assert layer_status["l2_cache"] != "not_populated", (
+        f"Layer 4 should be populated at M4, got {layer_status['l2_cache']}"
+    )
+    for tag in ("l3_cache", "soc_data_movement", "external_memory"):
         assert layer_status[tag] == "not_populated"
 
 

--- a/tests/reporting/test_layer4_l2_cache_panel.py
+++ b/tests/reporting/test_layer4_l2_cache_panel.py
@@ -216,7 +216,13 @@ class TestCrossSKUChart:
         chart = cross_sku_layer4_chart(REQUIRED_SKUS)
         for sku in REQUIRED_SKUS:
             m = resolve_sku_resource_model(sku)
-            expected = m.l2_cache_per_unit * (m.compute_units or 1)
+            # Don't paper over a missing compute_units with `or 1` --
+            # tighten the contract so a regression that drops the field
+            # surfaces directly here.
+            assert m.compute_units is not None and m.compute_units > 0, (
+                f"{sku} missing compute_units"
+            )
+            expected = m.l2_cache_per_unit * m.compute_units
             assert chart.l2_total_bytes[sku] == expected
 
     def test_cpu_l2_per_unit_above_kpu(self):
@@ -226,17 +232,37 @@ class TestCrossSKUChart:
         assert (chart.l2_per_unit_bytes["intel_core_i7_12700k"]
                 > chart.l2_per_unit_bytes["kpu_t128"] * 10)
 
-    def test_kpu_dominates_aggregate_at_t256(self):
-        """T256 has 256 tiles * 32 KiB = 8 MiB total L2, larger than
-        most cache-based SKUs in absolute terms."""
+    def test_kpu_t256_aggregate_l2_is_8_mib(self):
+        """T256 = 256 tiles * 32 KiB per-tile L2 = exactly 8 MiB total.
+        Tight bound to catch any double-counting regression."""
         chart = cross_sku_layer4_chart(REQUIRED_SKUS)
         kpu_t256_total = chart.l2_total_bytes["kpu_t256"]
-        # Assert it's at least 4 MiB
-        assert kpu_t256_total >= 4 * 1024 * 1024
+        assert kpu_t256_total == 8 * 1024 * 1024, (
+            f"T256 aggregate L2 expected 8 MiB, got "
+            f"{kpu_t256_total / (1024*1024):.2f} MiB"
+        )
+
+    def test_i7_aggregate_l2_matches_datasheet_12mb(self):
+        """The major M4 review fix: 8 P x 1.25 + 4 E (cluster) = 12 MB.
+        per_unit * effective_cores must land within one cache line
+        of 12 MiB. (Exact equality is impossible because 12 MiB / 10
+        effective cores is not an integer; the small rounding gap is
+        intentional and stays well below a 64-byte cache line.)"""
+        chart = cross_sku_layer4_chart(["intel_core_i7_12700k"])
+        total = chart.l2_total_bytes["intel_core_i7_12700k"]
+        target = 12 * 1024 * 1024
+        assert abs(total - target) < 64, (
+            f"i7 aggregate L2 {total} differs from 12 MiB by "
+            f"{target - total} bytes (>= 64 B cache line)"
+        )
 
     def test_provenance_all_theoretical(self):
         chart = cross_sku_layer4_chart(REQUIRED_SKUS)
-        assert all(p == "THEORETICAL" for p in chart.provenance.values())
+        # Compare against the canonical enum value rather than a
+        # hard-coded string so the test survives any future renaming
+        # of ConfidenceLevel.THEORETICAL.
+        expected = ConfidenceLevel.THEORETICAL.value.upper()
+        assert all(p == expected for p in chart.provenance.values())
 
 
 class TestTopologyValidation:

--- a/tests/reporting/test_layer4_l2_cache_panel.py
+++ b/tests/reporting/test_layer4_l2_cache_panel.py
@@ -1,0 +1,276 @@
+"""Self-consistency tests for the M4 Layer 4 (L2 cache) panel."""
+from __future__ import annotations
+
+import pytest
+
+from graphs.benchmarks.schema import LayerTag
+from graphs.core.confidence import ConfidenceLevel
+from graphs.hardware.architectural_energy import DataParallelEnergyModel
+from graphs.reporting.layer_panels import (
+    build_layer4_l2_cache_panel,
+    cross_sku_layer4_chart,
+    resolve_sku_resource_model,
+)
+from graphs.reporting.layer_panels.layer4_l2_cache import (
+    VALID_L2_TOPOLOGIES,
+    _has_l2_field,
+    _normalize_topology,
+)
+
+
+REQUIRED_SKUS = [
+    "jetson_orin_agx_64gb",
+    "intel_core_i7_12700k",
+    "ryzen_9_8945hs",
+    "kpu_t64",
+    "kpu_t128",
+    "kpu_t256",
+    "coral_edge_tpu",
+]
+OPTIONAL_SKUS = ["hailo8", "hailo10h"]
+TARGET_SKUS = REQUIRED_SKUS + OPTIONAL_SKUS
+
+# Topology partitioning that downstream tests rely on.
+PER_UNIT_SKUS = [
+    "intel_core_i7_12700k", "ryzen_9_8945hs",
+    "kpu_t64", "kpu_t128", "kpu_t256",
+]
+SHARED_LLC_SKUS = [
+    "jetson_orin_agx_64gb", "coral_edge_tpu", "hailo8", "hailo10h",
+]
+
+
+def _skip_if_optional_unresolved(sku: str) -> None:
+    if sku in OPTIONAL_SKUS and resolve_sku_resource_model(sku) is None:
+        pytest.skip(f"{sku} model unavailable in this environment")
+
+
+class TestPerSKUSchemaFields:
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_l2_cache_per_unit_field_present(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert _has_l2_field(m), f"{sku} missing l2_cache_per_unit"
+
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_l2_topology_set(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert m.l2_topology in VALID_L2_TOPOLOGIES, (
+            f"{sku} l2_topology={m.l2_topology!r}"
+        )
+
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_l2_provenance_theoretical(self, sku):
+        m = resolve_sku_resource_model(sku)
+        for key in ("l2_cache_per_unit", "l2_topology"):
+            conf = m.get_provenance(key)
+            assert conf.level is ConfidenceLevel.THEORETICAL, (
+                f"{sku}/{key} provenance={conf.level}"
+            )
+
+    @pytest.mark.parametrize("sku", PER_UNIT_SKUS)
+    def test_per_unit_skus_classified_correctly(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert m.l2_topology == "per-unit"
+
+    @pytest.mark.parametrize("sku", SHARED_LLC_SKUS)
+    def test_shared_llc_skus_classified_correctly(self, sku):
+        _skip_if_optional_unresolved(sku)
+        m = resolve_sku_resource_model(sku)
+        assert m.l2_topology == "shared-llc"
+
+
+class TestLegacyFieldUntouched:
+    """The schema's legacy ``l2_cache_total`` field (which holds the
+    LLC per M1 convention) must not collide with the new
+    ``l2_cache_per_unit``."""
+
+    def test_legacy_l2_total_unchanged_on_cpu(self):
+        m = resolve_sku_resource_model("intel_core_i7_12700k")
+        assert m.l2_cache_total == 25 * 1024 * 1024  # 25 MB L3 LLC
+
+    def test_legacy_l2_total_holds_llc_on_ryzen(self):
+        m = resolve_sku_resource_model("ryzen_9_8945hs")
+        assert m.l2_cache_total == 16 * 1024 * 1024  # 16 MB L3 LLC
+
+    def test_per_unit_distinct_from_total_on_cpu(self):
+        """Physical L2 per core (1.25 MB) should differ from the LLC."""
+        m = resolve_sku_resource_model("intel_core_i7_12700k")
+        assert m.l2_cache_per_unit < m.l2_cache_total
+
+
+class TestEnergyModelL2Lookup:
+    def test_per_op_l2_table_exists(self):
+        from graphs.hardware.technology_profile import EDGE_8NM_LPDDR5
+        m = DataParallelEnergyModel(tech_profile=EDGE_8NM_LPDDR5)
+        assert isinstance(m.l2_hit_rate_by_op, dict)
+        for op_kind in ("matrix", "elementwise", "default"):
+            assert op_kind in m.l2_hit_rate_by_op
+            rate = m.l2_hit_rate_by_op[op_kind]
+            assert 0.0 < rate <= 1.0
+
+    def test_matrix_l2_hit_above_elementwise(self):
+        from graphs.hardware.technology_profile import EDGE_8NM_LPDDR5
+        m = DataParallelEnergyModel(tech_profile=EDGE_8NM_LPDDR5)
+        assert m.l2_hit_rate_by_op["matrix"] > m.l2_hit_rate_by_op["elementwise"]
+
+    def test_scalar_field_unchanged(self):
+        from graphs.hardware.technology_profile import EDGE_8NM_LPDDR5
+        m = DataParallelEnergyModel(tech_profile=EDGE_8NM_LPDDR5)
+        assert m.l2_hit_rate == 0.90
+
+    def test_prefetch_effectiveness_default(self):
+        from graphs.hardware.technology_profile import EDGE_8NM_LPDDR5
+        m = DataParallelEnergyModel(tech_profile=EDGE_8NM_LPDDR5)
+        assert 0.0 < m.prefetch_effectiveness <= 1.0
+
+    def test_per_op_lookup_drives_compute_energy(self):
+        """L2 per-op rate must flow through compute_architectural_energy.
+        Like the M3 L1 case, the explanation echoes the chosen rate."""
+        from graphs.hardware.technology_profile import EDGE_8NM_LPDDR5
+        m = DataParallelEnergyModel(tech_profile=EDGE_8NM_LPDDR5)
+        m.l2_hit_rate_by_op = {
+            "matrix":      0.95,
+            "elementwise": 0.40,
+            "default":     0.90,
+        }
+        e_matrix = m.compute_architectural_energy(
+            ops=10000, bytes_transferred=40000,
+            execution_context={"op_kind": "matrix"},
+        )
+        e_elem = m.compute_architectural_energy(
+            ops=10000, bytes_transferred=40000,
+            execution_context={"op_kind": "elementwise"},
+        )
+        # The L2 explanation line carries the rate label
+        assert "95% of Shared/L1 misses" in e_matrix.explanation
+        assert "40% of Shared/L1 misses" in e_elem.explanation
+
+
+class TestPanelBuilder:
+    @pytest.mark.parametrize("sku", TARGET_SKUS)
+    def test_panel_is_l2_layer(self, sku):
+        _skip_if_optional_unresolved(sku)
+        panel = build_layer4_l2_cache_panel(sku)
+        assert panel.layer is LayerTag.L2_CACHE
+        assert "L2" in panel.title
+
+    @pytest.mark.parametrize("sku", TARGET_SKUS)
+    def test_panel_populated(self, sku):
+        _skip_if_optional_unresolved(sku)
+        panel = build_layer4_l2_cache_panel(sku)
+        assert panel.status != "not_populated"
+        assert panel.metrics
+
+    @pytest.mark.parametrize("sku", TARGET_SKUS)
+    def test_panel_has_topology(self, sku):
+        _skip_if_optional_unresolved(sku)
+        panel = build_layer4_l2_cache_panel(sku)
+        assert "Topology" in panel.metrics
+        assert panel.metrics["Topology"]["value"] in VALID_L2_TOPOLOGIES
+
+    def test_cpu_panel_includes_per_op_hit_rates(self):
+        panel = build_layer4_l2_cache_panel("intel_core_i7_12700k")
+        hit_metrics = [k for k in panel.metrics if "Hit rate (" in k]
+        assert len(hit_metrics) >= 3
+
+    def test_kpu_panel_marks_deterministic(self):
+        panel = build_layer4_l2_cache_panel("kpu_t128")
+        joined = " ".join(panel.notes).lower()
+        assert "software-managed" in joined or "deterministic" in joined
+
+    def test_coral_panel_marks_collapsed(self):
+        """TPU has L2 collapsed into UB; panel must not pretend a
+        capacity exists."""
+        panel = build_layer4_l2_cache_panel("coral_edge_tpu")
+        assert "L2 status" in panel.metrics
+        assert panel.metrics["L2 status"]["value"] == "collapsed into LLC"
+        # Must NOT have "L2 per unit" / "L2 total" fields when collapsed
+        assert "L2 per unit" not in panel.metrics
+        assert "L2 total" not in panel.metrics
+
+    def test_shared_llc_panels_have_llc_note(self):
+        """Every shared-llc SKU must mention the L2-is-LLC fact."""
+        for sku in ("jetson_orin_agx_64gb", "coral_edge_tpu",
+                    "hailo8", "hailo10h"):
+            _skip_if_optional_unresolved(sku)
+            panel = build_layer4_l2_cache_panel(sku)
+            joined = " ".join(panel.notes).lower()
+            assert ("last-level cache" in joined or "llc" in joined), (
+                f"{sku} shared-llc panel missing LLC annotation"
+            )
+
+    def test_unknown_sku_returns_unpopulated(self):
+        panel = build_layer4_l2_cache_panel("definitely_not_a_sku")
+        assert panel.status == "not_populated"
+
+
+class TestCrossSKUChart:
+    def test_chart_includes_required_skus(self):
+        chart = cross_sku_layer4_chart(REQUIRED_SKUS)
+        for sku in REQUIRED_SKUS:
+            assert sku in chart.l2_per_unit_bytes
+            assert sku in chart.topology
+            assert sku in chart.energy_pj_per_byte
+
+    def test_l2_total_equals_per_unit_times_units(self):
+        chart = cross_sku_layer4_chart(REQUIRED_SKUS)
+        for sku in REQUIRED_SKUS:
+            m = resolve_sku_resource_model(sku)
+            expected = m.l2_cache_per_unit * (m.compute_units or 1)
+            assert chart.l2_total_bytes[sku] == expected
+
+    def test_cpu_l2_per_unit_above_kpu(self):
+        """CPU per-core L2 (>= 1 MB) should be much larger than KPU
+        per-tile L2 (~32 KiB)."""
+        chart = cross_sku_layer4_chart(["intel_core_i7_12700k", "kpu_t128"])
+        assert (chart.l2_per_unit_bytes["intel_core_i7_12700k"]
+                > chart.l2_per_unit_bytes["kpu_t128"] * 10)
+
+    def test_kpu_dominates_aggregate_at_t256(self):
+        """T256 has 256 tiles * 32 KiB = 8 MiB total L2, larger than
+        most cache-based SKUs in absolute terms."""
+        chart = cross_sku_layer4_chart(REQUIRED_SKUS)
+        kpu_t256_total = chart.l2_total_bytes["kpu_t256"]
+        # Assert it's at least 4 MiB
+        assert kpu_t256_total >= 4 * 1024 * 1024
+
+    def test_provenance_all_theoretical(self):
+        chart = cross_sku_layer4_chart(REQUIRED_SKUS)
+        assert all(p == "THEORETICAL" for p in chart.provenance.values())
+
+
+class TestTopologyValidation:
+    def test_normalize_canonicalizes_case(self):
+        assert _normalize_topology("Per-Unit", "x") == "per-unit"
+        assert _normalize_topology(" SHARED ", "x") == "shared"
+        assert _normalize_topology("SHARED-LLC", "x") == "shared-llc"
+
+    def test_normalize_defaults_when_unset(self):
+        assert _normalize_topology(None, "x") == "per-unit"
+        assert _normalize_topology("", "x") == "per-unit"
+
+    def test_normalize_rejects_unknown(self):
+        with pytest.raises(ValueError, match="Invalid l2_topology"):
+            _normalize_topology("disjoint", "test_sku")
+
+    def test_panel_raises_on_invalid_topology(self):
+        m = resolve_sku_resource_model("kpu_t128")
+        original = m.l2_topology
+        try:
+            m.l2_topology = "MUDDLED"
+            with pytest.raises(ValueError):
+                build_layer4_l2_cache_panel("kpu_t128", model=m)
+        finally:
+            m.l2_topology = original
+
+
+class TestNoDoubleCounting:
+    """KPU SKUs read l2_cache_per_unit from the resource model, which
+    the SKU factory populated from the M0.5 KPUTileEnergyModel.
+    Confirm the values match exactly."""
+
+    @pytest.mark.parametrize("sku", ("kpu_t64", "kpu_t128", "kpu_t256"))
+    def test_kpu_l2_matches_tile_energy_model(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert hasattr(m, "tile_energy_model")
+        assert m.l2_cache_per_unit == m.tile_energy_model.l2_size_per_tile


### PR DESCRIPTION
## Summary
- Populate Layer 4 (L2 cache) panel for all 9 target SKUs.
- Add new `l2_cache_per_unit` and `l2_topology` fields on `HardwareResourceModel`, sidestepping the M1 convention that `l2_cache_total` carries the LLC.
- Per-op-type `l2_hit_rate_by_op` lookup (matrix=0.95, elementwise=0.80, default=0.90) plumbed into the GPU energy path; declared on both energy models.
- New `prefetch_effectiveness` coefficient on both energy models.
- Cross-SKU comparison page gains a Layer 4 capacity / topology / energy table.

## Why
Layer 4 is where GPU architectures that collapse L3 into an enlarged L2 diverge from CPU-style three-level caches. The new `l2_topology` annotation (per-unit / shared / shared-llc) keeps that visible. KPU SKUs read the per-tile L2 capacity directly from the M0.5 `KPUTileEnergyModel`; an explicit no-double-counting test guards the invariant.

## Design choices

- **New `l2_cache_per_unit` field** rather than reusing `l2_cache_total`: the legacy field carries the LLC per the M1 schema convention (which is L3 on x86, but L2 on Ampere). The new field is always physical L2.
- **`l2_topology` enum** with three values: `per-unit` (private CPU L2, KPU tile-local L2), `shared` (discrete GPU L2 with distinct L3), `shared-llc` (Ampere SoC, TPU UB collapse, Hailo on-chip SRAM).
- **Energy plumbing only on the GPU path.** `StoredProgramEnergyModel.l2_hit_rate` is declared but never consumed (its cold/warm/hot state model handles cache traversal differently). I added the dict for documentation parity but did not invent fake plumbing for it.
- **Coral Edge TPU L2 = 0** with `shared-llc` topology and a `"collapsed"` badge, rather than inventing a phantom capacity.

## Sample numbers (Layer 4 cross-SKU)

| SKU | L2 / unit | L2 total | Topology | Energy (pJ/B) |
|---|---|---|---|---|
| i7-12700K (Alder Lake) | 1.25 MiB | 12.5 MiB | per-unit | 1.31 |
| Ryzen 9 8945HS (Zen 4) | 1 MiB | 8 MiB | per-unit | 0.58 |
| Jetson Orin AGX | 256 KiB | 4 MiB | shared-llc | 1.05 |
| Coral Edge TPU | -- | collapsed | shared-llc | 1.83 |
| KPU T128 | 32 KiB | 4 MiB | per-unit | 1.83 |
| KPU T256 | 32 KiB | 8 MiB | per-unit | 1.83 |
| Hailo-8 | 256 KiB | 8 MiB | shared-llc | 1.83 |
| Hailo-10H | 307 KiB | 12 MiB | shared-llc | 1.83 |

## Test results

| Suite | Result |
|---|---|
| `tests/reporting/test_layer4_l2_cache_panel.py` | **82 passed** |
| Full unit suite (`tests/`) | 1158 passed, 7 skipped, 1 xfailed |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Inspect `compare.html` for the Layer 4 table (collapsed badge on Coral, shared-llc on Orin / Hailo / Coral)
- [x] When CI is green: `gh pr ready <#>`

Resolves #30

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Layer 4 (L2) coverage to microarchitecture reports: capacity, topology, per-byte energy, and per-op hit-rate modeling.
  * Extended hardware resource descriptions to include explicit L2 capacity/topology across CPUs, TPUs, KPUs, and accelerators.
* **Reporting**
  * New cross-SKU Layer 4 section and summary on the comparison page.
* **Tests**
  * Added comprehensive tests for Layer 4 panels and updated milestone expectations in the CLI smoke test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->