### PR TITLE
feat(microarch): M6 Layer 6 SoC data movement / on-chip fabric

### DIFF
--- a/cli/microarch_validation_report.py
+++ b/cli/microarch_validation_report.py
@@ -75,6 +75,7 @@ from graphs.reporting.layer_panels import (  # noqa: E402
     build_layer3_l1_cache_panel,
     build_layer4_l2_cache_panel,
     build_layer5_l3_cache_panel,
+    build_layer6_soc_fabric_panel,
 )
 
 
@@ -114,6 +115,7 @@ def build_empty_report_for(sku: str) -> MicroarchReport:
     _populate_layer3_l1_cache(report)
     _populate_layer4_l2_cache(report)
     _populate_layer5_l3_cache(report)
+    _populate_layer6_soc_fabric(report)
     return report
 
 
@@ -163,6 +165,12 @@ def _populate_layer5_l3_cache(report: MicroarchReport) -> None:
     """Replace the Layer 5 (L3 / LLC) panel in-place."""
     panel = build_layer5_l3_cache_panel(report.sku)
     _replace_layer_panel(report, LayerTag.L3_CACHE, panel)
+
+
+def _populate_layer6_soc_fabric(report: MicroarchReport) -> None:
+    """Replace the Layer 6 (SoC data movement) panel in-place."""
+    panel = build_layer6_soc_fabric_panel(report.sku)
+    _replace_layer_panel(report, LayerTag.SOC_DATA_MOVEMENT, panel)
 
 
 def write_json_bundle(reports: List[MicroarchReport], out_dir: Path) -> List[Path]:

--- a/src/graphs/hardware/architectural_energy.py
+++ b/src/graphs/hardware/architectural_energy.py
@@ -27,6 +27,7 @@ from typing import Dict, Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from graphs.hardware.technology_profile import TechnologyProfile
     from graphs.hardware.operand_fetch import OperandFetchBreakdown
+    from graphs.hardware.fabric_model import SoCFabricModel
 
 
 class ArchitectureClass(Enum):
@@ -2748,9 +2749,19 @@ class KPUTileEnergyModel:
     sure_program_load_energy: float = 50e-12  # ~50 pJ per program broadcast
     sure_program_cache_hit_energy: float = 1e-12  # ~1 pJ (cache hit, no broadcast)
 
-    # L3 distributed scratchpad routing (UNIQUE TO KPU)
+    # L3 distributed scratchpad routing (UNIQUE TO KPU).
+    # M6: routing_distance_factor moved to SoCFabricModel; this field
+    # is the fall-back default when no soc_fabric is attached. When
+    # ``soc_fabric`` is populated below, ``_estimate_l3_routing_distance``
+    # reads from there instead.
     l3_routing_distance_factor: float = 1.2  # Average routing distance multiplier
     l3_noc_energy_per_hop: float = 0.5e-12  # ~0.5 pJ per NoC hop
+
+    # M6: optional Layer 6 fabric model. When attached, the
+    # ``_estimate_l3_routing_distance`` formula reads
+    # ``routing_distance_factor`` from this model so KPU SKUs and the
+    # Layer 6 panel use a single source of truth.
+    soc_fabric: Optional['SoCFabricModel'] = None
 
     # Operator fusion benefits (UNIQUE TO KPU - HARDWARE FUSION)
     fusion_l2_traffic_reduction: float = 0.7  # 70% of intermediate data eliminated
@@ -3129,10 +3140,23 @@ class KPUTileEnergyModel:
         L3 is distributed across tiles, so data must route through NoC.
         Average distance depends on mesh dimensions.
 
-        For 2D mesh: average distance ≈ (width + height) / 3
+        For 2D mesh: average distance is (width + height) / 3, scaled
+        by ``routing_distance_factor`` to account for non-Manhattan
+        routes.
+
+        M6: when ``self.soc_fabric`` is populated, route the lookup
+        through the SoCFabricModel so the Layer 6 panel and the KPU
+        energy model share one source of truth. Falls back to the
+        local ``l3_routing_distance_factor`` constant when no fabric
+        is attached (preserves the original numeric output for
+        unmigrated callers).
         """
         width, height = self.tile_mesh_dimensions
-        return (width + height) / 3.0 * self.l3_routing_distance_factor
+        if self.soc_fabric is not None:
+            rdf = self.soc_fabric.routing_distance_factor
+        else:
+            rdf = self.l3_routing_distance_factor
+        return (width + height) / 3.0 * rdf
 
     def _estimate_token_routing_distance(self) -> float:
         """

--- a/src/graphs/hardware/fabric_model.py
+++ b/src/graphs/hardware/fabric_model.py
@@ -16,9 +16,10 @@ data movement milestone).
 """
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 import json
 from pathlib import Path
 
@@ -54,6 +55,15 @@ class SoCFabricModel:
         max_injection_gbps: Saturation injection rate per source,
             gigabits per second (Gbps). Bits/s, not bytes/s.
         provenance: Source tag for these values (datasheet URL, commit, etc.).
+        mesh_dimensions: For ``MESH_2D`` topology, the (width, height) tile
+            grid. Used by ``hop_count_avg`` and the KPU-NoC formula.
+        routing_distance_factor: Multiplier on shortest-path hop count to
+            account for non-Manhattan routes (~1.0 for ideal XY routing,
+            ~1.2 for typical real NoC routing). Replaces the
+            ``KPUTileEnergyModel.l3_routing_distance_factor`` constant.
+        low_confidence: Set when datasheet sources for the topology are
+            insufficient. Per issue M6 constraint, the panel surfaces the
+            assumption rather than leaving fields blank.
     """
     topology: Topology = Topology.UNKNOWN
     hop_latency_ns: float = 0.0
@@ -63,6 +73,64 @@ class SoCFabricModel:
     flit_size_bytes: int = 0
     max_injection_gbps: Optional[float] = None
     provenance: str = ""
+
+    # M6 additions
+    mesh_dimensions: Optional[Tuple[int, int]] = None
+    routing_distance_factor: float = 1.0
+    low_confidence: bool = False
+
+    # ------------------------------------------------------------------
+    # Analytical hop-count curve
+    # ------------------------------------------------------------------
+    def hop_count_avg(self, node_count: Optional[int] = None) -> float:
+        """
+        Average hop count between two random nodes for this topology.
+
+        ``node_count`` defaults to the implied count from
+        ``mesh_dimensions`` for ``MESH_2D``, ``controller_count`` for
+        bus-style topologies. The result is the analytical average,
+        not a worst case, and includes ``routing_distance_factor``.
+
+        Returns 0.0 when topology is UNKNOWN or node_count cannot be
+        inferred.
+        """
+        # Resolve node_count from topology-specific defaults
+        if node_count is None:
+            if self.topology is Topology.MESH_2D and self.mesh_dimensions:
+                w, h = self.mesh_dimensions
+                node_count = w * h
+            elif self.controller_count > 0:
+                node_count = self.controller_count
+            else:
+                return 0.0
+
+        if node_count <= 1:
+            return 0.0
+
+        topo = self.topology
+        rdf = self.routing_distance_factor
+
+        if topo is Topology.CROSSBAR or topo is Topology.FULL_MESH:
+            # Single-hop across the fabric.
+            return 1.0 * rdf
+        if topo is Topology.RING:
+            # Bidirectional ring: average path = N/4.
+            return (node_count / 4.0) * rdf
+        if topo is Topology.MESH_2D:
+            # Average Manhattan distance on a w x h mesh:
+            #   E[|x1-x2|] + E[|y1-y2|] = (w + h) / 3.
+            if self.mesh_dimensions:
+                w, h = self.mesh_dimensions
+                return ((w + h) / 3.0) * rdf
+            # Fall back to sqrt-N approximation
+            side = math.sqrt(node_count)
+            return ((2 * side) / 3.0) * rdf
+        if topo is Topology.CLOS:
+            # 3-stage Clos: O(log N) avg path; use ceil(log2(N)) as
+            # a rough proxy.
+            return max(1.0, math.log2(node_count)) * rdf
+        # UNKNOWN
+        return 0.0
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -74,6 +142,11 @@ class SoCFabricModel:
             "flit_size_bytes": self.flit_size_bytes,
             "max_injection_gbps": self.max_injection_gbps,
             "provenance": self.provenance,
+            "mesh_dimensions": (
+                list(self.mesh_dimensions) if self.mesh_dimensions else None
+            ),
+            "routing_distance_factor": self.routing_distance_factor,
+            "low_confidence": self.low_confidence,
         }
 
     @classmethod
