### PR TITLE
feat(microarch): M7 Layer 7 external memory population

### DIFF
--- a/cli/microarch_validation_report.py
+++ b/cli/microarch_validation_report.py
@@ -76,6 +76,7 @@ from graphs.reporting.layer_panels import (  # noqa: E402
     build_layer4_l2_cache_panel,
     build_layer5_l3_cache_panel,
     build_layer6_soc_fabric_panel,
+    build_layer7_external_memory_panel,
 )
 
 
@@ -116,6 +117,7 @@ def build_empty_report_for(sku: str) -> MicroarchReport:
     _populate_layer4_l2_cache(report)
     _populate_layer5_l3_cache(report)
     _populate_layer6_soc_fabric(report)
+    _populate_layer7_external_memory(report)
     return report
 
 
@@ -171,6 +173,12 @@ def _populate_layer6_soc_fabric(report: MicroarchReport) -> None:
     """Replace the Layer 6 (SoC data movement) panel in-place."""
     panel = build_layer6_soc_fabric_panel(report.sku)
     _replace_layer_panel(report, LayerTag.SOC_DATA_MOVEMENT, panel)
+
+
+def _populate_layer7_external_memory(report: MicroarchReport) -> None:
+    """Replace the Layer 7 (external memory) panel in-place."""
+    panel = build_layer7_external_memory_panel(report.sku)
+    _replace_layer_panel(report, LayerTag.EXTERNAL_MEMORY, panel)
 
 
 def write_json_bundle(reports: List[MicroarchReport], out_dir: Path) -> List[Path]:

--- a/src/graphs/hardware/architectural_energy.py
+++ b/src/graphs/hardware/architectural_energy.py
@@ -493,6 +493,21 @@ class StoredProgramEnergyModel(ArchitecturalEnergyModel):
         }
     )
 
+    # M7 Layer 7: external-memory access-pattern overhead. Sequential
+    # access amortizes row-buffer activations across many bytes (1.0x
+    # baseline); strided access misses the row buffer more often
+    # (~1.3x); random access pays full row activation per request
+    # (~2.0x). Tagged THEORETICAL; downstream consumers may multiply
+    # ``energy_per_byte`` by the appropriate pattern to model
+    # workload-specific DRAM energy.
+    memory_access_pattern_multiplier: Dict[str, float] = field(
+        default_factory=lambda: {
+            "sequential": 1.0,
+            "strided":    1.3,
+            "random":     2.0,
+        }
+    )
+
     # M5 Layer 5: cache-coherence PROTOCOL energy per request. Cost
     # of the snoop / directory message itself: state-transition
     # logic, broadcast write to coherence directory, snooper-side
@@ -919,6 +934,16 @@ class DataParallelEnergyModel(ArchitecturalEnergyModel):
     # so this value is panel-facing rather than energy-path-facing.
     # Derived from TechnologyProfile in __post_init__.
     coherence_protocol_overhead_pj_per_request: float = field(init=False)
+
+    # M7 Layer 7: external-memory access-pattern overhead. Same
+    # semantics and defaults as the StoredProgramEnergyModel field.
+    memory_access_pattern_multiplier: Dict[str, float] = field(
+        default_factory=lambda: {
+            "sequential": 1.0,
+            "strided":    1.3,
+            "random":     2.0,
+        }
+    )
 
     # Instruction pipeline stages - derived from tech_profile
     instruction_decode_energy: float = field(init=False)

--- a/src/graphs/hardware/models/accelerators/kpu_t128.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t128.py
@@ -373,6 +373,11 @@ def kpu_t128_resource_model() -> HardwareResourceModel:
     )
     model.coherence_protocol = "none"
 
+    # M7 Layer 7: 96 GB/s LPDDR5 (4GB on-package).
+    model.memory_technology = "LPDDR5"
+    model.memory_read_energy_per_byte_pj = 12.0
+    model.memory_write_energy_per_byte_pj = 14.4
+
     # M6 Layer 6: 2D mesh fabric tied to the M0.5 tile abstraction.
     # routing_distance_factor=1.2 matches the legacy constant in
     # KPUTileEnergyModel; attaching the fabric here lets
@@ -465,5 +470,18 @@ def kpu_t128_resource_model() -> HardwareResourceModel:
                     "preserves legacy energy formula)"),
         ),
     )
+
+    # M7 Layer 7 provenance
+    for key in ("memory_technology",
+                "memory_read_energy_per_byte_pj",
+                "memory_write_energy_per_byte_pj"):
+        model.set_provenance(
+            key,
+            EstimationConfidence.theoretical(
+                score=0.80,
+                source=("Stillwater KPU-T128: 96 GB/s LPDDR5 "
+                        "on-package (4GB); JEDEC LPDDR5 reference"),
+            ),
+        )
 
     return model

--- a/src/graphs/hardware/models/accelerators/kpu_t256.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t256.py
@@ -540,6 +540,11 @@ def kpu_t256_resource_model() -> HardwareResourceModel:
     )
     model.coherence_protocol = "none"
 
+    # M7 Layer 7: 256 GB/s LPDDR5 (high-end SKU).
+    model.memory_technology = "LPDDR5"
+    model.memory_read_energy_per_byte_pj = 11.0
+    model.memory_write_energy_per_byte_pj = 13.2
+
     # M6 Layer 6: 2D mesh fabric tied to M0.5 tile abstraction.
     model.soc_fabric = SoCFabricModel(
         topology=Topology.MESH_2D,
@@ -624,6 +629,19 @@ def kpu_t256_resource_model() -> HardwareResourceModel:
                     "KPUTileEnergyModel"),
         ),
     )
+
+    # M7 Layer 7 provenance
+    for key in ("memory_technology",
+                "memory_read_energy_per_byte_pj",
+                "memory_write_energy_per_byte_pj"):
+        model.set_provenance(
+            key,
+            EstimationConfidence.theoretical(
+                score=0.80,
+                source=("Stillwater KPU-T256: 256 GB/s LPDDR5 "
+                        "high-throughput config"),
+            ),
+        )
 
     return model
 

--- a/src/graphs/hardware/models/accelerators/kpu_t64.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t64.py
@@ -500,6 +500,11 @@ def kpu_t64_resource_model() -> HardwareResourceModel:
     )
     model.coherence_protocol = "none"
 