@@ -81,6 +154,8 @@ class SoCFabricModel:
         data = dict(data)
         if "topology" in data and isinstance(data["topology"], str):
             data["topology"] = Topology(data["topology"])
+        if isinstance(data.get("mesh_dimensions"), list):
+            data["mesh_dimensions"] = tuple(data["mesh_dimensions"])
         return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
 
     def save(self, path: Path) -> None:

--- a/src/graphs/hardware/fabric_model.py
+++ b/src/graphs/hardware/fabric_model.py
@@ -154,8 +154,23 @@ class SoCFabricModel:
         data = dict(data)
         if "topology" in data and isinstance(data["topology"], str):
             data["topology"] = Topology(data["topology"])
-        if isinstance(data.get("mesh_dimensions"), list):
-            data["mesh_dimensions"] = tuple(data["mesh_dimensions"])
+        # Validate mesh_dimensions shape early so a malformed JSON
+        # blob fails at deserialization rather than deep inside
+        # hop_count_avg() where the (w, h) unpack would crash.
+        dims = data.get("mesh_dimensions")
+        if dims is not None:
+            if isinstance(dims, list):
+                dims = tuple(dims)
+            if (
+                not isinstance(dims, tuple)
+                or len(dims) != 2
+                or not all(isinstance(v, int) and v > 0 for v in dims)
+            ):
+                raise ValueError(
+                    f"mesh_dimensions must be a pair of positive "
+                    f"integers; got {data.get('mesh_dimensions')!r}"
+                )
+            data["mesh_dimensions"] = dims
         return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
 
     def save(self, path: Path) -> None:

--- a/src/graphs/hardware/models/accelerators/kpu_t128.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t128.py
@@ -19,6 +19,7 @@ execution of systems of affine recurrence equations. Scheduling is
 advantage. See ``docs/hardware/kpu_domainflow_tile_model.md``.
 """
 
+from ...fabric_model import SoCFabricModel, Topology
 from ...resource_model import (
     HardwareResourceModel,
     HardwareType,
@@ -372,6 +373,25 @@ def kpu_t128_resource_model() -> HardwareResourceModel:
     )
     model.coherence_protocol = "none"
 
+    # M6 Layer 6: 2D mesh fabric tied to the M0.5 tile abstraction.
+    # routing_distance_factor=1.2 matches the legacy constant in
+    # KPUTileEnergyModel; attaching the fabric here lets
+    # _estimate_l3_routing_distance() read it as the single source
+    # of truth (verified by the M6 equivalence test).
+    model.soc_fabric = SoCFabricModel(
+        topology=Topology.MESH_2D,
+        hop_latency_ns=1.0,
+        pj_per_flit_per_hop=0.5,  # matches l3_noc_energy_per_hop * 1e12
+        bisection_bandwidth_gbps=128.0,
+        controller_count=tile_energy_model.num_tiles,
+        flit_size_bytes=16,
+        mesh_dimensions=tile_energy_model.tile_mesh_dimensions,
+        routing_distance_factor=1.2,
+        provenance=("Stillwater KPU-T128 16x8 tile mesh (M0.5 "
+                    "dataflow-tile abstraction)"),
+    )
+    tile_energy_model.soc_fabric = model.soc_fabric
+
     from graphs.core.confidence import EstimationConfidence
     model.set_provenance(
         "l1_cache_per_unit",
@@ -432,6 +452,17 @@ def kpu_t128_resource_model() -> HardwareResourceModel:
             source=("KPU domain-flow: software-managed distributed L3 "
                     "scratchpad; no inter-tile coherence protocol "
                     "(data routing is Layer 6 transport)"),
+        ),
+    )
+
+    # M6 Layer 6 provenance: tied to M0.5 tile abstraction
+    model.set_provenance(
+        "soc_fabric",
+        EstimationConfidence.theoretical(
+            score=0.85,
+            source=("Stillwater KPU-T128: 16x8 tile mesh tied to M0.5 "
+                    "KPUTileEnergyModel (routing_distance_factor=1.2 "
+                    "preserves legacy energy formula)"),
         ),
     )
 

--- a/src/graphs/hardware/models/accelerators/kpu_t256.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t256.py
@@ -4,6 +4,7 @@ Kpu T256 Resource Model hardware resource model.
 Extracted from resource_model.py during refactoring.
 """
 
+from ...fabric_model import SoCFabricModel, Topology
 from ...resource_model import (
     HardwareResourceModel,
     HardwareType,
@@ -539,6 +540,21 @@ def kpu_t256_resource_model() -> HardwareResourceModel:
     )
     model.coherence_protocol = "none"
 
+    # M6 Layer 6: 2D mesh fabric tied to M0.5 tile abstraction.
+    model.soc_fabric = SoCFabricModel(
+        topology=Topology.MESH_2D,
+        hop_latency_ns=1.0,
+        pj_per_flit_per_hop=0.5,
+        bisection_bandwidth_gbps=256.0,
+        controller_count=tile_energy_model.num_tiles,
+        flit_size_bytes=16,
+        mesh_dimensions=tile_energy_model.tile_mesh_dimensions,
+        routing_distance_factor=1.2,
+        provenance=("Stillwater KPU-T256 tile mesh (M0.5 "
+                    "dataflow-tile abstraction)"),
+    )
+    tile_energy_model.soc_fabric = model.soc_fabric
+
     from graphs.core.confidence import EstimationConfidence
     model.set_provenance(
         "l1_cache_per_unit",
@@ -596,6 +612,16 @@ def kpu_t256_resource_model() -> HardwareResourceModel:
             score=0.95,
             source=("KPU domain-flow: software-managed distributed L3 "
                     "scratchpad; no inter-tile coherence protocol"),
+        ),
+    )
+
+    # M6 Layer 6 provenance
+    model.set_provenance(
+        "soc_fabric",
+        EstimationConfidence.theoretical(
+            score=0.85,
+            source=("Stillwater KPU-T256: tile mesh tied to M0.5 "
+                    "KPUTileEnergyModel"),
         ),
     )
 

--- a/src/graphs/hardware/models/accelerators/kpu_t64.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t64.py
@@ -4,6 +4,7 @@ Kpu T64 Resource Model hardware resource model.
 Extracted from resource_model.py during refactoring.
 """
 
+from ...fabric_model import SoCFabricModel, Topology
 from ...resource_model import (
     HardwareResourceModel,
     HardwareType,
@@ -499,6 +500,21 @@ def kpu_t64_resource_model() -> HardwareResourceModel:
     )
     model.coherence_protocol = "none"
 
+    # M6 Layer 6: 2D mesh fabric tied to M0.5 tile abstraction.
+    model.soc_fabric = SoCFabricModel(
+        topology=Topology.MESH_2D,
+        hop_latency_ns=1.0,
+        pj_per_flit_per_hop=0.5,
+        bisection_bandwidth_gbps=64.0,
+        controller_count=tile_energy_model.num_tiles,
+        flit_size_bytes=16,
+        mesh_dimensions=tile_energy_model.tile_mesh_dimensions,
+        routing_distance_factor=1.2,
+        provenance=("Stillwater KPU-T64 tile mesh (M0.5 "
+                    "dataflow-tile abstraction)"),
+    )
+    tile_energy_model.soc_fabric = model.soc_fabric
+
     from graphs.core.confidence import EstimationConfidence
     model.set_provenance(
         "l1_cache_per_unit",
@@ -556,6 +572,16 @@ def kpu_t64_resource_model() -> HardwareResourceModel:
             score=0.95,
             source=("KPU domain-flow: software-managed distributed L3 "
                     "scratchpad; no inter-tile coherence protocol"),
+        ),
+    )
+
+    # M6 Layer 6 provenance
+    model.set_provenance(
+        "soc_fabric",
+        EstimationConfidence.theoretical(
+            score=0.85,
+            source=("Stillwater KPU-T64: tile mesh tied to M0.5 "
+                    "KPUTileEnergyModel"),
         ),
     )
 

--- a/src/graphs/hardware/models/edge/coral_edge_tpu.py
+++ b/src/graphs/hardware/models/edge/coral_edge_tpu.py
@@ -20,6 +20,7 @@ from ...resource_model import (
     BOMCostProfile,
 )
 from ...architectural_energy import TPUTileEnergyModel
+from ...fabric_model import SoCFabricModel, Topology
 
 
 def coral_edge_tpu_resource_model() -> HardwareResourceModel:
@@ -234,6 +235,21 @@ def coral_edge_tpu_resource_model() -> HardwareResourceModel:
         l3_present=False,
         l3_cache_total=0,
         coherence_protocol="none",
+
+        # M6 Layer 6: single systolic tile + unified buffer; the
+        # "fabric" is a trivial direct-connect between the systolic
+        # array and the UB, modeled as a 1-port crossbar.
+        soc_fabric=SoCFabricModel(
+            topology=Topology.CROSSBAR,
+            hop_latency_ns=1.0,
+            pj_per_flit_per_hop=3.0,
+            bisection_bandwidth_gbps=128.0,
+            controller_count=1,
+            flit_size_bytes=16,
+            routing_distance_factor=1.0,
+            provenance=("Coral Edge TPU: single systolic tile + UB; "
+                        "trivial direct-connect fabric"),
+        ),
     )
 
     # Attach tile energy model
@@ -306,6 +322,15 @@ def coral_edge_tpu_resource_model() -> HardwareResourceModel:
         EstimationConfidence.theoretical(
             score=0.95,
             source="Systolic array: no inter-core coherence by design",
+        ),
+    )
+
+    # M6 Layer 6 provenance
+    model.set_provenance(
+        "soc_fabric",
+        EstimationConfidence.theoretical(
+            score=0.85,
+            source="Coral Edge TPU: trivial single-tile direct-connect fabric",
         ),
     )
 

--- a/src/graphs/hardware/models/edge/hailo10h.py
+++ b/src/graphs/hardware/models/edge/hailo10h.py
@@ -14,6 +14,7 @@ Configuration:
 Competitor to: Qualcomm QCS6490, Edge TPUs, mobile NPUs
 """
 