+    # M7 Layer 7: 64 GB/s LPDDR5 on-package.
+    model.memory_technology = "LPDDR5"
+    model.memory_read_energy_per_byte_pj = 12.0
+    model.memory_write_energy_per_byte_pj = 14.4
+
     # M6 Layer 6: 2D mesh fabric tied to M0.5 tile abstraction.
     model.soc_fabric = SoCFabricModel(
         topology=Topology.MESH_2D,
@@ -584,6 +589,18 @@ def kpu_t64_resource_model() -> HardwareResourceModel:
                     "KPUTileEnergyModel"),
         ),
     )
+
+    # M7 Layer 7 provenance
+    for key in ("memory_technology",
+                "memory_read_energy_per_byte_pj",
+                "memory_write_energy_per_byte_pj"):
+        model.set_provenance(
+            key,
+            EstimationConfidence.theoretical(
+                score=0.80,
+                source="Stillwater KPU-T64: 64 GB/s LPDDR5 on-package",
+            ),
+        )
 
     return model
 

--- a/src/graphs/hardware/models/edge/coral_edge_tpu.py
+++ b/src/graphs/hardware/models/edge/coral_edge_tpu.py
@@ -236,6 +236,12 @@ def coral_edge_tpu_resource_model() -> HardwareResourceModel:
         l3_cache_total=0,
         coherence_protocol="none",
 
+        # M7 Layer 7: USB / LPDDR4 narrow path (4 GB/s). Higher per-byte
+        # cost reflects narrow bus + USB packetization on USB variants.
+        memory_technology="LPDDR4",
+        memory_read_energy_per_byte_pj=20.0,
+        memory_write_energy_per_byte_pj=24.0,
+
         # M6 Layer 6: single systolic tile + unified buffer; the
         # "fabric" is a trivial direct-connect between the systolic
         # array and the UB, modeled as a 1-port crossbar.
@@ -333,6 +339,20 @@ def coral_edge_tpu_resource_model() -> HardwareResourceModel:
             source="Coral Edge TPU: trivial single-tile direct-connect fabric",
         ),
     )
+
+    # M7 Layer 7 provenance
+    for key in ("memory_technology",
+                "memory_read_energy_per_byte_pj",
+                "memory_write_energy_per_byte_pj"):
+        model.set_provenance(
+            key,
+            EstimationConfidence.theoretical(
+                score=0.70,
+                source=("Coral Edge TPU: narrow LPDDR4 / USB-bound; "
+                        "energy reflects packetization overhead on "
+                        "USB variants"),
+            ),
+        )
 
     return model
 

--- a/src/graphs/hardware/models/edge/hailo10h.py
+++ b/src/graphs/hardware/models/edge/hailo10h.py
@@ -256,6 +256,14 @@ def hailo10h_resource_model() -> HardwareResourceModel:
         l3_cache_total=0,
         coherence_protocol="none",
 
+        # M7 Layer 7: Hailo-10H is transformer-optimized; host-side
+        # DRAM holds the model weights (LPDDR5 to keep BW up for KV
+        # cache spills). Steady-state still serves attention from
+        # on-chip 12 MB L2 SRAM.
+        memory_technology="LPDDR5 (host) + on-chip SRAM (KV cache)",
+        memory_read_energy_per_byte_pj=15.0,
+        memory_write_energy_per_byte_pj=18.0,
+
         # M6 Layer 6: dataflow mesh between 40 PE units (low confidence).
         soc_fabric=_get_hailo10h_fabric(),
     )
@@ -330,5 +338,19 @@ def hailo10h_resource_model() -> HardwareResourceModel:
                     "panel ships with low_confidence=True flag"),
         ),
     )
+
+    # M7 Layer 7 provenance
+    for key in ("memory_technology",
+                "memory_read_energy_per_byte_pj",
+                "memory_write_energy_per_byte_pj"):
+        model.set_provenance(
+            key,
+            EstimationConfidence.theoretical(
+                score=0.55,
+                source=("Hailo-10H host-side LPDDR5 for transformer "
+                        "weights + KV cache; steady-state attention "
+                        "from on-chip 12 MB L2"),
+            ),
+        )
 
     return model

--- a/src/graphs/hardware/models/edge/hailo8.py
+++ b/src/graphs/hardware/models/edge/hailo8.py
@@ -255,6 +255,15 @@ def hailo8_resource_model() -> HardwareResourceModel:
         l3_cache_total=0,
         coherence_protocol="none",
 
+        # M7 Layer 7: Hailo-8 deployments load model weights once at
+        # initialization, then run inference entirely from on-chip
+        # SRAM. The legacy energy_per_byte=2 pJ/B reflects on-chip
+        # SRAM access, not DRAM. Model the host-side DRAM here as
+        # LPDDR4 for the cold-start / weight-load path.
+        memory_technology="LPDDR4 (host) + on-chip SRAM (steady-state)",
+        memory_read_energy_per_byte_pj=22.0,
+        memory_write_energy_per_byte_pj=27.0,
+
         # M6 Layer 6: dataflow mesh between 32 PE units. Hailo does
         # NOT publish per-hop NoC details, so this entry ships with
         # low_confidence=True per issue M6 constraint. Mesh
@@ -332,5 +341,20 @@ def hailo8_resource_model() -> HardwareResourceModel:
                     "panel ships with low_confidence=True flag"),
         ),
     )
+
+    # M7 Layer 7 provenance: Hailo deploys with weights resident
+    # in on-chip SRAM; DRAM only on the cold-start path.
+    for key in ("memory_technology",
+                "memory_read_energy_per_byte_pj",
+                "memory_write_energy_per_byte_pj"):
+        model.set_provenance(
+            key,
+            EstimationConfidence.theoretical(
+                score=0.55,
+                source=("Hailo-8 host-side LPDDR4 for weight load; "
+                        "steady-state inference is on-chip SRAM "
+                        "(legacy 2 pJ/B value reflects SRAM, not DRAM)"),
+            ),
+        )
 
     return model

--- a/src/graphs/hardware/models/edge/intel_core_i7_12700k.py
+++ b/src/graphs/hardware/models/edge/intel_core_i7_12700k.py
@@ -277,6 +277,13 @@ def intel_core_i7_12700k_resource_model() -> HardwareResourceModel:
         l3_cache_total=25 * 1024 * 1024,  # 25 MiB shared L3
         coherence_protocol="snoopy_mesi",
 
+        # M7 Layer 7: DDR5 dual-channel external memory.
+        # Reads ~25 pJ/B; writes ~30 pJ/B (~1.2x asymmetry from
+        # write-buffer + bank precharge tail).
+        memory_technology="DDR5",
+        memory_read_energy_per_byte_pj=25.0,
+        memory_write_energy_per_byte_pj=30.0,
+
         # M6 Layer 6: Alder Lake double ring bus carries L2->L3 / L3
         # snoop traffic between cores. 12 stops on the ring (8 P + 4 E
         # cores + cache slices); avg latency ~1.5 ns / stop, ~5 pJ/flit.
@@ -400,5 +407,19 @@ def intel_core_i7_12700k_resource_model() -> HardwareResourceModel:
                     "OPT manual"),
         ),
     )
+
+    # M7 Layer 7 provenance for external memory
+    for key in ("memory_technology",
+                "memory_read_energy_per_byte_pj",
+                "memory_write_energy_per_byte_pj"):
+        model.set_provenance(
+            key,
+            EstimationConfidence.theoretical(
+                score=0.80,
+                source=("DDR5-4800 dual-channel desktop config; "
+                        "energy from JEDEC DDR5 reference + ~1.2x R/W "
+                        "asymmetry"),
+            ),
+        )
 
     return model

--- a/src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py
+++ b/src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py
@@ -515,6 +515,11 @@ def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
         l3_cache_total=0,
         coherence_protocol="none",  # SIMT memory model, not snoopy
 
+        # M7 Layer 7: 256-bit LPDDR5 (204.8 GB/s).
+        memory_technology="LPDDR5",
+        memory_read_energy_per_byte_pj=15.0,
+        memory_write_energy_per_byte_pj=18.0,
+
         # M6 Layer 6: SM-to-L2 crossbar interconnect. 16 SMs * 4 L2
         # slices = 64-port crossbar; effectively single-hop access
         # across the full L2.
@@ -602,6 +607,19 @@ def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
                     "per-flit energy estimated from 8nm process baseline"),
         ),
     )
+
+    # M7 Layer 7 provenance
+    for key in ("memory_technology",
+                "memory_read_energy_per_byte_pj",
+                "memory_write_energy_per_byte_pj"):
+        model.set_provenance(
+            key,
+            EstimationConfidence.theoretical(
+                score=0.85,
+                source=("Jetson Orin AGX: 256-bit LPDDR5 @ 204.8 GB/s "
+                        "(NVIDIA datasheet); JEDEC LPDDR5 energy"),
+            ),
+        )
 
     return model
 

--- a/src/graphs/hardware/models/edge/ryzen_9_8945hs.py
+++ b/src/graphs/hardware/models/edge/ryzen_9_8945hs.py
@@ -212,6 +212,12 @@ def ryzen_9_8945hs_resource_model() -> HardwareResourceModel:
         l3_cache_total=16 * 1024 * 1024,
         coherence_protocol="snoopy_mesi",
 
+        # M7 Layer 7: LPDDR5x mobile DRAM. Lower energy than DDR5
+        # desktop (mobile-optimized PHY).
+        memory_technology="LPDDR5x",
+        memory_read_energy_per_byte_pj=18.0,
+        memory_write_energy_per_byte_pj=22.0,
+
         # M6 Layer 6: Zen 4 Phoenix has a single CCX with all 8 cores
         # on one Infinity Fabric ring (no inter-CCX hop). N4 process
         # gives slightly lower per-flit energy than Alder Lake at 10nm.
@@ -326,5 +332,18 @@ def ryzen_9_8945hs_resource_model() -> HardwareResourceModel:
                     "values estimated from N4 process"),
         ),
     )
+
+    # M7 Layer 7 provenance
+    for key in ("memory_technology",
+                "memory_read_energy_per_byte_pj",
+                "memory_write_energy_per_byte_pj"):
+        model.set_provenance(
+            key,
+            EstimationConfidence.theoretical(
+                score=0.80,
+                source=("LPDDR5x mobile DRAM (Phoenix laptop config); "
+                        "energy from JEDEC LPDDR5x reference"),
+            ),
+        )
 
     return model

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -880,6 +880,23 @@ class HardwareResourceModel:
     # Provenance: ``soc_fabric``.
     soc_fabric: Optional["SoCFabricModel"] = None
 
+    # M7 Layer 7: explicit external memory technology naming.
+    # Examples: "DDR5", "LPDDR5", "LPDDR5x", "HBM3", "HBM3e",
+    # "GDDR6", "on-chip" (for accelerators with no DRAM).
+    # Provenance: ``memory_technology``.
+    memory_technology: Optional[str] = None
+
+    # M7 Layer 7: read / write energy asymmetry. Modern DRAM costs
+    # ~1.2 - 1.5x more per byte for writes than reads (write-buffer
+    # tail-end energy + bank precharge). Defaults to None when only
+    # the legacy symmetric ``energy_per_byte`` is populated; the
+    # Layer 7 panel falls back to that field when these are unset.
+    # Values are picojoules per byte (panel-friendly units).
+    # Provenance: ``memory_read_energy_per_byte_pj``,
+    # ``memory_write_energy_per_byte_pj``.
+    memory_read_energy_per_byte_pj: Optional[float] = None
+    memory_write_energy_per_byte_pj: Optional[float] = None
+
     # Provenance of individual resource-model fields.
     # Maps field name (e.g., "peak_bandwidth", "energy_per_flop_fp32") to
     # the EstimationConfidence that describes where that value came from.

--- a/src/graphs/reporting/layer_panels/__init__.py
+++ b/src/graphs/reporting/layer_panels/__init__.py
@@ -44,6 +44,12 @@ from .layer6_soc_fabric import (
     cross_sku_layer6_chart,
     CrossSKULayer6Chart,
 )