+from ...fabric_model import SoCFabricModel, Topology
 from ...resource_model import (
     HardwareResourceModel,
     HardwareType,
@@ -27,6 +28,24 @@ from ...resource_model import (
     ThermalOperatingPoint,
     BOMCostProfile,
 )
+
+
+def _get_hailo10h_fabric() -> SoCFabricModel:
+    """M6 Layer 6 fabric for Hailo-10H (low confidence)."""
+    return SoCFabricModel(
+        topology=Topology.MESH_2D,
+        hop_latency_ns=1.5,
+        pj_per_flit_per_hop=1.5,
+        bisection_bandwidth_gbps=80.0,
+        controller_count=40,
+        flit_size_bytes=16,
+        mesh_dimensions=(8, 5),
+        routing_distance_factor=1.1,
+        low_confidence=True,
+        provenance=("Hailo-10H: no public NoC topology data; assumed "
+                    "8x5 mesh estimated from compute_units=40 layout, "
+                    "transformer-optimized"),
+    )
 
 
 def hailo10h_resource_model() -> HardwareResourceModel:
@@ -236,6 +255,9 @@ def hailo10h_resource_model() -> HardwareResourceModel:
         l3_present=False,
         l3_cache_total=0,
         coherence_protocol="none",
+
+        # M6 Layer 6: dataflow mesh between 40 PE units (low confidence).
+        soc_fabric=_get_hailo10h_fabric(),
     )
 
     # M3 Layer 3 provenance
@@ -296,6 +318,16 @@ def hailo10h_resource_model() -> HardwareResourceModel:
         EstimationConfidence.theoretical(
             score=0.95,
             source="Hailo dataflow: no inter-unit coherence (compiler-routed)",
+        ),
+    )
+
+    # M6 Layer 6 provenance (low confidence - thin datasheet)
+    model.set_provenance(
+        "soc_fabric",
+        EstimationConfidence.theoretical(
+            score=0.40,
+            source=("Hailo-10H NoC topology not publicly documented; "
+                    "panel ships with low_confidence=True flag"),
         ),
     )
 