+from .layer7_external_memory import (
+    build_layer7_external_memory_panel,
+    build_layer7_panels_for_skus,
+    cross_sku_layer7_chart,
+    CrossSKULayer7Chart,
+)
 
 __all__ = [
     "build_layer1_panel",
@@ -70,4 +76,8 @@ __all__ = [
     "build_layer6_panels_for_skus",
     "cross_sku_layer6_chart",
     "CrossSKULayer6Chart",
+    "build_layer7_external_memory_panel",
+    "build_layer7_panels_for_skus",
+    "cross_sku_layer7_chart",
+    "CrossSKULayer7Chart",
 ]

--- a/src/graphs/reporting/layer_panels/layer7_external_memory.py
+++ b/src/graphs/reporting/layer_panels/layer7_external_memory.py
@@ -1,0 +1,230 @@
+"""
+Layer 7 external memory panel builder.
+
+Surfaces per-SKU external (DRAM) memory characteristics: technology
+class, peak bandwidth, read / write energy with explicit asymmetry,
+and access-pattern overhead (sequential / strided / random) from
+the energy model.
+
+The cross-SKU view also surfaces a bandwidth-vs-pJ/byte data table --
+the visually striking comparison that motivates the M7 milestone:
+modern DDR5/LPDDR5 sit at ~10-25 pJ/B; older LPDDR4 climbs to 20+;
+HBM3 (not currently in the catalog) drops below 10 pJ/B at the cost
+of higher die area.
+
+For SKUs whose deployment is on-chip-dominated (Hailo), the
+``memory_technology`` string is annotated to reflect the host-vs-
+on-chip split rather than papering over it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from graphs.benchmarks.schema import LayerTag
+from graphs.core.confidence import ConfidenceLevel
+from graphs.hardware.architectural_energy import StoredProgramEnergyModel
+from graphs.hardware.resource_model import HardwareResourceModel
+from graphs.reporting.microarch_schema import LayerPanel
+from graphs.reporting.layer_panels.layer1_alu import resolve_sku_resource_model
+
+
+def _provenance_or_theoretical(
+    model: HardwareResourceModel, key: str,
+) -> str:
+    conf = model.get_provenance(key)
+    if conf.level is ConfidenceLevel.UNKNOWN:
+        return ConfidenceLevel.THEORETICAL.value.upper()
+    return conf.level.value.upper()
+
+
+def _read_energy_pj(model: HardwareResourceModel) -> float:
+    """Return the read energy per byte in pJ. Falls back to the legacy
+    symmetric ``energy_per_byte`` when no asymmetric value is set."""
+    if model.memory_read_energy_per_byte_pj is not None:
+        return model.memory_read_energy_per_byte_pj
+    return model.energy_per_byte * 1e12
+
+
+def _write_energy_pj(model: HardwareResourceModel) -> float:
+    """Return the write energy per byte in pJ. Falls back to the legacy
+    symmetric ``energy_per_byte`` when no asymmetric value is set."""
+    if model.memory_write_energy_per_byte_pj is not None:
+        return model.memory_write_energy_per_byte_pj
+    return model.energy_per_byte * 1e12
+
+
+def _default_access_pattern_table() -> Dict[str, float]:
+    """Pull the default access-pattern multipliers from the energy
+    model's dataclass field default."""
+    fld = next(
+        f for f in StoredProgramEnergyModel.__dataclass_fields__.values()
+        if f.name == "memory_access_pattern_multiplier"
+    )
+    return dict(fld.default_factory())
+
+
+# --------------------------------------------------------------------
+# Panel construction
+# --------------------------------------------------------------------
+
+def build_layer7_external_memory_panel(
+    sku_id: str,
+    model: Optional[HardwareResourceModel] = None,
+) -> LayerPanel:
+    """Build the Layer 7 (external memory) panel for one SKU."""
+    if model is None:
+        model = resolve_sku_resource_model(sku_id)
+
+    title = "Layer 7: External Memory"
+
+    if model is None or not model.peak_bandwidth:
+        return LayerPanel(
+            layer=LayerTag.EXTERNAL_MEMORY,
+            title=title,
+            status="not_populated",
+            summary=f"No external memory model attached for {sku_id}.",
+        )
+
+    tech = model.memory_technology or "(unspecified)"
+    bw_gbs = model.peak_bandwidth / 1e9
+    rd = _read_energy_pj(model)
+    wr = _write_energy_pj(model)
+    asymmetry = wr / rd if rd > 0 else 1.0
+
+    metrics: Dict[str, Dict] = {
+        "Memory technology": {
+            "value": tech,
+            "unit":  "",
+            "provenance": _provenance_or_theoretical(model, "memory_technology"),
+        },
+        "Peak bandwidth": {
+            "value": f"{bw_gbs:.1f}",
+            "unit":  "GB/s",
+            "provenance": _provenance_or_theoretical(model, "peak_bandwidth"),
+        },
+        "Read energy": {
+            "value": f"{rd:.2f}",
+            "unit":  "pJ/B",
+            "provenance": _provenance_or_theoretical(
+                model, "memory_read_energy_per_byte_pj"
+            ),
+        },
+        "Write energy": {
+            "value": f"{wr:.2f}",
+            "unit":  "pJ/B",
+            "provenance": _provenance_or_theoretical(
+                model, "memory_write_energy_per_byte_pj"
+            ),
+        },
+        "W/R asymmetry": {
+            "value": f"{asymmetry:.2f}x",
+            "unit":  "ratio",
+            "provenance": "n/a",
+        },
+    }
+
+    # Access-pattern multipliers from the energy-model defaults
+    for pattern, mult in _default_access_pattern_table().items():
+        metrics[f"Access pattern ({pattern})"] = {
+            "value": f"{mult:.2f}x",
+            "unit":  "ratio",
+            "provenance": "THEORETICAL",
+        }
+
+    notes: List[str] = [
+        "Layer 7 captures the cost of moving bytes between the chip "
+        "and external memory. Access-pattern multipliers model "
+        "row-buffer locality: sequential streams amortize row "
+        "activation across many bytes; random access pays full "
+        "row-activation energy per request."
+    ]
+
+    if "on-chip" in tech.lower():
+        notes.append(
+            "This SKU's deployment loads model weights into on-chip "
+            "SRAM at initialization and runs steady-state inference "
+            "without DRAM traffic. The Layer 7 numbers describe the "
+            "host-side memory used during weight loading, not the "
+            "steady-state inference loop."
+        )
+
+    summary = (
+        f"External memory for {sku_id}: {tech}, "
+        f"{bw_gbs:.1f} GB/s peak. "
+        f"Reads at {rd:.2f} pJ/B; writes at {wr:.2f} pJ/B "
+        f"({asymmetry:.2f}x asymmetry)."
+    )
+
+    return LayerPanel(
+        layer=LayerTag.EXTERNAL_MEMORY,
+        title=title,
+        status="theoretical",
+        summary=summary,
+        metrics=metrics,
+        notes=notes,
+    )
+
+
+def build_layer7_panels_for_skus(
+    sku_ids: List[str],
+) -> Dict[str, LayerPanel]:
+    return {sku: build_layer7_external_memory_panel(sku) for sku in sku_ids}
+
+
+# --------------------------------------------------------------------
+# Cross-SKU comparison: bandwidth vs pJ/byte
+# --------------------------------------------------------------------
+
+@dataclass
+class CrossSKULayer7Chart:
+    skus: List[str]
+    memory_technology: Dict[str, str]
+    peak_bandwidth_gbps: Dict[str, float]
+    read_energy_pj: Dict[str, float]
+    write_energy_pj: Dict[str, float]
+    asymmetry: Dict[str, float]
+    provenance: Dict[str, str]
+
+
+def cross_sku_layer7_chart(sku_ids: List[str]) -> CrossSKULayer7Chart:
+    chart = CrossSKULayer7Chart(
+        skus=list(sku_ids),
+        memory_technology={},
+        peak_bandwidth_gbps={},
+        read_energy_pj={},
+        write_energy_pj={},
+        asymmetry={},
+        provenance={},
+    )
+
+    models: Dict[str, Optional[HardwareResourceModel]] = {
+        sku: resolve_sku_resource_model(sku) for sku in sku_ids
+    }
+
+    for sku in sku_ids:
+        m = models.get(sku)
+        if m is None or not m.peak_bandwidth:
+            continue
+        chart.memory_technology[sku] = (
+            m.memory_technology or "(unspecified)"
+        )
+        chart.peak_bandwidth_gbps[sku] = m.peak_bandwidth / 1e9
+        rd = _read_energy_pj(m)
+        wr = _write_energy_pj(m)
+        chart.read_energy_pj[sku] = rd
+        chart.write_energy_pj[sku] = wr
+        chart.asymmetry[sku] = wr / rd if rd > 0 else 1.0
+        chart.provenance[sku] = _provenance_or_theoretical(
+            m, "memory_technology"
+        )
+
+    return chart
+
+
+__all__ = [
+    "build_layer7_external_memory_panel",
+    "build_layer7_panels_for_skus",
+    "cross_sku_layer7_chart",
+    "CrossSKULayer7Chart",
+]

--- a/src/graphs/reporting/microarch_html_template.py
+++ b/src/graphs/reporting/microarch_html_template.py
@@ -786,6 +786,85 @@ def _render_layer6_cross_sku_table(reports: List[MicroarchReport]) -> str:
 """
 
 
+def _render_layer7_cross_sku_table(reports: List[MicroarchReport]) -> str:
+    """
+    Render the Layer 7 external-memory comparison: technology,
+    bandwidth, R/W energy, asymmetry. The bandwidth-vs-pJ/byte
+    column pair gives the visually striking comparison from the M7
+    motivation -- DDR5 pays >2x the pJ/byte of LPDDR5 at lower BW.
+    """
+    try:
+        from graphs.reporting.layer_panels import cross_sku_layer7_chart
+    except Exception:
+        return ""
+
+    sku_ids = [r.sku for r in reports]
+    chart = cross_sku_layer7_chart(sku_ids)
+    if not chart.memory_technology:
+        return ""
+
+    name_lookup = {r.sku: (r.display_name or r.sku) for r in reports}
+    header_cells = "".join(
+        f"<th>{html.escape(name_lookup.get(sku, sku))}</th>"
+        for sku in chart.skus
+    )
+
+    def _row(label, getter, fmt):
+        cells = [f"<th>{html.escape(label)}</th>"]
+        for sku in chart.skus:
+            v = getter(sku)
+            if v is None:
+                cells.append("<td>--</td>")
+            else:
+                cells.append(f"<td>{fmt(v)}</td>")
+        return "<tr>" + "".join(cells) + "</tr>"
+
+    rows = (
+        _row("Memory technology",
+             lambda s: chart.memory_technology.get(s),
+             lambda v: html.escape(v))
+        + _row("Peak BW (GB/s)",
+               lambda s: chart.peak_bandwidth_gbps.get(s),
+               lambda v: f"{v:.1f}")
+        + _row("Read energy (pJ/B)",
+               lambda s: chart.read_energy_pj.get(s),
+               lambda v: f"{v:.2f}")
+        + _row("Write energy (pJ/B)",
+               lambda s: chart.write_energy_pj.get(s),
+               lambda v: f"{v:.2f}")
+        + _row("W/R asymmetry",
+               lambda s: chart.asymmetry.get(s),
+               lambda v: f"{v:.2f}x")
+    )
+
+    badge_cells = []
+    for sku in chart.skus:
+        prov = chart.provenance.get(sku, "UNKNOWN")
+        badge = _safe_status_class(prov.lower())
+        badge_cells.append(
+            f'<td><span class="badge {badge}">{html.escape(prov)}</span></td>'
+        )
+    rows += "<tr><th>Provenance</th>" + "".join(badge_cells) + "</tr>"
+
+    return f"""
+<section>
+  <h3>Layer 7: external memory across SKUs</h3>
+  <p class="meta">External-memory characteristics. Bandwidth and
+  pJ/byte trade off across technology generations: DDR5 desktop
+  pays the highest energy per byte; LPDDR5 mobile / on-package
+  is the sweet spot for edge inference; HBM3 (not in this catalog
+  yet) drops below 10 pJ/B at the cost of die area. Hailo SKUs
+  load weights from host DRAM at initialization and serve
+  steady-state inference from on-chip SRAM, so their host-side
+  numbers describe the cold-start path.</p>
+  <table class="layer7-cross">
+    <thead><tr><th></th>{header_cells}</tr></thead>
+    <tbody>{rows}</tbody>
+  </table>
+</section>
+"""
+
+
 def render_comparison_page(
     reports: List[MicroarchReport],
     repo_root: Path,
@@ -801,8 +880,9 @@ def render_comparison_page(
       - Layer 4 L2-capacity / topology table (M4)
       - Layer 5 L3-presence / coherence table (M5)
       - Layer 6 SoC fabric topology + hop coefficients (M6)
+      - Layer 7 external-memory technology + bandwidth + pJ/B (M7)
 
-    M7-M8 add later layer comparison sections.
+    M8 adds the engineering-deck export.
     """
     assets = _load_logo(repo_root)
     rows = "".join(
@@ -818,6 +898,7 @@ def render_comparison_page(
     layer4_section = _render_layer4_cross_sku_table(reports)
     layer5_section = _render_layer5_cross_sku_table(reports)
     layer6_section = _render_layer6_cross_sku_table(reports)
+    layer7_section = _render_layer7_cross_sku_table(reports)
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -827,8 +908,8 @@ def render_comparison_page(
 table {{ width: 100%; border-collapse: collapse; background: #fff; }}
 table th, table td {{ padding: 10px 12px; border-bottom: 1px solid #e3e6eb; text-align: left; }}
 table th {{ font-size: 12px; text-transform: uppercase; color: #586374; background: #f3f5f8; }}
-table.layer1-cross td, table.layer2-cross td, table.layer3-cross td, table.layer4-cross td, table.layer5-cross td, table.layer6-cross td {{ text-align: right; }}
-table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.layer3-cross th:first-child, table.layer4-cross th:first-child, table.layer5-cross th:first-child, table.layer6-cross th:first-child {{ text-align: left; }}
+table.layer1-cross td, table.layer2-cross td, table.layer3-cross td, table.layer4-cross td, table.layer5-cross td, table.layer6-cross td, table.layer7-cross td {{ text-align: right; }}
+table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.layer3-cross th:first-child, table.layer4-cross th:first-child, table.layer5-cross th:first-child, table.layer6-cross th:first-child, table.layer7-cross th:first-child {{ text-align: left; }}
   </style>
 </head>
 <body>
@@ -837,9 +918,9 @@ table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.laye
   <section class="page-header">
     <h2>Compare across SKUs</h2>
     <div class="meta">
-      Layers 1-6 (ALU, Register File, L1 Cache / Scratchpad, L2 Cache,
-      L3 / LLC, SoC Data Movement) populated; remaining layer
-      comparisons follow at M7-M8.
+      All seven layers populated (ALU, Register File, L1 Cache /
+      Scratchpad, L2 Cache, L3 / LLC, SoC Data Movement, External
+      Memory). Engineering-deck export lands at M8.
     </div>
   </section>
   {_render_legend()}
@@ -855,6 +936,7 @@ table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.laye
   {layer4_section}
   {layer5_section}
   {layer6_section}
+  {layer7_section}
 </main>
 {_render_brand_footer("microarch-model-delivery-plan.md")}
 </body>

--- a/tests/cli/test_microarch_validation_report.py
+++ b/tests/cli/test_microarch_validation_report.py
@@ -1,9 +1,8 @@
 """Smoke tests for cli/microarch_validation_report.py.
 
-M0 shipped empty panels; M1 populates Layer 1 (ALU); M2 populates
-Layer 2 (Register File); M3 populates Layer 3 (L1 cache / scratchpad);
-M4 populates Layer 4 (L2 cache); M5 populates Layer 5 (L3 / LLC);
-M6 populates Layer 6 (SoC data movement).
+M0 shipped empty panels; M1-M7 populate all seven layers (ALU,
+Register File, L1 cache, L2 cache, L3/LLC, SoC fabric, External
+memory).
 """
 from __future__ import annotations
 
@@ -51,16 +50,14 @@ def test_json_bundle_emits_one_file_per_sku(tmp_path: Path, cli_main):
         "soc_data_movement", "external_memory",
     ]
     assert layer_tags == expected
-    # M6: layers 1-6 populated as 'theoretical'; layer 7 remains
-    # 'not_populated' until M7 lands.
+    # M7: all seven layers populated as 'theoretical'.
     layer_status = {p["layer"]: p["status"] for p in payload["layers"]}
     for tag in ("alu", "register", "l1_cache", "l2_cache", "l3_cache",
-                "soc_data_movement"):
+                "soc_data_movement", "external_memory"):
         assert layer_status[tag] == "theoretical", (
-            f"Layer for {tag} should be 'theoretical' at M6, "
+            f"Layer for {tag} should be 'theoretical' at M7, "
             f"got {layer_status[tag]!r}"
         )
-    assert layer_status["external_memory"] == "not_populated"
 
 
 def test_html_bundle_writes_index_hardware_compare(tmp_path: Path, cli_main):
@@ -75,7 +72,7 @@ def test_html_bundle_writes_index_hardware_compare(tmp_path: Path, cli_main):
     assert (tmp_path / "compare.html").exists()
 
 
-def test_html_has_branes_branding_and_placeholder(tmp_path: Path, cli_main):
+def test_html_has_branes_branding_and_layer_titles(tmp_path: Path, cli_main):
     cli_main.main([
         "--hardware", "kpu_t128",
         "--format", "html",
@@ -88,8 +85,9 @@ def test_html_has_branes_branding_and_placeholder(tmp_path: Path, cli_main):
     assert "CALIBRATED" in sku_html
     assert "INTERPOLATED" in sku_html
     assert "THEORETICAL" in sku_html
-    # M0 placeholder text
-    assert "NOT YET POPULATED" in sku_html
+    # M7 contract: all seven layers populated, so the M0 placeholder
+    # text "NOT YET POPULATED" must not appear in any per-SKU page.
+    assert "NOT YET POPULATED" not in sku_html
     # All seven layer titles present
     for expected_title in [
         "Layer 1: ALU",

--- a/tests/reporting/test_layer7_external_memory_panel.py
+++ b/tests/reporting/test_layer7_external_memory_panel.py
@@ -1,0 +1,209 @@
+"""Self-consistency tests for the M7 Layer 7 (external memory) panel."""
+from __future__ import annotations
+
+import pytest
+
+from graphs.benchmarks.schema import LayerTag
+from graphs.core.confidence import ConfidenceLevel
+from graphs.hardware.architectural_energy import (
+    DataParallelEnergyModel,
+    StoredProgramEnergyModel,
+)
+from graphs.reporting.layer_panels import (
+    build_layer7_external_memory_panel,
+    cross_sku_layer7_chart,
+    resolve_sku_resource_model,
+)
+
+
+REQUIRED_SKUS = [
+    "jetson_orin_agx_64gb",
+    "intel_core_i7_12700k",
+    "ryzen_9_8945hs",
+    "kpu_t64",
+    "kpu_t128",
+    "kpu_t256",
+    "coral_edge_tpu",
+]
+OPTIONAL_SKUS = ["hailo8", "hailo10h"]
+TARGET_SKUS = REQUIRED_SKUS + OPTIONAL_SKUS
+
+
+def _skip_if_optional_unresolved(sku: str) -> None:
+    if sku in OPTIONAL_SKUS and resolve_sku_resource_model(sku) is None:
+        pytest.skip(f"{sku} model unavailable in this environment")
+
+
+class TestPerSKUSchemaFields:
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_memory_technology_set(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert m.memory_technology
+        assert isinstance(m.memory_technology, str)
+
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_read_write_energy_set(self, sku):
+        m = resolve_sku_resource_model(sku)
+        assert m.memory_read_energy_per_byte_pj is not None
+        assert m.memory_write_energy_per_byte_pj is not None
+        assert m.memory_read_energy_per_byte_pj > 0
+        assert m.memory_write_energy_per_byte_pj > 0
+
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_write_at_or_above_read(self, sku):
+        """DRAM writes always cost >= reads (precharge tail)."""
+        m = resolve_sku_resource_model(sku)
+        assert (m.memory_write_energy_per_byte_pj
+                >= m.memory_read_energy_per_byte_pj)
+
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_asymmetry_in_plausible_range(self, sku):
+        """W/R asymmetry should be in [1.0, 1.5] for any modern DRAM."""
+        m = resolve_sku_resource_model(sku)
+        ratio = (m.memory_write_energy_per_byte_pj
+                 / m.memory_read_energy_per_byte_pj)
+        assert 1.0 <= ratio <= 1.5, (
+            f"{sku} W/R asymmetry {ratio:.2f}x outside [1.0, 1.5]"
+        )
+
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_layer7_provenance_theoretical(self, sku):
+        m = resolve_sku_resource_model(sku)
+        for key in ("memory_technology",
+                    "memory_read_energy_per_byte_pj",
+                    "memory_write_energy_per_byte_pj"):
+            conf = m.get_provenance(key)
+            assert conf.level is ConfidenceLevel.THEORETICAL, (
+                f"{sku}/{key} provenance={conf.level}"
+            )
+
+
+class TestEnergyModelAccessPattern:
+    def test_access_pattern_table_on_both_models(self):
+        from graphs.hardware.technology_profile import EDGE_8NM_LPDDR5
+        sp = StoredProgramEnergyModel(tech_profile=EDGE_8NM_LPDDR5)
+        dp = DataParallelEnergyModel(tech_profile=EDGE_8NM_LPDDR5)
+        for m in (sp, dp):
+            assert isinstance(m.memory_access_pattern_multiplier, dict)
+            for pattern in ("sequential", "strided", "random"):
+                assert pattern in m.memory_access_pattern_multiplier
+
+    def test_pattern_ordering(self):
+        """Sequential is cheapest; strided is in the middle; random
+        is most expensive."""
+        from graphs.hardware.technology_profile import EDGE_8NM_LPDDR5
+        m = StoredProgramEnergyModel(tech_profile=EDGE_8NM_LPDDR5)
+        seq = m.memory_access_pattern_multiplier["sequential"]
+        strd = m.memory_access_pattern_multiplier["strided"]
+        rnd = m.memory_access_pattern_multiplier["random"]
+        assert seq <= strd < rnd
+
+    def test_sequential_is_baseline(self):
+        from graphs.hardware.technology_profile import EDGE_8NM_LPDDR5
+        m = StoredProgramEnergyModel(tech_profile=EDGE_8NM_LPDDR5)
+        assert m.memory_access_pattern_multiplier["sequential"] == 1.0
+
+
+class TestPanelBuilder:
+    @pytest.mark.parametrize("sku", TARGET_SKUS)
+    def test_panel_is_external_memory_layer(self, sku):
+        _skip_if_optional_unresolved(sku)
+        panel = build_layer7_external_memory_panel(sku)
+        assert panel.layer is LayerTag.EXTERNAL_MEMORY
+        assert "External" in panel.title or "Memory" in panel.title
+
+    @pytest.mark.parametrize("sku", TARGET_SKUS)
+    def test_panel_populated(self, sku):
+        _skip_if_optional_unresolved(sku)
+        panel = build_layer7_external_memory_panel(sku)
+        assert panel.status != "not_populated"
+        assert panel.metrics
+
+    @pytest.mark.parametrize("sku", TARGET_SKUS)
+    def test_panel_has_required_metrics(self, sku):
+        _skip_if_optional_unresolved(sku)
+        panel = build_layer7_external_memory_panel(sku)
+        assert "Memory technology" in panel.metrics
+        assert "Peak bandwidth" in panel.metrics
+        assert "Read energy" in panel.metrics
+        assert "Write energy" in panel.metrics
+        assert "W/R asymmetry" in panel.metrics
+
+    @pytest.mark.parametrize("sku", TARGET_SKUS)
+    def test_panel_has_access_pattern_metrics(self, sku):
+        _skip_if_optional_unresolved(sku)
+        panel = build_layer7_external_memory_panel(sku)
+        for pattern in ("sequential", "strided", "random"):
+            key = f"Access pattern ({pattern})"
+            assert key in panel.metrics
+
+    def test_hailo_panel_calls_out_on_chip_split(self):
+        """Hailo SKUs deploy weights from on-chip SRAM in steady
+        state -- the panel must surface this rather than papering
+        over with phantom DRAM numbers."""
+        for sku in ("hailo8", "hailo10h"):
+            _skip_if_optional_unresolved(sku)
+            panel = build_layer7_external_memory_panel(sku)
+            joined = " ".join(panel.notes).lower()
+            assert "on-chip" in joined or "sram" in joined
+
+    def test_unknown_sku_returns_unpopulated(self):
+        panel = build_layer7_external_memory_panel("definitely_not_a_sku")
+        assert panel.status == "not_populated"
+
+
+class TestCrossSKUChart:
+    def test_chart_includes_required_skus(self):
+        chart = cross_sku_layer7_chart(REQUIRED_SKUS)
+        for sku in REQUIRED_SKUS:
+            assert sku in chart.memory_technology
+            assert sku in chart.peak_bandwidth_gbps
+            assert sku in chart.read_energy_pj
+            assert sku in chart.write_energy_pj
+
+    def test_lpddr5_cheaper_than_ddr5(self):
+        """The motivation chart: mobile / on-package LPDDR5 should
+        cost less per byte than desktop DDR5 even though both are
+        DDR-class JEDEC standards."""
+        chart = cross_sku_layer7_chart(["intel_core_i7_12700k",
+                                         "jetson_orin_agx_64gb"])
+        assert (chart.read_energy_pj["jetson_orin_agx_64gb"]
+                < chart.read_energy_pj["intel_core_i7_12700k"])
+
+    def test_kpu_t256_highest_bandwidth(self):
+        """T256 is the high-end KPU SKU; should top the BW chart
+        in this catalog."""
+        chart = cross_sku_layer7_chart(REQUIRED_SKUS)
+        winner = max(chart.peak_bandwidth_gbps,
+                     key=chart.peak_bandwidth_gbps.get)
+        assert winner == "kpu_t256"
+
+    def test_asymmetry_consistent_with_per_sku(self):
+        """Chart's W/R asymmetry must equal write/read ratio."""
+        chart = cross_sku_layer7_chart(REQUIRED_SKUS)
+        for sku in REQUIRED_SKUS:
+            expected = chart.write_energy_pj[sku] / chart.read_energy_pj[sku]
+            assert abs(chart.asymmetry[sku] - expected) < 1e-9
+
+    def test_provenance_all_theoretical(self):
+        chart = cross_sku_layer7_chart(REQUIRED_SKUS)
+        expected = ConfidenceLevel.THEORETICAL.value.upper()
+        assert all(p == expected for p in chart.provenance.values())
+
+
+class TestPlausibility:
+    """Energy ranges sanity check against the M7 issue's motivation."""
+
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_read_energy_in_plausible_range(self, sku):
+        """Modern DRAM read energy: 5 - 35 pJ/B. HBM at the low end,
+        legacy desktop DDR4/5 at the high end."""
+        m = resolve_sku_resource_model(sku)
+        assert 5.0 <= m.memory_read_energy_per_byte_pj <= 35.0
+
+    @pytest.mark.parametrize("sku", REQUIRED_SKUS)
+    def test_bandwidth_in_plausible_range(self, sku):
+        """Bandwidth across the catalog: 1 - 1024 GB/s."""
+        m = resolve_sku_resource_model(sku)
+        bw_gbs = m.peak_bandwidth / 1e9
+        assert 1.0 <= bw_gbs <= 1024.0


### PR DESCRIPTION
## Summary
- Populate Layer 7 (external memory) panel for all 9 target SKUs.
- Add `memory_technology`, `memory_read_energy_per_byte_pj`, `memory_write_energy_per_byte_pj` fields on `HardwareResourceModel`.
- Add `memory_access_pattern_multiplier` dict (sequential / strided / random) on both energy models.
- Cross-SKU comparison page gains a Layer 7 technology + bandwidth + pJ/byte table.
- **This completes the M1-M7 layer-population sequence.**

## Why
External-memory coefficients are the largest contributor to memory-bound workload energy. The cross-SKU pJ/byte comparison across DDR5 / LPDDR5 / LPDDR4 is the visually striking chart for the M8 engineering deck.

## Per-SKU memory classification

| SKU | Memory | Peak BW | R / W (pJ/B) |
|---|---|---|---|
| Intel i7-12700K | DDR5 | 76.8 GB/s | 25.0 / 30.0 |
| Ryzen 9 8945HS | LPDDR5x | 89.6 GB/s | 18.0 / 22.0 |
| Jetson Orin AGX | LPDDR5 | 204.8 GB/s | 15.0 / 18.0 |
| KPU T64 | LPDDR5 | 64.0 GB/s | 12.0 / 14.4 |
| KPU T128 | LPDDR5 | 96.0 GB/s | 12.0 / 14.4 |
| KPU T256 | LPDDR5 | 256.0 GB/s | 11.0 / 13.2 |
| Coral Edge TPU | LPDDR4 | 4.0 GB/s | 20.0 / 24.0 |
| Hailo-8 | LPDDR4 (host) + on-chip SRAM | 200 GB/s | 22.0 / 27.0 |
| Hailo-10H | LPDDR5 (host) + on-chip SRAM | 40 GB/s | 15.0 / 18.0 |

Hailo SKUs are honestly tagged: deployments load weights from host DRAM at initialization and serve steady-state inference from on-chip SRAM. The Layer 7 numbers describe the cold-start path; the panel note calls this out.

## Design choices

- **Asymmetric R/W energy** (~1.2x ratio) reflects DRAM precharge tail. Test asserts `1.0 <= ratio <= 1.5` for every SKU.
- **Access-pattern multipliers** are panel/documentation-only at M7 — they aren't yet plumbed into the energy formulas. Sequential is the baseline (1.0); random pays the full row-activation per request (2.0).
- **Hailo annotation** in the technology string ("LPDDR4 (host) + on-chip SRAM (steady-state)") avoids the silent phantom-DRAM numbers that would mislead.

## Test results

| Suite | Result |
|---|---|
| `tests/reporting/test_layer7_external_memory_panel.py` | **95 passed** |
| Full unit suite (`tests/`) | 1409 passed, 7 skipped, 1 xfailed |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Inspect `compare.html` for the Layer 7 table (memory technology, R/W asymmetry)
- [x] When CI is green: `gh pr ready <#>`

Resolves #33

Generated with [Claude Code](https://claude.com/claude-code)