--- a/src/graphs/hardware/models/edge/hailo8.py
+++ b/src/graphs/hardware/models/edge/hailo8.py
@@ -14,6 +14,7 @@ Configuration:
 Competitor to: KPU-T64, Google Coral Edge TPU, Qualcomm QCS6490
 """
 
+from ...fabric_model import SoCFabricModel, Topology
 from ...resource_model import (
     HardwareResourceModel,
     HardwareType,
@@ -27,6 +28,29 @@ from ...resource_model import (
     ThermalOperatingPoint,
     BOMCostProfile,
 )
+
+
+def _get_hailo8_fabric() -> SoCFabricModel:
+    """M6 Layer 6 fabric for Hailo-8.
+
+    Hailo does not publish NoC details. Per the issue M6 constraint
+    we ship with ``low_confidence=True`` and document the assumption:
+    32 dataflow units laid out as an 8x4 mesh, hop coefficients
+    estimated from the 16nm process baseline.
+    """
+    return SoCFabricModel(
+        topology=Topology.MESH_2D,
+        hop_latency_ns=1.5,
+        pj_per_flit_per_hop=1.5,
+        bisection_bandwidth_gbps=64.0,
+        controller_count=32,
+        flit_size_bytes=16,
+        mesh_dimensions=(8, 4),
+        routing_distance_factor=1.1,
+        low_confidence=True,
+        provenance=("Hailo-8: no public NoC topology data; assumed "
+                    "8x4 mesh estimated from compute_units=32 layout"),
+    )
 
 
 def hailo8_resource_model() -> HardwareResourceModel:
@@ -230,6 +254,13 @@ def hailo8_resource_model() -> HardwareResourceModel:
         l3_present=False,
         l3_cache_total=0,
         coherence_protocol="none",
+
+        # M6 Layer 6: dataflow mesh between 32 PE units. Hailo does
+        # NOT publish per-hop NoC details, so this entry ships with
+        # low_confidence=True per issue M6 constraint. Mesh
+        # dimensions are estimated as a near-square 8x4 layout of
+        # the 32 dataflow units.
+        soc_fabric=_get_hailo8_fabric(),
     )
 
     # M3 Layer 3 provenance
@@ -289,6 +320,16 @@ def hailo8_resource_model() -> HardwareResourceModel:
         EstimationConfidence.theoretical(
             score=0.95,
             source="Hailo dataflow: no inter-unit coherence (compiler-routed)",
+        ),
+    )
+
+    # M6 Layer 6 provenance (low confidence - thin datasheet)
+    model.set_provenance(
+        "soc_fabric",
+        EstimationConfidence.theoretical(
+            score=0.40,
+            source=("Hailo-8 NoC topology not publicly documented; "
+                    "panel ships with low_confidence=True flag"),
         ),
     )
 

--- a/src/graphs/hardware/models/edge/intel_core_i7_12700k.py
+++ b/src/graphs/hardware/models/edge/intel_core_i7_12700k.py
@@ -21,6 +21,7 @@ from ...resource_model import (
     get_base_alu_energy,
     ThermalOperatingPoint,
 )
+from ...fabric_model import SoCFabricModel, Topology
 from graphs.core.confidence import EstimationConfidence
 
 
@@ -275,6 +276,21 @@ def intel_core_i7_12700k_resource_model() -> HardwareResourceModel:
         l3_present=True,
         l3_cache_total=25 * 1024 * 1024,  # 25 MiB shared L3
         coherence_protocol="snoopy_mesi",
+
+        # M6 Layer 6: Alder Lake double ring bus carries L2->L3 / L3
+        # snoop traffic between cores. 12 stops on the ring (8 P + 4 E
+        # cores + cache slices); avg latency ~1.5 ns / stop, ~5 pJ/flit.
+        soc_fabric=SoCFabricModel(
+            topology=Topology.RING,
+            hop_latency_ns=1.5,
+            pj_per_flit_per_hop=5.0,
+            bisection_bandwidth_gbps=512.0,  # ~64 GB/s ring half-bandwidth
+            controller_count=12,             # 8 P + 4 E ring stops
+            flit_size_bytes=32,
+            routing_distance_factor=1.0,     # XY-style routing on ring
+            provenance=("Intel Core i7-12700K Alder Lake double ring "
+                        "bus (~12 stops, snoop coherence carrier)"),
+        ),
     )
 
     # ------------------------------------------------------------------
@@ -371,6 +387,17 @@ def intel_core_i7_12700k_resource_model() -> HardwareResourceModel:
             score=0.95,
             source=("x86 multi-core: snoopy MESI/MOESI on the ring "
                     "interconnect; PROTOCOL energy modeled at Layer 5"),
+        ),
+    )
+
+    # M6 Layer 6 provenance for the on-chip fabric
+    model.set_provenance(
+        "soc_fabric",
+        EstimationConfidence.theoretical(
+            score=0.75,
+            source=("Alder Lake double ring bus topology: per-hop "
+                    "latency / energy from analytical model + Intel "
+                    "OPT manual"),
         ),
     )
 

--- a/src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py
+++ b/src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py
@@ -21,6 +21,7 @@ from ...resource_model import (
     ThermalOperatingPoint,
     BOMCostProfile,
 )
+from ...fabric_model import SoCFabricModel, Topology
 
 
 def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
@@ -513,6 +514,21 @@ def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
         l3_present=False,
         l3_cache_total=0,
         coherence_protocol="none",  # SIMT memory model, not snoopy
+
+        # M6 Layer 6: SM-to-L2 crossbar interconnect. 16 SMs * 4 L2
+        # slices = 64-port crossbar; effectively single-hop access
+        # across the full L2.
+        soc_fabric=SoCFabricModel(
+            topology=Topology.CROSSBAR,
+            hop_latency_ns=2.0,
+            pj_per_flit_per_hop=8.0,
+            bisection_bandwidth_gbps=2048.0,  # ~256 GB/s SM<->L2
+            controller_count=16,              # 16 SMs as crossbar ports
+            flit_size_bytes=32,
+            routing_distance_factor=1.0,
+            provenance=("Jetson Orin AGX Ampere SoC: SM-to-L2 crossbar "
+                        "interconnect (NVIDIA architectural fact)"),
+        ),
     )
 
     # M3 Layer 3 provenance for L1 cache fields
@@ -574,6 +590,16 @@ def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
             score=0.90,
             source=("SIMT shared-memory model: not snoopy / coherent in "
                     "the CPU sense (warp-level memory ordering only)"),
+        ),
+    )
+
+    # M6 Layer 6 provenance: SM-to-L2 crossbar
+    model.set_provenance(
+        "soc_fabric",
+        EstimationConfidence.theoretical(
+            score=0.75,
+            source=("Ampere SM-to-L2 crossbar topology is documented; "
+                    "per-flit energy estimated from 8nm process baseline"),
         ),
     )
 

--- a/src/graphs/hardware/models/edge/ryzen_9_8945hs.py
+++ b/src/graphs/hardware/models/edge/ryzen_9_8945hs.py
@@ -21,6 +21,7 @@ from ...resource_model import (
     get_base_alu_energy,
     ThermalOperatingPoint,
 )
+from ...fabric_model import SoCFabricModel, Topology
 from graphs.core.confidence import EstimationConfidence
 
 
@@ -210,6 +211,22 @@ def ryzen_9_8945hs_resource_model() -> HardwareResourceModel:
         l3_present=True,
         l3_cache_total=16 * 1024 * 1024,
         coherence_protocol="snoopy_mesi",
+
+        # M6 Layer 6: Zen 4 Phoenix has a single CCX with all 8 cores
+        # on one Infinity Fabric ring (no inter-CCX hop). N4 process
+        # gives slightly lower per-flit energy than Alder Lake at 10nm.
+        soc_fabric=SoCFabricModel(
+            topology=Topology.RING,
+            hop_latency_ns=1.2,
+            pj_per_flit_per_hop=2.5,
+            bisection_bandwidth_gbps=480.0,
+            controller_count=8,
+            flit_size_bytes=32,
+            routing_distance_factor=1.0,
+            provenance=("AMD Ryzen 9 8945HS Phoenix Zen 4 single-CCX "
+                        "Infinity Fabric ring (8 cores, no inter-CCX "
+                        "hop)"),
+        ),
     )
 
     for prec in (Precision.FP64, Precision.FP32, Precision.FP16,
@@ -296,6 +313,17 @@ def ryzen_9_8945hs_resource_model() -> HardwareResourceModel:
             score=0.95,
             source=("AMD Infinity Fabric coherence: snoopy MESI on the "
                     "intra-CCX bus"),
+        ),
+    )
+
+    # M6 Layer 6 provenance
+    model.set_provenance(
+        "soc_fabric",
+        EstimationConfidence.theoretical(
+            score=0.70,
+            source=("Phoenix Zen 4 Infinity Fabric: single-CCX ring; "
+                    "AMD does not publish per-hop NoC details, energy "
+                    "values estimated from N4 process"),
         ),
     )
 

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -35,6 +35,7 @@ FusionReport = PartitionReport
 
 if TYPE_CHECKING:
     from graphs.hardware.architectural_energy import ArchitecturalEnergyModel
+    from graphs.hardware.fabric_model import SoCFabricModel
 
 
 class HardwareType(Enum):
@@ -871,6 +872,13 @@ class HardwareResourceModel:
     # transitions); Layer 6 owns the TRANSPORT cost (NoC hops).
     # Provenance: ``coherence_protocol``.
     coherence_protocol: Optional[str] = None
+
+    # M6 Layer 6: on-chip fabric / NoC topology + characteristics.
+    # Captures the TRANSPORT cost of routing packets between cores,
+    # caches, and memory controllers (NoC hops, bisection bandwidth,
+    # per-flit energy). The PROTOCOL cost lives at Layer 5.
+    # Provenance: ``soc_fabric``.
+    soc_fabric: Optional["SoCFabricModel"] = None
 
     # Provenance of individual resource-model fields.
     # Maps field name (e.g., "peak_bandwidth", "energy_per_flop_fp32") to

--- a/src/graphs/reporting/layer_panels/__init__.py
+++ b/src/graphs/reporting/layer_panels/__init__.py
@@ -38,6 +38,12 @@ from .layer5_l3_cache import (
     cross_sku_layer5_chart,
     CrossSKULayer5Chart,
 )
+from .layer6_soc_fabric import (
+    build_layer6_soc_fabric_panel,
+    build_layer6_panels_for_skus,
+    cross_sku_layer6_chart,
+    CrossSKULayer6Chart,
+)
 
 __all__ = [
     "build_layer1_panel",
@@ -60,4 +66,8 @@ __all__ = [
     "build_layer5_panels_for_skus",
     "cross_sku_layer5_chart",
     "CrossSKULayer5Chart",
+    "build_layer6_soc_fabric_panel",
+    "build_layer6_panels_for_skus",
+    "cross_sku_layer6_chart",
+    "CrossSKULayer6Chart",
 ]

--- a/src/graphs/reporting/layer_panels/layer6_soc_fabric.py
+++ b/src/graphs/reporting/layer_panels/layer6_soc_fabric.py
@@ -1,0 +1,261 @@
+"""
+Layer 6 SoC fabric / on-chip data movement panel builder.
+
+Surfaces per-SKU NoC topology, hop count, per-hop latency / energy,
+bisection bandwidth, and controller count. The Layer 6 panel
+captures the TRANSPORT cost of moving packets across the chip --
+distinct from the coherence PROTOCOL cost (Layer 5) and from
+external memory bandwidth (Layer 7).
+
+Topology classes:
+- ``crossbar``  -- single-hop full bipartite (GPU SM-to-L2, trivial
+  single-tile fabrics)
+- ``ring``      -- bidirectional ring bus (CPU multi-core)
+- ``mesh_2d``   -- 2D mesh of tiles / PEs (KPU, Hailo)
+- ``clos``      -- multi-stage Clos network (datacenter scale-out)
+- ``full_mesh`` -- direct point-to-point (small clusters)
+- ``unknown``   -- topology not classified
+
+Per the M6 issue constraint, SKUs with thin datasheet sources ship
+with the ``low_confidence`` flag set on their SoCFabricModel. The
+panel renders an explicit warning rather than hiding the
+uncertainty.
+
+KPU SKUs: panel reads the fabric attached to ``model.soc_fabric``,
+which the KPU factories populate with ``routing_distance_factor=1.2``
+matching the legacy ``KPUTileEnergyModel.l3_routing_distance_factor``
+constant. The energy model now reads from the same source -- single
+source of truth.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from graphs.benchmarks.schema import LayerTag
+from graphs.core.confidence import ConfidenceLevel
+from graphs.hardware.fabric_model import SoCFabricModel, Topology
+from graphs.hardware.resource_model import HardwareResourceModel
+from graphs.reporting.microarch_schema import LayerPanel
+from graphs.reporting.layer_panels.layer1_alu import resolve_sku_resource_model
+
+
+# Per-topology narrative for the panel notes.
+_TOPOLOGY_NOTES: Dict[Topology, str] = {
+    Topology.CROSSBAR: (
+        "Crossbar topology: every source has a direct dedicated path "
+        "to every destination. Latency is constant (1 hop) regardless "
+        "of source / destination pair. Used for GPU SM-to-L2 fabrics "
+        "and small single-tile accelerators."
+    ),
+    Topology.RING: (
+        "Ring topology: stops on a bidirectional bus. Average path "
+        "length scales linearly with stop count (N/4). Used for "
+        "x86 multi-core CPUs (Alder Lake double ring, AMD Infinity "
+        "Fabric intra-CCX)."
+    ),
+    Topology.MESH_2D: (
+        "2D-mesh topology: tiles arranged on a grid with XY routing. "
+        "Average Manhattan distance is (W + H) / 3 hops; bisection "
+        "bandwidth scales with the smaller mesh side. Used for "
+        "tile-array accelerators (KPU domain-flow, Hailo dataflow)."
+    ),
+    Topology.CLOS: (
+        "Clos network: multi-stage non-blocking switch. Avg path "
+        "length scales as O(log N). Used in datacenter-scale fabrics."
+    ),
+    Topology.FULL_MESH: (
+        "Full mesh: every node has a dedicated link to every other. "
+        "Constant 1-hop latency but quadratic edge cost; only "
+        "practical for small clusters."
+    ),
+    Topology.UNKNOWN: (
+        "Topology not classified for this SKU."
+    ),
+}
+
+
+def _has_fabric(model: HardwareResourceModel) -> bool:
+    return model.soc_fabric is not None
+
+
+def _provenance_or_theoretical(
+    model: HardwareResourceModel, key: str,
+) -> str:
+    conf = model.get_provenance(key)
+    if conf.level is ConfidenceLevel.UNKNOWN:
+        return ConfidenceLevel.THEORETICAL.value.upper()
+    return conf.level.value.upper()
+
+
+def _topology_summary(fabric: SoCFabricModel) -> str:
+    """One-word topology summary including mesh dims when applicable."""
+    base = fabric.topology.value
+    if fabric.topology is Topology.MESH_2D and fabric.mesh_dimensions:
+        w, h = fabric.mesh_dimensions
+        return f"{base} ({w}x{h})"
+    if fabric.controller_count > 1:
+        return f"{base} ({fabric.controller_count} ports)"
+    return base
+
+
+# --------------------------------------------------------------------
+# Panel construction
+# --------------------------------------------------------------------
+
+def build_layer6_soc_fabric_panel(
+    sku_id: str,
+    model: Optional[HardwareResourceModel] = None,
+) -> LayerPanel:
+    """Build the Layer 6 (SoC data movement) panel for one SKU."""
+    if model is None:
+        model = resolve_sku_resource_model(sku_id)
+
+    title = "Layer 6: SoC Data Movement"
+
+    if model is None or not _has_fabric(model):
+        return LayerPanel(
+            layer=LayerTag.SOC_DATA_MOVEMENT,
+            title=title,
+            status="not_populated",
+            summary=f"No SoC fabric model attached for {sku_id}.",
+        )
+
+    f = model.soc_fabric
+    avg_hops = f.hop_count_avg()
+    topo_str = _topology_summary(f)
+
+    metrics: Dict[str, Dict] = {
+        "Topology": {
+            "value": topo_str,
+            "unit":  "",
+            "provenance": _provenance_or_theoretical(model, "soc_fabric"),
+        },
+        "Avg hop count": {
+            "value": f"{avg_hops:.2f}",
+            "unit":  "hops",
+            "provenance": "THEORETICAL",
+        },
+        "Hop latency": {
+            "value": f"{f.hop_latency_ns:.2f}",
+            "unit":  "ns",
+            "provenance": "THEORETICAL",
+        },
+        "Energy / flit / hop": {
+            "value": f"{f.pj_per_flit_per_hop:.2f}",
+            "unit":  "pJ",
+            "provenance": "THEORETICAL",
+        },
+        "Bisection bandwidth": {
+            "value": f"{f.bisection_bandwidth_gbps:.0f}",
+            "unit":  "Gbps",
+            "provenance": "THEORETICAL",
+        },
+        "Controller count": {
+            "value": str(f.controller_count),
+            "unit":  "",
+            "provenance": "n/a",
+        },
+        "Flit size": {
+            "value": str(f.flit_size_bytes),
+            "unit":  "B",
+            "provenance": "n/a",
+        },
+    }
+
+    notes: List[str] = [_TOPOLOGY_NOTES.get(f.topology, "")]
+
+    if f.routing_distance_factor != 1.0:
+        notes.append(
+            f"Routing distance factor of {f.routing_distance_factor:.2f} "
+            "applied to shortest-path hop counts (accounts for "
+            "non-Manhattan routes in the real NoC)."
+        )
+
+    if f.low_confidence:
+        notes.append(
+            "LOW CONFIDENCE: vendor does not publish per-hop NoC "
+            "details; this panel ships analytical estimates with "
+            "the assumption documented in the fabric provenance "
+            "string. Per M6 issue constraint."
+        )
+
+    summary = (
+        f"On-chip fabric for {sku_id}: {topo_str}. "
+        f"Avg path = {avg_hops:.2f} hops at "
+        f"{f.hop_latency_ns:.1f} ns / hop and "
+        f"{f.pj_per_flit_per_hop:.1f} pJ / flit / hop."
+    )
+    if f.low_confidence:
+        summary += " (low-confidence datasheet)"
+
+    return LayerPanel(
+        layer=LayerTag.SOC_DATA_MOVEMENT,
+        title=title,
+        status="theoretical",
+        summary=summary,
+        metrics=metrics,
+        notes=notes,
+    )
+
+
+def build_layer6_panels_for_skus(
+    sku_ids: List[str],
+) -> Dict[str, LayerPanel]:
+    return {sku: build_layer6_soc_fabric_panel(sku) for sku in sku_ids}
+
+
+# --------------------------------------------------------------------
+# Cross-SKU comparison
+# --------------------------------------------------------------------
+
+@dataclass
+class CrossSKULayer6Chart:
+    skus: List[str]
+    topology: Dict[str, str]
+    avg_hop_count: Dict[str, float]
+    hop_latency_ns: Dict[str, float]
+    pj_per_flit_per_hop: Dict[str, float]
+    bisection_bandwidth_gbps: Dict[str, float]
+    low_confidence: Dict[str, bool]
+    provenance: Dict[str, str]
+
+
+def cross_sku_layer6_chart(sku_ids: List[str]) -> CrossSKULayer6Chart:
+    chart = CrossSKULayer6Chart(
+        skus=list(sku_ids),
+        topology={},
+        avg_hop_count={},
+        hop_latency_ns={},
+        pj_per_flit_per_hop={},
+        bisection_bandwidth_gbps={},
+        low_confidence={},
+        provenance={},
+    )
+
+    models: Dict[str, Optional[HardwareResourceModel]] = {
+        sku: resolve_sku_resource_model(sku) for sku in sku_ids
+    }
+
+    for sku in sku_ids:
+        m = models.get(sku)
+        if m is None or not _has_fabric(m):
+            continue
+        f = m.soc_fabric
+        chart.topology[sku] = _topology_summary(f)
+        chart.avg_hop_count[sku] = f.hop_count_avg()
+        chart.hop_latency_ns[sku] = f.hop_latency_ns
+        chart.pj_per_flit_per_hop[sku] = f.pj_per_flit_per_hop
+        chart.bisection_bandwidth_gbps[sku] = f.bisection_bandwidth_gbps
+        chart.low_confidence[sku] = f.low_confidence
+        chart.provenance[sku] = _provenance_or_theoretical(m, "soc_fabric")
+
+    return chart
+
+
+__all__ = [
+    "build_layer6_soc_fabric_panel",
+    "build_layer6_panels_for_skus",
+    "cross_sku_layer6_chart",
+    "CrossSKULayer6Chart",
+]

--- a/src/graphs/reporting/microarch_html_template.py
+++ b/src/graphs/reporting/microarch_html_template.py
@@ -705,6 +705,87 @@ def _render_layer5_cross_sku_table(reports: List[MicroarchReport]) -> str:
 """
 
 
+def _render_layer6_cross_sku_table(reports: List[MicroarchReport]) -> str:
+    """
+    Render a SoC fabric topology + hop / energy table across SKUs.
+    """
+    try:
+        from graphs.reporting.layer_panels import cross_sku_layer6_chart
+    except Exception:
+        return ""
+
+    sku_ids = [r.sku for r in reports]
+    chart = cross_sku_layer6_chart(sku_ids)
+    if not chart.topology:
+        return ""
+
+    name_lookup = {r.sku: (r.display_name or r.sku) for r in reports}
+    header_cells = "".join(
+        f"<th>{html.escape(name_lookup.get(sku, sku))}</th>"
+        for sku in chart.skus
+    )
+
+    def _row(label, getter, fmt):
+        cells = [f"<th>{html.escape(label)}</th>"]
+        for sku in chart.skus:
+            v = getter(sku)
+            if v is None:
+                cells.append("<td>--</td>")
+            else:
+                cells.append(f"<td>{fmt(v)}</td>")
+        return "<tr>" + "".join(cells) + "</tr>"
+
+    rows = (
+        _row("Topology",
+             lambda s: chart.topology.get(s),
+             lambda v: html.escape(v))
+        + _row("Avg hops",
+               lambda s: chart.avg_hop_count.get(s),
+               lambda v: f"{v:.2f}")
+        + _row("Hop latency (ns)",
+               lambda s: chart.hop_latency_ns.get(s),
+               lambda v: f"{v:.2f}")
+        + _row("pJ / flit / hop",
+               lambda s: chart.pj_per_flit_per_hop.get(s),
+               lambda v: f"{v:.2f}")
+        + _row("Bisection BW (Gbps)",
+               lambda s: chart.bisection_bandwidth_gbps.get(s),
+               lambda v: f"{v:.0f}")
+    )
+
+    # Confidence row: blends provenance with the low_confidence flag
+    badge_cells = []
+    for sku in chart.skus:
+        lc = chart.low_confidence.get(sku, False)
+        prov = chart.provenance.get(sku, "UNKNOWN")
+        if lc:
+            label = "LOW-CONFIDENCE"
+            badge = "theoretical"  # show as theoretical-style badge
+        else:
+            label = prov
+            badge = _safe_status_class(prov.lower())
+        badge_cells.append(
+            f'<td><span class="badge {badge}">{html.escape(label)}</span></td>'
+        )
+    rows += "<tr><th>Confidence</th>" + "".join(badge_cells) + "</tr>"
+
+    return f"""
+<section>
+  <h3>Layer 6: on-chip fabric / NoC across SKUs</h3>
+  <p class="meta">Topology and per-hop coefficients for the on-chip
+  interconnect that moves packets between cores, caches, and memory
+  controllers. Layer 6 owns the TRANSPORT cost; the coherence
+  PROTOCOL cost stays at Layer 5. SKUs whose vendors do not publish
+  NoC details ship with a LOW-CONFIDENCE badge per the M6 issue
+  constraint.</p>
+  <table class="layer6-cross">
+    <thead><tr><th></th>{header_cells}</tr></thead>
+    <tbody>{rows}</tbody>
+  </table>
+</section>
+"""
+
+
 def render_comparison_page(
     reports: List[MicroarchReport],
     repo_root: Path,
@@ -719,8 +800,9 @@ def render_comparison_page(
       - Layer 3 L1-capacity / storage-kind table (M3)
       - Layer 4 L2-capacity / topology table (M4)
       - Layer 5 L3-presence / coherence table (M5)
+      - Layer 6 SoC fabric topology + hop coefficients (M6)
 
-    M6-M8 add later layer comparison sections.
+    M7-M8 add later layer comparison sections.
     """
     assets = _load_logo(repo_root)
     rows = "".join(
@@ -735,6 +817,7 @@ def render_comparison_page(
     layer3_section = _render_layer3_cross_sku_table(reports)
     layer4_section = _render_layer4_cross_sku_table(reports)
     layer5_section = _render_layer5_cross_sku_table(reports)
+    layer6_section = _render_layer6_cross_sku_table(reports)
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -744,8 +827,8 @@ def render_comparison_page(
 table {{ width: 100%; border-collapse: collapse; background: #fff; }}
 table th, table td {{ padding: 10px 12px; border-bottom: 1px solid #e3e6eb; text-align: left; }}
 table th {{ font-size: 12px; text-transform: uppercase; color: #586374; background: #f3f5f8; }}
-table.layer1-cross td, table.layer2-cross td, table.layer3-cross td, table.layer4-cross td, table.layer5-cross td {{ text-align: right; }}
-table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.layer3-cross th:first-child, table.layer4-cross th:first-child, table.layer5-cross th:first-child {{ text-align: left; }}
+table.layer1-cross td, table.layer2-cross td, table.layer3-cross td, table.layer4-cross td, table.layer5-cross td, table.layer6-cross td {{ text-align: right; }}
+table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.layer3-cross th:first-child, table.layer4-cross th:first-child, table.layer5-cross th:first-child, table.layer6-cross th:first-child {{ text-align: left; }}
   </style>
 </head>
 <body>
@@ -754,8 +837,9 @@ table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.laye
   <section class="page-header">
     <h2>Compare across SKUs</h2>
     <div class="meta">
-      Layers 1-5 (ALU, Register File, L1 Cache / Scratchpad, L2 Cache,
-      L3 / LLC) populated; remaining layer comparisons follow at M6-M8.
+      Layers 1-6 (ALU, Register File, L1 Cache / Scratchpad, L2 Cache,
+      L3 / LLC, SoC Data Movement) populated; remaining layer
+      comparisons follow at M7-M8.
     </div>
   </section>
   {_render_legend()}
@@ -770,6 +854,7 @@ table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.laye
   {layer3_section}
   {layer4_section}
   {layer5_section}
+  {layer6_section}
 </main>
 {_render_brand_footer("microarch-model-delivery-plan.md")}
 </body>

--- a/tests/cli/test_microarch_validation_report.py
+++ b/tests/cli/test_microarch_validation_report.py
@@ -2,7 +2,8 @@
 
 M0 shipped empty panels; M1 populates Layer 1 (ALU); M2 populates
 Layer 2 (Register File); M3 populates Layer 3 (L1 cache / scratchpad);
-M4 populates Layer 4 (L2 cache); M5 populates Layer 5 (L3 / LLC).
+M4 populates Layer 4 (L2 cache); M5 populates Layer 5 (L3 / LLC);
+M6 populates Layer 6 (SoC data movement).
 """
 from __future__ import annotations
 
@@ -50,16 +51,16 @@ def test_json_bundle_emits_one_file_per_sku(tmp_path: Path, cli_main):
         "soc_data_movement", "external_memory",
     ]
     assert layer_tags == expected
-    # M5: layers 1-5 populated as 'theoretical'; layers 6-7 remain
-    # 'not_populated' until their milestones land.
+    # M6: layers 1-6 populated as 'theoretical'; layer 7 remains
+    # 'not_populated' until M7 lands.
     layer_status = {p["layer"]: p["status"] for p in payload["layers"]}
-    for tag in ("alu", "register", "l1_cache", "l2_cache", "l3_cache"):
+    for tag in ("alu", "register", "l1_cache", "l2_cache", "l3_cache",
+                "soc_data_movement"):
         assert layer_status[tag] == "theoretical", (
-            f"Layer for {tag} should be 'theoretical' at M5, "
+            f"Layer for {tag} should be 'theoretical' at M6, "
             f"got {layer_status[tag]!r}"
         )
-    for tag in ("soc_data_movement", "external_memory"):
-        assert layer_status[tag] == "not_populated"
+    assert layer_status["external_memory"] == "not_populated"
 
 
 def test_html_bundle_writes_index_hardware_compare(tmp_path: Path, cli_main):

--- a/tests/reporting/test_layer6_soc_fabric_panel.py
+++ b/tests/reporting/test_layer6_soc_fabric_panel.py
@@ -1,0 +1,272 @@
+"""Self-consistency tests for the M6 Layer 6 (SoC fabric) panel."""
+from __future__ import annotations
+
+import pytest
+
+from graphs.benchmarks.schema import LayerTag
+from graphs.core.confidence import ConfidenceLevel
+from graphs.hardware.fabric_model import SoCFabricModel, Topology
+from graphs.reporting.layer_panels import (
+    build_layer6_soc_fabric_panel,
+    cross_sku_layer6_chart,
+    resolve_sku_resource_model,
+)
+
+
+REQUIRED_SKUS = [
+    "jetson_orin_agx_64gb",
+    "intel_core_i7_12700k",
+    "ryzen_9_8945hs",
+    "kpu_t64",
+    "kpu_t128",
+    "kpu_t256",
+    "coral_edge_tpu",
+]
+OPTIONAL_SKUS = ["hailo8", "hailo10h"]
+TARGET_SKUS = REQUIRED_SKUS + OPTIONAL_SKUS
+
+# Architectural partitioning
+RING_SKUS = ["intel_core_i7_12700k", "ryzen_9_8945hs"]
+CROSSBAR_SKUS = ["jetson_orin_agx_64gb", "coral_edge_tpu"]
+MESH_SKUS = ["kpu_t64", "kpu_t128", "kpu_t256", "hailo8", "hailo10h"]
+LOW_CONFIDENCE_SKUS = ["hailo8", "hailo10h"]
+
+
+def _skip_if_optional_unresolved(sku: str) -> None:
+    if sku in OPTIONAL_SKUS and resolve_sku_resource_model(sku) is None:
+        pytest.skip(f"{sku} model unavailable in this environment")
+
+
+# --------------------------------------------------------------------
+# Topology scaling tests (acceptance criterion from issue body)
+# --------------------------------------------------------------------
+
+class TestTopologyScaling:
+    """The hop_count_avg curve must scale according to topology:
+    crossbar = O(1), ring = O(N), 2D mesh = O(sqrt(N))."""
+
+    def test_crossbar_constant(self):
+        f = SoCFabricModel(topology=Topology.CROSSBAR, controller_count=4)
+        h4 = f.hop_count_avg()
+        f2 = SoCFabricModel(topology=Topology.CROSSBAR, controller_count=64)
+        h64 = f2.hop_count_avg()
+        assert h4 == h64 == 1.0
+
+    def test_ring_linear_in_n(self):
+        f4 = SoCFabricModel(topology=Topology.RING, controller_count=4)
+        f16 = SoCFabricModel(topology=Topology.RING, controller_count=16)
+        f64 = SoCFabricModel(topology=Topology.RING, controller_count=64)
+        # Linear: doubling N doubles avg hop count (within float)
+        ratio_16_4 = f16.hop_count_avg() / f4.hop_count_avg()
+        ratio_64_16 = f64.hop_count_avg() / f16.hop_count_avg()
+        assert abs(ratio_16_4 - 4.0) < 1e-9
+        assert abs(ratio_64_16 - 4.0) < 1e-9
+
+    def test_mesh_2d_sqrt_n_when_square(self):
+        """For square w x w mesh: avg hops = (w + w)/3 = 2w/3 ~ sqrt(N)."""
+        f4 = SoCFabricModel(topology=Topology.MESH_2D, mesh_dimensions=(4, 4))
+        f16 = SoCFabricModel(topology=Topology.MESH_2D,
+                             mesh_dimensions=(16, 16))
+        # 4x4 -> 8/3; 16x16 -> 32/3; ratio is 4 = sqrt(256/16).
+        ratio = f16.hop_count_avg() / f4.hop_count_avg()
+        assert abs(ratio - 4.0) < 1e-9
+
+    def test_routing_factor_scales_linearly(self):
+        f1 = SoCFabricModel(topology=Topology.MESH_2D, mesh_dimensions=(8, 8),
+                            routing_distance_factor=1.0)
+        f2 = SoCFabricModel(topology=Topology.MESH_2D, mesh_dimensions=(8, 8),
+                            routing_distance_factor=1.5)
+        assert abs(f2.hop_count_avg() / f1.hop_count_avg() - 1.5) < 1e-9
+
+    def test_unknown_topology_returns_zero(self):
+        f = SoCFabricModel(topology=Topology.UNKNOWN, controller_count=10)
+        assert f.hop_count_avg() == 0.0
+
+
+# --------------------------------------------------------------------
+# Per-SKU schema fields
+# --------------------------------------------------------------------
+
+class TestPerSKUSchemaFields:
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_soc_fabric_populated(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert m.soc_fabric is not None
+        assert m.soc_fabric.topology is not Topology.UNKNOWN
+
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_soc_fabric_provenance_theoretical(self, sku):
+        m = resolve_sku_resource_model(sku)
+        conf = m.get_provenance("soc_fabric")
+        assert conf.level is ConfidenceLevel.THEORETICAL
+
+    @pytest.mark.parametrize("sku", RING_SKUS)
+    def test_cpu_skus_use_ring(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert m.soc_fabric.topology is Topology.RING
+
+    @pytest.mark.parametrize("sku", CROSSBAR_SKUS)
+    def test_crossbar_skus(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert m.soc_fabric.topology is Topology.CROSSBAR
+
+    @pytest.mark.parametrize("sku",
+                             ["kpu_t64", "kpu_t128", "kpu_t256"])
+    def test_kpu_uses_mesh_2d(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert m.soc_fabric.topology is Topology.MESH_2D
+        assert m.soc_fabric.mesh_dimensions is not None
+
+    @pytest.mark.parametrize("sku", LOW_CONFIDENCE_SKUS)
+    def test_low_confidence_skus_flagged(self, sku):
+        _skip_if_optional_unresolved(sku)
+        m = resolve_sku_resource_model(sku)
+        assert m.soc_fabric.low_confidence is True
+
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_provenance_string_populated(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert m.soc_fabric.provenance, f"{sku} fabric missing provenance"
+
+
+# --------------------------------------------------------------------
+# KPU equivalence: M6 must not regress numeric output
+# --------------------------------------------------------------------
+
+class TestKPUNumericEquivalence:
+    """Critical M6 invariant: the KPU energy formula's numeric output
+    must be identical before and after routing through soc_fabric."""
+
+    @pytest.mark.parametrize("sku", ("kpu_t64", "kpu_t128", "kpu_t256"))
+    def test_routing_distance_unchanged(self, sku):
+        m = resolve_sku_resource_model(sku)
+        tem = m.tile_energy_model
+        # With fabric attached (default after M6)
+        with_fabric = tem._estimate_l3_routing_distance()
+
+        # Detach fabric and verify the legacy formula returns the same
+        original = tem.soc_fabric
+        try:
+            tem.soc_fabric = None
+            without_fabric = tem._estimate_l3_routing_distance()
+        finally:
+            tem.soc_fabric = original
+
+        assert with_fabric == without_fabric, (
+            f"{sku}: fabric path returns {with_fabric}, "
+            f"legacy path returns {without_fabric}"
+        )
+
+    @pytest.mark.parametrize("sku", ("kpu_t64", "kpu_t128", "kpu_t256"))
+    def test_routing_distance_factor_matches_legacy_constant(self, sku):
+        """The fabric's routing_distance_factor must match the
+        KPUTileEnergyModel.l3_routing_distance_factor default (1.2)."""
+        m = resolve_sku_resource_model(sku)
+        assert m.soc_fabric.routing_distance_factor == 1.2
+        assert m.tile_energy_model.l3_routing_distance_factor == 1.2
+
+    @pytest.mark.parametrize("sku", ("kpu_t64", "kpu_t128", "kpu_t256"))
+    def test_mesh_dims_match_tile_energy_model(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert (m.soc_fabric.mesh_dimensions
+                == m.tile_energy_model.tile_mesh_dimensions)
+
+
+# --------------------------------------------------------------------
+# Panel construction
+# --------------------------------------------------------------------
+
+class TestPanelBuilder:
+    @pytest.mark.parametrize("sku", TARGET_SKUS)
+    def test_panel_is_soc_layer(self, sku):
+        _skip_if_optional_unresolved(sku)
+        panel = build_layer6_soc_fabric_panel(sku)
+        assert panel.layer is LayerTag.SOC_DATA_MOVEMENT
+        assert "SoC" in panel.title or "Data Movement" in panel.title
+
+    @pytest.mark.parametrize("sku", TARGET_SKUS)
+    def test_panel_populated(self, sku):
+        _skip_if_optional_unresolved(sku)
+        panel = build_layer6_soc_fabric_panel(sku)
+        assert panel.status != "not_populated"
+        assert panel.metrics
+
+    @pytest.mark.parametrize("sku", TARGET_SKUS)
+    def test_panel_has_topology_and_hop_count(self, sku):
+        _skip_if_optional_unresolved(sku)
+        panel = build_layer6_soc_fabric_panel(sku)
+        assert "Topology" in panel.metrics
+        assert "Avg hop count" in panel.metrics
+
+    @pytest.mark.parametrize("sku", LOW_CONFIDENCE_SKUS)
+    def test_low_confidence_panels_flag_in_summary(self, sku):
+        _skip_if_optional_unresolved(sku)
+        panel = build_layer6_soc_fabric_panel(sku)
+        joined = " ".join(panel.notes).lower()
+        assert "low confidence" in joined or "low-confidence" in joined
+
+    def test_unknown_sku_returns_unpopulated(self):
+        panel = build_layer6_soc_fabric_panel("definitely_not_a_sku")
+        assert panel.status == "not_populated"
+
+
+# --------------------------------------------------------------------
+# Cross-SKU chart
+# --------------------------------------------------------------------
+
+class TestCrossSKUChart:
+    def test_chart_includes_required_skus(self):
+        chart = cross_sku_layer6_chart(REQUIRED_SKUS)
+        for sku in REQUIRED_SKUS:
+            assert sku in chart.topology
+            assert sku in chart.avg_hop_count
+
+    def test_kpu_t256_has_largest_hop_count(self):
+        """KPU T256 (16x16 mesh) should have the largest average hop
+        count in the catalog."""
+        chart = cross_sku_layer6_chart(REQUIRED_SKUS)
+        winner = max(chart.avg_hop_count, key=chart.avg_hop_count.get)
+        assert winner == "kpu_t256"
+
+    def test_crossbar_skus_have_minimal_hops(self):
+        chart = cross_sku_layer6_chart(REQUIRED_SKUS)
+        for sku in CROSSBAR_SKUS:
+            # 1.0 for true crossbar; 0.0 if controller_count=1
+            assert chart.avg_hop_count[sku] <= 1.0
+
+    def test_low_confidence_flag_passed_through(self):
+        chart = cross_sku_layer6_chart(REQUIRED_SKUS + LOW_CONFIDENCE_SKUS)
+        for sku in LOW_CONFIDENCE_SKUS:
+            if sku not in chart.low_confidence:
+                continue  # optional unresolved
+            assert chart.low_confidence[sku] is True
+
+    def test_provenance_all_theoretical(self):
+        chart = cross_sku_layer6_chart(REQUIRED_SKUS)
+        expected = ConfidenceLevel.THEORETICAL.value.upper()
+        assert all(p == expected for p in chart.provenance.values())
+
+
+# --------------------------------------------------------------------
+# Round-trip serialization of the new fabric fields
+# --------------------------------------------------------------------
+
+class TestSerialization:
+    def test_round_trip_preserves_mesh_dimensions(self):
+        f = SoCFabricModel(
+            topology=Topology.MESH_2D,
+            mesh_dimensions=(16, 8),
+            routing_distance_factor=1.2,
+            low_confidence=False,
+        )
+        d = f.to_dict()
+        r = SoCFabricModel.from_dict(d)
+        assert r.mesh_dimensions == (16, 8)
+        assert r.routing_distance_factor == 1.2
+        assert r.low_confidence is False
+
+    def test_round_trip_preserves_low_confidence(self):
+        f = SoCFabricModel(topology=Topology.RING, low_confidence=True)
+        d = f.to_dict()
+        r = SoCFabricModel.from_dict(d)
+        assert r.low_confidence is True

--- a/tests/reporting/test_layer6_soc_fabric_panel.py
+++ b/tests/reporting/test_layer6_soc_fabric_panel.py
@@ -270,3 +270,27 @@ class TestSerialization:
         d = f.to_dict()
         r = SoCFabricModel.from_dict(d)
         assert r.low_confidence is True
+
+    def test_from_dict_rejects_malformed_mesh_dimensions(self):
+        """A malformed mesh_dimensions blob must fail at
+        deserialization, not later in hop_count_avg() where the
+        (w, h) unpack would crash."""
+        bad_inputs = [
+            {"topology": "mesh_2d", "mesh_dimensions": [16]},        # too short
+            {"topology": "mesh_2d", "mesh_dimensions": [16, 8, 4]},  # too long
+            {"topology": "mesh_2d", "mesh_dimensions": [0, 8]},      # zero
+            {"topology": "mesh_2d", "mesh_dimensions": [-4, 8]},     # negative
+            {"topology": "mesh_2d", "mesh_dimensions": ["a", "b"]},  # non-int
+            {"topology": "mesh_2d", "mesh_dimensions": "16x8"},      # string
+        ]
+        for blob in bad_inputs:
+            with pytest.raises(ValueError, match="mesh_dimensions"):
+                SoCFabricModel.from_dict(blob)
+
+    def test_from_dict_accepts_well_formed_mesh_dimensions(self):
+        f = SoCFabricModel.from_dict({
+            "topology": "mesh_2d",
+            "mesh_dimensions": [16, 8],
+        })
+        assert f.mesh_dimensions == (16, 8)
+        assert f.hop_count_avg() == (16 + 8) / 3.0  # rdf default = 1.0


### PR DESCRIPTION
## Summary
- Populate Layer 6 (SoC data movement / on-chip NoC) for all 9 target SKUs.
- Extend `SoCFabricModel` with `mesh_dimensions`, `routing_distance_factor`, `low_confidence` fields and an analytical `hop_count_avg()` method.
- New `soc_fabric` field on `HardwareResourceModel`.
- KPU integration: `_estimate_l3_routing_distance()` reads from `soc_fabric` when populated; legacy formula numeric output preserved exactly.
- Cross-SKU comparison page gains a Layer 6 topology + hop-coefficient table.

## Why
Layer 6 is the highest-risk milestone per the issue body — datasheet sources for NoC topology are thinnest. Without it, coherence transport cost (M5 PROTOCOL split) has nowhere to go and the KPU inter-tile NoC story is invisible.

## Per-SKU classification

| SKU | Topology | Avg hops | Confidence |
|---|---|---|---|
| i7-12700K | RING (12 stops) | 3.00 | THEORETICAL |
| Ryzen 9 8945HS | RING (8 stops) | 2.00 | THEORETICAL |
| Jetson Orin AGX | CROSSBAR (16 ports) | 1.00 | THEORETICAL |
| Coral Edge TPU | CROSSBAR (1 port) | 0.00 | THEORETICAL |
| KPU T64 | MESH_2D (8x8) | 6.40 | THEORETICAL |
| KPU T128 | MESH_2D (16x8) | 9.60 | THEORETICAL |
| KPU T256 | MESH_2D (16x16) | 12.80 | THEORETICAL |
| Hailo-8 | MESH_2D (8x4) | 4.40 | **LOW-CONFIDENCE** |
| Hailo-10H | MESH_2D (8x5) | 4.77 | **LOW-CONFIDENCE** |

KPU T128 hop count = 9.60 = (16+8)/3 × 1.2 — exact match to the legacy `KPUTileEnergyModel.l3_routing_distance_factor` formula.

## Topology scaling (acceptance criterion from issue body)
- **Crossbar:** O(1) — `hop_count_avg(N) == 1.0` for any N
- **Ring:** O(N) — doubling node count doubles avg hops
- **2D mesh:** O(√N) — for square mesh, doubling side quadruples avg hops
- **CLOS:** O(log N)

All four scalings asserted in `TestTopologyScaling`.

## Critical KPU equivalence guard
`TestKPUNumericEquivalence` asserts that `_estimate_l3_routing_distance()` returns identical output with vs. without the fabric attached, on all three KPU SKUs. The fabric-attached path uses `fabric.routing_distance_factor=1.2`; the no-fabric path uses the legacy `l3_routing_distance_factor=1.2` constant. Same number — single source of truth.

## Low-confidence handling (issue M6 constraint)
Hailo-8 and Hailo-10H ship with `low_confidence=True` on their fabric models. The panel surfaces an explicit "LOW CONFIDENCE: vendor does not publish per-hop NoC details" note rather than hiding the uncertainty. Cross-SKU table renders a `LOW-CONFIDENCE` badge.

## Test results

| Suite | Result |
|---|---|
| `tests/reporting/test_layer6_soc_fabric_panel.py` | **81 passed** |
| Full unit suite (`tests/`) | 1312 passed, 7 skipped, 1 xfailed |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Inspect `compare.html` for the Layer 6 table (topology + LOW-CONFIDENCE badge on Hailo)
- [ ] When CI is green: `gh pr ready <#>`

Resolves #32

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Layer 6 (SoC data movement/fabric) support to hardware models with topology specifications (mesh, ring, crossbar), hop counts, latency, energy, and bandwidth metrics for multiple device platforms.
  * Introduced cross-SKU comparison views showing fabric characteristics and confidence levels in reports.

* **Documentation**
  * Updated microarchitectural reports to display Layer 6 population at M6 milestone and include fabric interconnect details.

* **Tests**
  * Added comprehensive validation tests for Layer 6 SoC fabric panel generation and cross-SKU fabric metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->