### PR TITLE
feat(microarch): Path A measurement-validation panel

### DIFF
--- a/cli/microarch_validation_report.py
+++ b/cli/microarch_validation_report.py
@@ -77,6 +77,7 @@ from graphs.reporting.layer_panels import (  # noqa: E402
     build_layer5_l3_cache_panel,
     build_layer6_soc_fabric_panel,
     build_layer7_external_memory_panel,
+    build_validation_panel,
 )
 
 
@@ -108,7 +109,10 @@ SKU_ARCHETYPE = {
 }
 
 
-def build_empty_report_for(sku: str) -> MicroarchReport:
+def build_empty_report_for(
+    sku: str,
+    with_validation: bool = False,
+) -> MicroarchReport:
     report = empty_report(sku=sku, display_name=sku)
     report.archetype = SKU_ARCHETYPE.get(sku, "")
     _populate_layer1_alu(report)
@@ -118,6 +122,8 @@ def build_empty_report_for(sku: str) -> MicroarchReport:
     _populate_layer5_l3_cache(report)
     _populate_layer6_soc_fabric(report)
     _populate_layer7_external_memory(report)
+    if with_validation:
+        _populate_validation(report)
     return report
 
 
@@ -179,6 +185,18 @@ def _populate_layer7_external_memory(report: MicroarchReport) -> None:
     """Replace the Layer 7 (external memory) panel in-place."""
     panel = build_layer7_external_memory_panel(report.sku)
     _replace_layer_panel(report, LayerTag.EXTERNAL_MEMORY, panel)
+
+
+def _populate_validation(report: MicroarchReport) -> None:
+    """Append the Path A measurement-validation panel.
+
+    The validation panel uses ``LayerTag.COMPOSITE`` and is appended
+    after the seven layer panels (rather than replacing one of them)
+    so the seven-layer layout stays intact while the validation
+    summary surfaces alongside.
+    """
+    panel = build_validation_panel(report.sku)
+    report.layers.append(panel)
 
 
 def write_json_bundle(reports: List[MicroarchReport], out_dir: Path) -> List[Path]:
@@ -409,6 +427,15 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
               "Default: all."),
     )
     p.add_argument(
+        "--with-validation",
+        action="store_true",
+        help=("Path A: append a measurement-validation panel that "
+              "compares M1-M7 analytical predictions against measured "
+              "model-level latencies in calibration_data/. Adds ~60 s "
+              "per validated SKU because each measurement triggers "
+              "a UnifiedAnalyzer prediction."),
+    )
+    p.add_argument(
         "--serve",
         action="store_true",
         help="Reserved for future use (serve HTML over http.server).",
@@ -426,7 +453,10 @@ def main(argv: List[str]) -> int:
     out_dir = Path(args.output).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    reports = [build_empty_report_for(sku) for sku in args.hardware]
+    reports = [
+        build_empty_report_for(sku, with_validation=args.with_validation)
+        for sku in args.hardware
+    ]
 
     produced: List[Path] = []
     fmt = args.format

--- a/cli/microarch_validation_report.py
+++ b/cli/microarch_validation_report.py
@@ -194,9 +194,20 @@ def _populate_validation(report: MicroarchReport) -> None:
     after the seven layer panels (rather than replacing one of them)
     so the seven-layer layout stays intact while the validation
     summary surfaces alongside.
+
+    When the validation panel promotes the SKU's confidence to
+    ``interpolated`` (median MAPE within tolerance), propagate that
+    upward to ``report.overall_confidence`` so the per-SKU page
+    header and the cross-SKU summary table both reflect the
+    promoted state. When validation can't promote (no measurement
+    data, or measured MAPE exceeded tolerance), leave the layer-
+    level THEORETICAL value the per-layer hooks already set.
     """
     panel = build_validation_panel(report.sku)
     report.layers.append(panel)
+    if (panel.status == "interpolated"
+            and report.overall_confidence == "THEORETICAL"):
+        report.overall_confidence = "INTERPOLATED"
 
 
 def write_json_bundle(reports: List[MicroarchReport], out_dir: Path) -> List[Path]:

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -897,17 +897,6 @@ class HardwareResourceModel:
     memory_read_energy_per_byte_pj: Optional[float] = None
     memory_write_energy_per_byte_pj: Optional[float] = None
 
-    # Path A measurement validation: per-(model, precision) MAPE
-    # values from the calibration_data measurement set. Populated by
-    # ``graphs.reporting.validation.validate_sku``; left empty for
-    # SKUs without measurement data. Each key is a string of the
-    # form ``"<model>:<precision>"`` (e.g., ``"resnet18:fp32"``);
-    # each value is the MAPE percent (predicted vs measured latency).
-    # Used to drive an aggregate-confidence promotion from
-    # THEORETICAL -> INTERPOLATED at the SKU level when the median
-    # MAPE is within tolerance.
-    validation_results: Dict[str, float] = field(default_factory=dict)
-
     # Provenance of individual resource-model fields.
     # Maps field name (e.g., "peak_bandwidth", "energy_per_flop_fp32") to
     # the EstimationConfidence that describes where that value came from.

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -897,6 +897,17 @@ class HardwareResourceModel:
     memory_read_energy_per_byte_pj: Optional[float] = None
     memory_write_energy_per_byte_pj: Optional[float] = None
 
+    # Path A measurement validation: per-(model, precision) MAPE
+    # values from the calibration_data measurement set. Populated by
+    # ``graphs.reporting.validation.validate_sku``; left empty for
+    # SKUs without measurement data. Each key is a string of the
+    # form ``"<model>:<precision>"`` (e.g., ``"resnet18:fp32"``);
+    # each value is the MAPE percent (predicted vs measured latency).
+    # Used to drive an aggregate-confidence promotion from
+    # THEORETICAL -> INTERPOLATED at the SKU level when the median
+    # MAPE is within tolerance.
+    validation_results: Dict[str, float] = field(default_factory=dict)
+
     # Provenance of individual resource-model fields.
     # Maps field name (e.g., "peak_bandwidth", "energy_per_flop_fp32") to
     # the EstimationConfidence that describes where that value came from.

--- a/src/graphs/reporting/layer_panels/__init__.py
+++ b/src/graphs/reporting/layer_panels/__init__.py
@@ -50,6 +50,12 @@ from .layer7_external_memory import (
     cross_sku_layer7_chart,
     CrossSKULayer7Chart,
 )
+from .validation_panel import (
+    build_validation_panel,
+    cross_sku_validation_chart,
+    CrossSKUValidationChart,
+    clear_validation_cache,
+)
 
 __all__ = [
     "build_layer1_panel",
@@ -80,4 +86,8 @@ __all__ = [
     "build_layer7_panels_for_skus",
     "cross_sku_layer7_chart",
     "CrossSKULayer7Chart",
+    "build_validation_panel",
+    "cross_sku_validation_chart",
+    "CrossSKUValidationChart",
+    "clear_validation_cache",
 ]

--- a/src/graphs/reporting/layer_panels/validation_panel.py
+++ b/src/graphs/reporting/layer_panels/validation_panel.py
@@ -73,10 +73,15 @@ def build_validation_panel(
     title = "Validation: predicted vs measured"
     model = resolve_sku_resource_model(sku_id)
     if model is None:
+        # Use ``theoretical`` here rather than ``not_populated``: the
+        # generic renderer collapses every ``not_populated`` panel to
+        # a "NOT YET POPULATED" placeholder and drops the custom
+        # summary / notes. A theoretical-tagged panel preserves the
+        # explanatory text we want the reader to see.
         return LayerPanel(
             layer=LayerTag.COMPOSITE,
             title=title,
-            status="not_populated",
+            status="theoretical",
             summary=f"Resource model unavailable for {sku_id}.",
         )
 
@@ -85,7 +90,7 @@ def build_validation_panel(
         return LayerPanel(
             layer=LayerTag.COMPOSITE,
             title=title,
-            status="not_populated",
+            status="theoretical",
             summary=(
                 f"No measurement data registered for {sku_id}; the "
                 "SKU's aggregate confidence stays at THEORETICAL "
@@ -104,7 +109,7 @@ def build_validation_panel(
         return LayerPanel(
             layer=LayerTag.COMPOSITE,
             title=title,
-            status="not_populated",
+            status="theoretical",
             summary=(
                 f"Calibration data registered for {sku_id} but no "
                 "measurement files matched the available models / "
@@ -112,13 +117,13 @@ def build_validation_panel(
             ),
         )
 
-    # Side-effect: write the per-result MAPE values into the model's
-    # validation_results dict (keyed by "<model>:<precision>") so the
-    # cross-SKU comparison and JSON export can read them out.
-    model.validation_results.update({
-        f"{r.measurement.model}:{r.measurement.precision}": r.mape_pct
-        for r in summary_obj.results
-    })
+    # The per-result MAPE values are surfaced through the panel's
+    # own metrics dict (below) which is what flows into the JSON
+    # export. We deliberately avoid mutating ``model`` here -- since
+    # ``resolve_sku_resource_model`` returns a fresh instance each
+    # call, mutations on it would not survive a second resolution.
+    # Downstream consumers should read from ``report.layers[i]
+    # .metrics`` instead.
 
     metrics: Dict[str, Dict] = {
         "Models validated": {

--- a/src/graphs/reporting/layer_panels/validation_panel.py
+++ b/src/graphs/reporting/layer_panels/validation_panel.py
@@ -1,0 +1,241 @@
+"""
+Path A: end-to-end measurement validation panel.
+
+Builds a ``LayerTag.COMPOSITE``-tagged panel that surfaces
+predicted-vs-measured MAPE per (model, precision) tuple for each
+SKU that has measurement data. SKUs without measurements render
+"No measurement data; SKU stays at THEORETICAL aggregate" -- not a
+crash, not an empty section.
+
+Promotion semantics:
+- ``median_mape_pct <= 30%`` -> aggregate confidence promotes from
+  THEORETICAL -> INTERPOLATED (panel badge becomes "interpolated")
+- ``median_mape_pct >  30%`` -> SKU stays THEORETICAL with the
+  numeric MAPE surfaced so a reader can judge the drift
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from graphs.benchmarks.schema import LayerTag
+from graphs.reporting.microarch_schema import LayerPanel
+from graphs.reporting.layer_panels.layer1_alu import resolve_sku_resource_model
+from graphs.reporting.validation import (
+    SKUValidationSummary,
+    sku_id_to_calibration_dir,
+    validate_sku,
+)
+
+
+@dataclass
+class _CachedValidation:
+    """Module-level cache: validation results are expensive to
+    compute (each prediction calls UnifiedAnalyzer / FX-traces a
+    PyTorch model). Hold a single in-process cache keyed by SKU id."""
+    cache: Dict[str, SKUValidationSummary] = field(default_factory=dict)
+
+
+_CACHE = _CachedValidation()
+
+
+def _validate_or_cached(sku_id: str) -> Optional[SKUValidationSummary]:
+    """Run ``validate_sku`` once per SKU id within a process; cache
+    the result. Returns None for SKUs without measurement data so
+    the caller can render the empty state without paying for an
+    UnifiedAnalyzer import."""
+    if sku_id_to_calibration_dir(sku_id) is None:
+        return None
+    if sku_id in _CACHE.cache:
+        return _CACHE.cache[sku_id]
+    summary = validate_sku(sku_id)
+    _CACHE.cache[sku_id] = summary
+    return summary
+
+
+def clear_validation_cache() -> None:
+    """Test helper: drop the cache between scenarios."""
+    _CACHE.cache.clear()
+
+
+# --------------------------------------------------------------------
+# Panel construction
+# --------------------------------------------------------------------
+
+def build_validation_panel(
+    sku_id: str,
+) -> LayerPanel:
+    """Build the Path A validation panel for one SKU.
+
+    Tagged ``LayerTag.COMPOSITE`` so it renders alongside the seven
+    layer panels without expanding the LayerTag enum.
+    """
+    title = "Validation: predicted vs measured"
+    model = resolve_sku_resource_model(sku_id)
+    if model is None:
+        return LayerPanel(
+            layer=LayerTag.COMPOSITE,
+            title=title,
+            status="not_populated",
+            summary=f"Resource model unavailable for {sku_id}.",
+        )
+
+    summary_obj = _validate_or_cached(sku_id)
+    if summary_obj is None:
+        return LayerPanel(
+            layer=LayerTag.COMPOSITE,
+            title=title,
+            status="not_populated",
+            summary=(
+                f"No measurement data registered for {sku_id}; the "
+                "SKU's aggregate confidence stays at THEORETICAL "
+                "until a calibration campaign lands."
+            ),
+            notes=[
+                "Path A validates the M1-M7 analytical chain end-to-end "
+                "against per-model latency measurements in "
+                "calibration_data/. Add an entry to "
+                "graphs.reporting.validation.sku_id_resolution to "
+                "register measurement data for additional SKUs."
+            ],
+        )
+
+    if summary_obj.n_results == 0:
+        return LayerPanel(
+            layer=LayerTag.COMPOSITE,
+            title=title,
+            status="not_populated",
+            summary=(
+                f"Calibration data registered for {sku_id} but no "
+                "measurement files matched the available models / "
+                "precisions; check calibration_data/ contents."
+            ),
+        )
+
+    # Side-effect: write the per-result MAPE values into the model's
+    # validation_results dict (keyed by "<model>:<precision>") so the
+    # cross-SKU comparison and JSON export can read them out.
+    model.validation_results.update({
+        f"{r.measurement.model}:{r.measurement.precision}": r.mape_pct
+        for r in summary_obj.results
+    })
+
+    metrics: Dict[str, Dict] = {
+        "Models validated": {
+            "value": str(summary_obj.n_results),
+            "unit":  "",
+            "provenance": "n/a",
+        },
+        "Median MAPE": {
+            "value": f"{summary_obj.median_mape_pct:.1f}",
+            "unit":  "%",
+            "provenance": "CALIBRATED",
+        },
+        "Mean MAPE": {
+            "value": f"{summary_obj.mean_mape_pct:.1f}",
+            "unit":  "%",
+            "provenance": "CALIBRATED",
+        },
+        "Within tolerance": {
+            "value": f"{summary_obj.n_within_tolerance}/{summary_obj.n_results}",
+            "unit":  "",
+            "provenance": "n/a",
+        },
+    }
+
+    # Top-3 best and top-3 worst per-model entries for quick scanning
+    sorted_results = sorted(summary_obj.results, key=lambda r: r.mape_pct)
+    for r in sorted_results[:3]:
+        key = f"Best ({r.measurement.model}:{r.measurement.precision})"
+        metrics[key] = {
+            "value": f"{r.mape_pct:.1f}",
+            "unit":  "% MAPE",
+            "provenance": "CALIBRATED",
+        }
+    if len(sorted_results) >= 4:
+        for r in sorted_results[-3:]:
+            key = f"Worst ({r.measurement.model}:{r.measurement.precision})"
+            metrics[key] = {
+                "value": f"{r.mape_pct:.1f}",
+                "unit":  "% MAPE",
+                "provenance": "CALIBRATED",
+            }
+
+    if summary_obj.overall_within_tolerance:
+        status = "interpolated"
+        narrative = (
+            f"End-to-end validation: median MAPE "
+            f"{summary_obj.median_mape_pct:.1f}% across "
+            f"{summary_obj.n_results} models -- within the +/-30% "
+            "M1 tolerance. SKU aggregate confidence promotes from "
+            "THEORETICAL to INTERPOLATED."
+        )
+    else:
+        status = "theoretical"
+        narrative = (
+            f"End-to-end validation: median MAPE "
+            f"{summary_obj.median_mape_pct:.1f}% across "
+            f"{summary_obj.n_results} models -- exceeds the +/-30% "
+            "tolerance. The drift is reported per-model so a "
+            "downstream Path B microbenchmark campaign can target "
+            "the layers most responsible."
+        )
+
+    notes = [
+        narrative,
+        "Predicted latency is from the M1-M7 analytical chain via "
+        "UnifiedAnalyzer. Measured latency is from the per-model "
+        "files under calibration_data/.",
+    ]
+
+    return LayerPanel(
+        layer=LayerTag.COMPOSITE,
+        title=title,
+        status=status,
+        summary=(
+            f"Validated against {summary_obj.n_results} measured "
+            f"models for {sku_id}; "
+            f"median MAPE {summary_obj.median_mape_pct:.1f}%."
+        ),
+        metrics=metrics,
+        notes=notes,
+    )
+
+
+# --------------------------------------------------------------------
+# Cross-SKU summary
+# --------------------------------------------------------------------
+
+@dataclass
+class CrossSKUValidationChart:
+    skus: List[str]
+    n_results: Dict[str, int]
+    median_mape_pct: Dict[str, float]
+    within_tolerance: Dict[str, bool]
+
+
+def cross_sku_validation_chart(
+    sku_ids: List[str],
+) -> CrossSKUValidationChart:
+    chart = CrossSKUValidationChart(
+        skus=list(sku_ids),
+        n_results={},
+        median_mape_pct={},
+        within_tolerance={},
+    )
+    for sku in sku_ids:
+        summary_obj = _validate_or_cached(sku)
+        if summary_obj is None or summary_obj.n_results == 0:
+            continue
+        chart.n_results[sku] = summary_obj.n_results
+        chart.median_mape_pct[sku] = summary_obj.median_mape_pct
+        chart.within_tolerance[sku] = summary_obj.overall_within_tolerance
+    return chart
+
+
+__all__ = [
+    "build_validation_panel",
+    "cross_sku_validation_chart",
+    "CrossSKUValidationChart",
+    "clear_validation_cache",
+]

--- a/src/graphs/reporting/microarch_html_template.py
+++ b/src/graphs/reporting/microarch_html_template.py
@@ -865,6 +865,82 @@ def _render_layer7_cross_sku_table(reports: List[MicroarchReport]) -> str:
 """
 
 
+def _render_validation_cross_sku_table(
+    reports: List[MicroarchReport],
+) -> str:
+    """
+    Render the Path A measurement-validation cross-SKU summary.
+
+    Only emits a table when at least one SKU in the report set has
+    validation results attached. Reads from the in-process cache the
+    validation panel populated, so this is a free read (no extra
+    UnifiedAnalyzer calls).
+    """
+    try:
+        from graphs.reporting.layer_panels import (
+            cross_sku_validation_chart,
+        )
+    except Exception:
+        return ""
+
+    sku_ids = [r.sku for r in reports]
+    chart = cross_sku_validation_chart(sku_ids)
+    if not chart.n_results:
+        return ""  # Nothing validated; suppress the section entirely
+
+    name_lookup = {r.sku: (r.display_name or r.sku) for r in reports}
+    only_validated = [s for s in chart.skus if s in chart.n_results]
+    header_cells = "".join(
+        f"<th>{html.escape(name_lookup.get(sku, sku))}</th>"
+        for sku in only_validated
+    )
+
+    def _row(label, getter, fmt):
+        cells = [f"<th>{html.escape(label)}</th>"]
+        for sku in only_validated:
+            v = getter(sku)
+            if v is None:
+                cells.append("<td>--</td>")
+            else:
+                cells.append(f"<td>{fmt(v)}</td>")
+        return "<tr>" + "".join(cells) + "</tr>"
+
+    rows = (
+        _row("Models validated",
+             lambda s: chart.n_results.get(s),
+             lambda v: str(v))
+        + _row("Median MAPE",
+               lambda s: chart.median_mape_pct.get(s),
+               lambda v: f"{v:.1f}%")
+    )
+    badge_cells = []
+    for sku in only_validated:
+        ok = chart.within_tolerance.get(sku, False)
+        cls = "interpolated" if ok else "theoretical"
+        label = "INTERPOLATED" if ok else "THEORETICAL"
+        badge_cells.append(
+            f'<td><span class="badge {cls}">{label}</span></td>'
+        )
+    rows += "<tr><th>Aggregate confidence</th>" + "".join(badge_cells) + "</tr>"
+
+    return f"""
+<section>
+  <h3>Path A: end-to-end measurement validation</h3>
+  <p class="meta">SKUs with measurement data in
+  <code>calibration_data/</code> have their M1-M7 analytical
+  predictions compared against measured per-model latency. Median
+  MAPE within +/-30% promotes the SKU's aggregate confidence from
+  THEORETICAL to INTERPOLATED. SKUs without measurements are
+  omitted from this table; their confidence stays at THEORETICAL
+  until a calibration campaign lands.</p>
+  <table class="validation-cross">
+    <thead><tr><th></th>{header_cells}</tr></thead>
+    <tbody>{rows}</tbody>
+  </table>
+</section>
+"""
+
+
 def render_comparison_page(
     reports: List[MicroarchReport],
     repo_root: Path,
@@ -881,6 +957,7 @@ def render_comparison_page(
       - Layer 5 L3-presence / coherence table (M5)
       - Layer 6 SoC fabric topology + hop coefficients (M6)
       - Layer 7 external-memory technology + bandwidth + pJ/B (M7)
+      - Path A measurement validation summary (when --with-validation)
 
     M8 adds the engineering-deck export.
     """
@@ -899,6 +976,7 @@ def render_comparison_page(
     layer5_section = _render_layer5_cross_sku_table(reports)
     layer6_section = _render_layer6_cross_sku_table(reports)
     layer7_section = _render_layer7_cross_sku_table(reports)
+    validation_section = _render_validation_cross_sku_table(reports)
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -937,6 +1015,7 @@ table.layer1-cross th:first-child, table.layer2-cross th:first-child, table.laye
   {layer5_section}
   {layer6_section}
   {layer7_section}
+  {validation_section}
 </main>
 {_render_brand_footer("microarch-model-delivery-plan.md")}
 </body>

--- a/src/graphs/reporting/microarch_html_template.py
+++ b/src/graphs/reporting/microarch_html_template.py
@@ -871,11 +871,25 @@ def _render_validation_cross_sku_table(
     """
     Render the Path A measurement-validation cross-SKU summary.
 
-    Only emits a table when at least one SKU in the report set has
-    validation results attached. Reads from the in-process cache the
-    validation panel populated, so this is a free read (no extra
-    UnifiedAnalyzer calls).
+    Only emits a table when at least one report in the set has the
+    validation panel attached -- i.e., the CLI was run with
+    ``--with-validation`` and the validation panel got appended to
+    ``report.layers``. Without this gate the cross-SKU helper would
+    invoke ``cross_sku_validation_chart()``, which runs the
+    expensive ``validate_sku()`` -> ``UnifiedAnalyzer`` path even
+    when validation was opt-out at the CLI level.
     """
+    # Detect the presence of the validation panel by tag rather than
+    # by index so the schema-level layer ordering can change without
+    # breaking the gate.
+    from graphs.benchmarks.schema import LayerTag
+    has_any_validation_panel = any(
+        any(layer.layer is LayerTag.COMPOSITE for layer in r.layers)
+        for r in reports
+    )
+    if not has_any_validation_panel:
+        return ""
+
     try:
         from graphs.reporting.layer_panels import (
             cross_sku_validation_chart,
@@ -908,7 +922,7 @@ def _render_validation_cross_sku_table(
     rows = (
         _row("Models validated",
              lambda s: chart.n_results.get(s),
-             lambda v: str(v))
+             str)
         + _row("Median MAPE",
                lambda s: chart.median_mape_pct.get(s),
                lambda v: f"{v:.1f}%")

--- a/src/graphs/reporting/validation/__init__.py
+++ b/src/graphs/reporting/validation/__init__.py
@@ -11,7 +11,8 @@ This package does not modify the analytical model; it only validates
 its outputs against measured ground truth.
 """
 from .measurement_comparison import (
-    MeasurementRecord,
+    MeasurementSummary,
+    MeasurementRecord,  # deprecated alias for back-compat
     PredictionRecord,
     ValidationResult,
     SKUValidationSummary,
@@ -28,7 +29,8 @@ from .sku_id_resolution import (
 )
 
 __all__ = [
-    "MeasurementRecord",
+    "MeasurementSummary",
+    "MeasurementRecord",  # deprecated alias for back-compat
     "PredictionRecord",
     "ValidationResult",
     "SKUValidationSummary",

--- a/src/graphs/reporting/validation/__init__.py
+++ b/src/graphs/reporting/validation/__init__.py
@@ -1,0 +1,43 @@
+"""
+Measurement-based validation for the M1-M7 micro-arch model.
+
+Path A of the calibration plan: load existing per-model measurements
+from ``calibration_data/`` and compare against the M1-M7 analytical
+chain. Surfaces MAPE per (SKU, model, precision) tuple and promotes
+the SKU's aggregate confidence from THEORETICAL -> INTERPOLATED when
+end-to-end agreement is within tolerance.
+
+This package does not modify the analytical model; it only validates
+its outputs against measured ground truth.
+"""
+from .measurement_comparison import (
+    MeasurementRecord,
+    PredictionRecord,
+    ValidationResult,
+    SKUValidationSummary,
+    load_measurement,
+    list_available_measurements,
+    predict_via_unified_analyzer,
+    validate_sku,
+    compute_mape,
+)
+from .sku_id_resolution import (
+    sku_id_to_calibration_dir,
+    sku_id_to_mapper_name,
+    sku_id_to_thermal_profile,
+)
+
+__all__ = [
+    "MeasurementRecord",
+    "PredictionRecord",
+    "ValidationResult",
+    "SKUValidationSummary",
+    "load_measurement",
+    "list_available_measurements",
+    "predict_via_unified_analyzer",
+    "validate_sku",
+    "compute_mape",
+    "sku_id_to_calibration_dir",
+    "sku_id_to_mapper_name",
+    "sku_id_to_thermal_profile",
+]

--- a/src/graphs/reporting/validation/measurement_comparison.py
+++ b/src/graphs/reporting/validation/measurement_comparison.py
@@ -1,10 +1,13 @@
 """
 Measurement-vs-prediction comparison for the M1-M7 micro-arch model.
 
-Loads per-model latency measurements from ``calibration_data/`` and
-runs the M1-M7 analytical chain via ``UnifiedAnalyzer`` for the same
-(SKU, model, precision, batch_size) tuple. Reports MAPE per
-combination and aggregates across a SKU's measurement set.
+Loads per-model latency measurements via ``GroundTruthLoader`` (the
+canonical entry point into ``calibration_data/`` -- per the
+data-hygiene rules, no module outside the loader itself reads the
+measurement JSON files directly) and runs the M1-M7 analytical
+chain via ``UnifiedAnalyzer`` for the same (SKU, model, precision,
+batch_size) tuple. Reports MAPE per combination and aggregates
+across a SKU's measurement set.
 
 Energy comparisons are intentionally out of scope at this stage --
 the calibration data we have is latency-only at the model level.
@@ -13,11 +16,11 @@ Energy validation belongs to Path B (microbenchmark fitting).
 This module is deliberately import-light: ``UnifiedAnalyzer`` is
 loaded lazily inside ``predict_via_unified_analyzer`` so the panel
 builder can introspect available measurements without paying the
-PyTorch import cost.
+PyTorch import cost. ``GroundTruthLoader`` is also lazy-imported
+to keep the validation package usable in trimmed environments.
 """
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -29,9 +32,19 @@ from graphs.reporting.validation.sku_id_resolution import (
 )
 
 
-# Repository root, used to locate calibration_data/.
+# Repository root, used to construct relative source paths in records.
 _REPO_ROOT = Path(__file__).resolve().parents[4]
-_CALIBRATION_ROOT = _REPO_ROOT / "calibration_data"
+
+
+def _ground_truth_loader():
+    """Lazy import + construct a default GroundTruthLoader.
+
+    Centralises the data-hygiene contract: every measurement read in
+    this module flows through this helper, so the
+    ci/check_no_legacy_json_reads.sh sweep stays clean.
+    """
+    from graphs.calibration.ground_truth import GroundTruthLoader
+    return GroundTruthLoader()
 
 
 # --------------------------------------------------------------------
@@ -39,15 +52,24 @@ _CALIBRATION_ROOT = _REPO_ROOT / "calibration_data"
 # --------------------------------------------------------------------
 
 @dataclass
-class MeasurementRecord:
-    """A single per-model measurement loaded from calibration_data/."""
+class MeasurementSummary:
+    """A one-line summary of a measurement loaded via GroundTruthLoader.
+
+    Distinct from ``graphs.calibration.ground_truth.MeasurementRecord``,
+    which carries the full per-subgraph payload. The validation panel
+    only needs the top-level latency + identification.
+    """
     sku_id: str
     model: str
     precision: str               # "fp32" / "fp16" / "bf16"
     batch_size: int
     measured_latency_ms: float
     measurement_date: str = ""
-    source_path: str = ""
+    source_path: str = ""        # relative to repo root, for display
+
+
+# Backwards-compat alias so tests and callers using the old name keep working.
+MeasurementRecord = MeasurementSummary
 
 
 @dataclass
@@ -65,7 +87,7 @@ class PredictionRecord:
 @dataclass
 class ValidationResult:
     """One (measurement, prediction) pair plus derived metrics."""
-    measurement: MeasurementRecord
+    measurement: MeasurementSummary
     prediction: PredictionRecord
     mape_pct: float              # |predicted - measured| / measured * 100
     ratio: float                 # predicted / measured
@@ -123,38 +145,60 @@ def load_measurement(
     model: str,
     precision: str = "fp32",
     batch_size: int = 1,
-) -> Optional[MeasurementRecord]:
-    """Load one measurement file. Returns None when missing.
+) -> Optional[MeasurementSummary]:
+    """Load one measurement summary via ``GroundTruthLoader``.
 
-    Looks in: ``<repo>/calibration_data/<dir>/measurements/<precision>/<model>_b<batch>.json``
+    Returns None when the SKU has no calibration_data registration
+    or when the requested (model, precision, batch) combination is
+    not present. All filesystem access flows through
+    ``GroundTruthLoader`` per the data-hygiene contract.
     """
     calib_dir = sku_id_to_calibration_dir(sku_id)
     if calib_dir is None:
         return None
 
-    base = _CALIBRATION_ROOT / calib_dir / "measurements" / precision.lower()
-    path = base / f"{model}_b{batch_size}.json"
-    if not path.exists():
-        return None
-
     try:
-        data = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
+        loader = _ground_truth_loader()
+        record = loader.load(
+            hardware_id=calib_dir,
+            model=model,
+            precision=precision,
+            batch_size=batch_size,
+        )
+    except FileNotFoundError:
+        return None
+    except Exception:
+        # Loader raised on malformed file or unreachable schema --
+        # treat as "no usable measurement" rather than crashing the
+        # panel build.
         return None
 
-    summary = data.get("model_summary") or {}
-    latency_ms = summary.get("total_latency_ms")
-    if latency_ms is None:
+    summary = record.model_summary
+    if summary is None or not getattr(summary, "total_latency_ms", 0):
         return None
 
-    return MeasurementRecord(
+    # Build the relative source path for display.
+    cfg_path: Optional[Path] = None
+    for cfg in loader.list_configurations(calib_dir):
+        if (cfg["model"] == record.model
+                and cfg["precision"].lower() == record.precision.lower()
+                and cfg["batch_size"] == record.batch_size):
+            cfg_path = (
+                loader.data_dir / calib_dir / cfg["file"]
+            )
+            break
+    rel_source = (
+        str(cfg_path.relative_to(_REPO_ROOT)) if cfg_path else ""
+    )
+
+    return MeasurementSummary(
         sku_id=sku_id,
-        model=data.get("model", model),
-        precision=data.get("precision", precision).lower(),
-        batch_size=int(data.get("batch_size", batch_size)),
-        measured_latency_ms=float(latency_ms),
-        measurement_date=str(data.get("measurement_date", "")),
-        source_path=str(path.relative_to(_REPO_ROOT)),
+        model=record.model,
+        precision=record.precision.lower(),
+        batch_size=record.batch_size,
+        measured_latency_ms=float(summary.total_latency_ms),
+        measurement_date=str(record.measurement_date or ""),
+        source_path=rel_source,
     )
 
 
@@ -163,25 +207,19 @@ def list_available_measurements(
     precision: str = "fp32",
 ) -> List[str]:
     """Return the list of model names with measurement files for the
-    given (SKU, precision). Sorted; empty when no data."""
+    given (SKU, precision). Sorted; empty when no data.
+
+    Delegates to ``GroundTruthLoader.list_models`` per the
+    data-hygiene contract.
+    """
     calib_dir = sku_id_to_calibration_dir(sku_id)
     if calib_dir is None:
         return []
-
-    base = _CALIBRATION_ROOT / calib_dir / "measurements" / precision.lower()
-    if not base.is_dir():
+    try:
+        loader = _ground_truth_loader()
+        return loader.list_models(calib_dir, precision=precision)
+    except Exception:
         return []
-
-    models = set()
-    for f in base.glob("*_b*.json"):
-        # Filename: ``<model>_b<batch>.json``; strip the ``_b<n>`` tail
-        stem = f.stem
-        # Find the last "_b" followed by digits
-        idx = stem.rfind("_b")
-        if idx <= 0 or not stem[idx + 2:].isdigit():
-            continue
-        models.add(stem[:idx])
-    return sorted(models)
 
 
 # --------------------------------------------------------------------
@@ -328,7 +366,8 @@ def validate_sku(
 
 
 __all__ = [
-    "MeasurementRecord",
+    "MeasurementSummary",
+    "MeasurementRecord",  # deprecated alias for back-compat
     "PredictionRecord",
     "ValidationResult",
     "SKUValidationSummary",

--- a/src/graphs/reporting/validation/measurement_comparison.py
+++ b/src/graphs/reporting/validation/measurement_comparison.py
@@ -1,0 +1,340 @@
+"""
+Measurement-vs-prediction comparison for the M1-M7 micro-arch model.
+
+Loads per-model latency measurements from ``calibration_data/`` and
+runs the M1-M7 analytical chain via ``UnifiedAnalyzer`` for the same
+(SKU, model, precision, batch_size) tuple. Reports MAPE per
+combination and aggregates across a SKU's measurement set.
+
+Energy comparisons are intentionally out of scope at this stage --
+the calibration data we have is latency-only at the model level.
+Energy validation belongs to Path B (microbenchmark fitting).
+
+This module is deliberately import-light: ``UnifiedAnalyzer`` is
+loaded lazily inside ``predict_via_unified_analyzer`` so the panel
+builder can introspect available measurements without paying the
+PyTorch import cost.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from graphs.reporting.validation.sku_id_resolution import (
+    sku_id_to_calibration_dir,
+    sku_id_to_mapper_name,
+    sku_id_to_thermal_profile,
+)
+
+
+# Repository root, used to locate calibration_data/.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_CALIBRATION_ROOT = _REPO_ROOT / "calibration_data"
+
+
+# --------------------------------------------------------------------
+# Records
+# --------------------------------------------------------------------
+
+@dataclass
+class MeasurementRecord:
+    """A single per-model measurement loaded from calibration_data/."""
+    sku_id: str
+    model: str
+    precision: str               # "fp32" / "fp16" / "bf16"
+    batch_size: int
+    measured_latency_ms: float
+    measurement_date: str = ""
+    source_path: str = ""
+
+
+@dataclass
+class PredictionRecord:
+    """A single analytical prediction from UnifiedAnalyzer."""
+    sku_id: str
+    model: str
+    precision: str
+    batch_size: int
+    predicted_latency_ms: float
+    energy_mj: float = 0.0
+    error: str = ""              # populated when prediction failed
+
+
+@dataclass
+class ValidationResult:
+    """One (measurement, prediction) pair plus derived metrics."""
+    measurement: MeasurementRecord
+    prediction: PredictionRecord
+    mape_pct: float              # |predicted - measured| / measured * 100
+    ratio: float                 # predicted / measured
+
+    @property
+    def within_tolerance(self) -> bool:
+        """Default tolerance: 30% MAPE (matches the user-approved M1
+        precision target)."""
+        return self.mape_pct <= 30.0
+
+
+@dataclass
+class SKUValidationSummary:
+    """Aggregate over all (model, precision, batch) results for one SKU."""
+    sku_id: str
+    results: List[ValidationResult] = field(default_factory=list)
+
+    @property
+    def n_results(self) -> int:
+        return len(self.results)
+
+    @property
+    def mean_mape_pct(self) -> float:
+        if not self.results:
+            return 0.0
+        return sum(r.mape_pct for r in self.results) / len(self.results)
+
+    @property
+    def median_mape_pct(self) -> float:
+        if not self.results:
+            return 0.0
+        sorted_mapes = sorted(r.mape_pct for r in self.results)
+        n = len(sorted_mapes)
+        if n % 2 == 1:
+            return sorted_mapes[n // 2]
+        return 0.5 * (sorted_mapes[n // 2 - 1] + sorted_mapes[n // 2])
+
+    @property
+    def n_within_tolerance(self) -> int:
+        return sum(1 for r in self.results if r.within_tolerance)
+
+    @property
+    def overall_within_tolerance(self) -> bool:
+        """The SKU's whole validation set agrees to within 30% on the
+        median. Stricter than mean to resist outliers."""
+        return self.n_results > 0 and self.median_mape_pct <= 30.0
+
+
+# --------------------------------------------------------------------
+# Loading measurements
+# --------------------------------------------------------------------
+
+def load_measurement(
+    sku_id: str,
+    model: str,
+    precision: str = "fp32",
+    batch_size: int = 1,
+) -> Optional[MeasurementRecord]:
+    """Load one measurement file. Returns None when missing.
+
+    Looks in: ``<repo>/calibration_data/<dir>/measurements/<precision>/<model>_b<batch>.json``
+    """
+    calib_dir = sku_id_to_calibration_dir(sku_id)
+    if calib_dir is None:
+        return None
+
+    base = _CALIBRATION_ROOT / calib_dir / "measurements" / precision.lower()
+    path = base / f"{model}_b{batch_size}.json"
+    if not path.exists():
+        return None
+
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    summary = data.get("model_summary") or {}
+    latency_ms = summary.get("total_latency_ms")
+    if latency_ms is None:
+        return None
+
+    return MeasurementRecord(
+        sku_id=sku_id,
+        model=data.get("model", model),
+        precision=data.get("precision", precision).lower(),
+        batch_size=int(data.get("batch_size", batch_size)),
+        measured_latency_ms=float(latency_ms),
+        measurement_date=str(data.get("measurement_date", "")),
+        source_path=str(path.relative_to(_REPO_ROOT)),
+    )
+
+
+def list_available_measurements(
+    sku_id: str,
+    precision: str = "fp32",
+) -> List[str]:
+    """Return the list of model names with measurement files for the
+    given (SKU, precision). Sorted; empty when no data."""
+    calib_dir = sku_id_to_calibration_dir(sku_id)
+    if calib_dir is None:
+        return []
+
+    base = _CALIBRATION_ROOT / calib_dir / "measurements" / precision.lower()
+    if not base.is_dir():
+        return []
+
+    models = set()
+    for f in base.glob("*_b*.json"):
+        # Filename: ``<model>_b<batch>.json``; strip the ``_b<n>`` tail
+        stem = f.stem
+        # Find the last "_b" followed by digits
+        idx = stem.rfind("_b")
+        if idx <= 0 or not stem[idx + 2:].isdigit():
+            continue
+        models.add(stem[:idx])
+    return sorted(models)
+
+
+# --------------------------------------------------------------------
+# Predicting via UnifiedAnalyzer
+# --------------------------------------------------------------------
+
+def predict_via_unified_analyzer(
+    sku_id: str,
+    model: str,
+    precision: str = "fp32",
+    batch_size: int = 1,
+) -> PredictionRecord:
+    """Run UnifiedAnalyzer for the given combination and return a
+    PredictionRecord. Errors are captured in ``record.error`` so the
+    caller can render gracefully.
+
+    UnifiedAnalyzer is imported lazily here -- the import path pulls
+    in PyTorch, which is too expensive for panel-only code paths.
+    """
+    record = PredictionRecord(
+        sku_id=sku_id,
+        model=model,
+        precision=precision.lower(),
+        batch_size=batch_size,
+        predicted_latency_ms=0.0,
+    )
+
+    mapper_name = sku_id_to_mapper_name(sku_id)
+    if mapper_name is None:
+        record.error = (
+            f"No UnifiedAnalyzer mapper registered for SKU '{sku_id}'."
+        )
+        return record
+
+    try:
+        from graphs.estimation.unified_analyzer import UnifiedAnalyzer
+        from graphs.hardware.resource_model import Precision
+    except ImportError as exc:
+        record.error = f"UnifiedAnalyzer unavailable: {exc}"
+        return record
+
+    # Resolve precision to the enum
+    precision_map = {
+        "fp32": Precision.FP32,
+        "fp16": Precision.FP16,
+        "bf16": Precision.BF16,
+        "int8": Precision.INT8,
+    }
+    prec_enum = precision_map.get(precision.lower())
+    if prec_enum is None:
+        record.error = f"Unsupported precision '{precision}'."
+        return record
+
+    thermal = sku_id_to_thermal_profile(sku_id)
+
+    try:
+        ua = UnifiedAnalyzer(verbose=False)
+        result = ua.analyze_model(
+            model_name=model,
+            hardware_name=mapper_name,
+            batch_size=batch_size,
+            precision=prec_enum,
+            thermal_profile=thermal,
+        )
+    except Exception as exc:  # broad catch -- we surface the error string
+        record.error = f"{type(exc).__name__}: {exc}"
+        return record
+
+    record.predicted_latency_ms = float(result.total_latency_ms or 0.0)
+    record.energy_mj = float(result.energy_per_inference_mj or 0.0)
+    return record
+
+
+# --------------------------------------------------------------------
+# MAPE + per-SKU validation driver
+# --------------------------------------------------------------------
+
+def compute_mape(measured_ms: float, predicted_ms: float) -> float:
+    """Mean absolute percentage error for a single value pair."""
+    if measured_ms <= 0:
+        return float("inf")
+    return abs(predicted_ms - measured_ms) / measured_ms * 100.0
+
+
+def validate_sku(
+    sku_id: str,
+    precisions: Optional[List[str]] = None,
+    batch_size: int = 1,
+    models: Optional[List[str]] = None,
+) -> SKUValidationSummary:
+    """
+    Run the full measurement-vs-prediction comparison for one SKU.
+
+    Loads every available measurement under ``calibration_data/<dir>/
+    measurements/<prec>/`` (or restricts to ``models`` if given),
+    runs UnifiedAnalyzer for the same combination, and returns a
+    summary. Failed predictions are skipped but counted in
+    ``error_count`` (caller-side via len(measurements) - len(results)).
+    """
+    summary = SKUValidationSummary(sku_id=sku_id)
+    if precisions is None:
+        precisions = ["fp32", "fp16", "bf16"]
+
+    for precision in precisions:
+        candidates = (
+            models if models is not None
+            else list_available_measurements(sku_id, precision=precision)
+        )
+        for model in candidates:
+            measurement = load_measurement(
+                sku_id=sku_id,
+                model=model,
+                precision=precision,
+                batch_size=batch_size,
+            )
+            if measurement is None:
+                continue
+
+            prediction = predict_via_unified_analyzer(
+                sku_id=sku_id,
+                model=model,
+                precision=precision,
+                batch_size=batch_size,
+            )
+            if prediction.error or prediction.predicted_latency_ms <= 0:
+                continue
+
+            mape = compute_mape(
+                measurement.measured_latency_ms,
+                prediction.predicted_latency_ms,
+            )
+            ratio = (
+                prediction.predicted_latency_ms
+                / measurement.measured_latency_ms
+            )
+            summary.results.append(ValidationResult(
+                measurement=measurement,
+                prediction=prediction,
+                mape_pct=mape,
+                ratio=ratio,
+            ))
+
+    return summary
+
+
+__all__ = [
+    "MeasurementRecord",
+    "PredictionRecord",
+    "ValidationResult",
+    "SKUValidationSummary",
+    "load_measurement",
+    "list_available_measurements",
+    "predict_via_unified_analyzer",
+    "validate_sku",
+    "compute_mape",
+]

--- a/src/graphs/reporting/validation/measurement_comparison.py
+++ b/src/graphs/reporting/validation/measurement_comparison.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from graphs.reporting.validation.sku_id_resolution import (
     sku_id_to_calibration_dir,
@@ -345,6 +345,13 @@ def validate_sku(
                 batch_size=batch_size,
             )
             if prediction.error or prediction.predicted_latency_ms <= 0:
+                continue
+
+            # Skip pathological measurements where measured latency
+            # is zero / negative (malformed calibration data) -- the
+            # ratio computation would raise ZeroDivisionError and
+            # MAPE would already be inf, so the result has no signal.
+            if measurement.measured_latency_ms <= 0:
                 continue
 
             mape = compute_mape(

--- a/src/graphs/reporting/validation/sku_id_resolution.py
+++ b/src/graphs/reporting/validation/sku_id_resolution.py
@@ -1,0 +1,86 @@
+"""
+SKU id resolution for the validation pipeline.
+
+Three identifier spaces collide here:
+
+- **Microarch report SKU id** (``intel_core_i7_12700k``, ``kpu_t128``)
+  used by the M1-M7 panels and ``HardwareResourceModel`` factories.
+- **Calibration data directory name** (``intel_core_i7_12700k``,
+  ``jetson_orin_agx_30w``) under ``calibration_data/`` -- includes
+  thermal profile in the name for Jetson SKUs.
+- **UnifiedAnalyzer mapper name** (``i7-12700k``,
+  ``jetson-orin-agx-64gb``) used by ``UnifiedAnalyzer.analyze_model``.
+
+The three tables below resolve any one to the others. Missing
+entries return None, which the validation pipeline treats as
+"no measurement data for this SKU."
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+# Microarch SKU id -> calibration_data/<dir> name.
+# When a SKU has multiple thermal profiles in calibration_data
+# (Jetson at 15W / 30W / 50W / MAXN), pick the one that matches the
+# thermal_profile reported by the resource model factory.
+_SKU_TO_CALIBRATION_DIR = {
+    "intel_core_i7_12700k":  "intel_core_i7_12700k",
+    "ryzen_9_8945hs":        "ryzen_9_8945hs",
+    "jetson_orin_agx_64gb":  "jetson_orin_agx_30w",  # 30W matches M1-M7 baseline
+    # KPU / TPU / Hailo: no measurement data
+    "kpu_t64":               None,
+    "kpu_t128":              None,
+    "kpu_t256":              None,
+    "coral_edge_tpu":        None,
+    "hailo8":                None,
+    "hailo10h":              None,
+}
+
+
+# Microarch SKU id -> UnifiedAnalyzer mapper name.
+_SKU_TO_MAPPER_NAME = {
+    "intel_core_i7_12700k":  "i7-12700k",
+    "ryzen_9_8945hs":        "ryzen",
+    "jetson_orin_agx_64gb":  "jetson-orin-agx-64gb",
+    "kpu_t64":               "kpu-t64",
+    "kpu_t128":              None,                   # not in mapper registry
+    "kpu_t256":              "kpu-t256",
+    "coral_edge_tpu":        "coral-edge-tpu",
+    "hailo8":                "hailo-8",
+    "hailo10h":              "hailo-10h",
+}
+
+
+# For Jetson, the thermal_profile string passed to UnifiedAnalyzer.
+# Other SKUs default to None (use the resource model's default).
+_SKU_TO_THERMAL_PROFILE = {
+    "jetson_orin_agx_64gb":  "30W",
+}
+
+
+def sku_id_to_calibration_dir(sku_id: str) -> Optional[str]:
+    """Return the calibration_data subdirectory for a SKU, or None
+    when no measurement data is registered."""
+    return _SKU_TO_CALIBRATION_DIR.get(sku_id)
+
+
+def sku_id_to_mapper_name(sku_id: str) -> Optional[str]:
+    """Return the UnifiedAnalyzer mapper name for a SKU, or None when
+    the SKU is not in the mapper registry (used to detect SKUs we can
+    populate in M1-M7 but not yet drive end-to-end through
+    UnifiedAnalyzer)."""
+    return _SKU_TO_MAPPER_NAME.get(sku_id)
+
+
+def sku_id_to_thermal_profile(sku_id: str) -> Optional[str]:
+    """Return the thermal_profile string to pass to
+    UnifiedAnalyzer.analyze_model, or None to use the SKU default."""
+    return _SKU_TO_THERMAL_PROFILE.get(sku_id)
+
+
+__all__ = [
+    "sku_id_to_calibration_dir",
+    "sku_id_to_mapper_name",
+    "sku_id_to_thermal_profile",
+]

--- a/tests/reporting/test_measurement_validation.py
+++ b/tests/reporting/test_measurement_validation.py
@@ -1,0 +1,303 @@
+"""Tests for the Path A measurement-validation pipeline."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from graphs.benchmarks.schema import LayerTag
+from graphs.reporting.layer_panels import (
+    build_validation_panel,
+    cross_sku_validation_chart,
+)
+from graphs.reporting.layer_panels.validation_panel import (
+    clear_validation_cache,
+)
+from graphs.reporting.validation import (
+    MeasurementRecord,
+    PredictionRecord,
+    SKUValidationSummary,
+    ValidationResult,
+    compute_mape,
+    list_available_measurements,
+    load_measurement,
+    sku_id_to_calibration_dir,
+    sku_id_to_mapper_name,
+    sku_id_to_thermal_profile,
+)
+
+
+# --------------------------------------------------------------------
+# SKU id resolution
+# --------------------------------------------------------------------
+
+class TestSKUIdResolution:
+    def test_i7_resolves_to_calibration_dir(self):
+        assert sku_id_to_calibration_dir("intel_core_i7_12700k") == (
+            "intel_core_i7_12700k"
+        )
+
+    def test_orin_picks_30w_profile(self):
+        """Orin AGX has multiple thermal profiles in calibration_data;
+        the resolution table picks 30W to match the M1-M7 baseline."""
+        assert sku_id_to_calibration_dir("jetson_orin_agx_64gb") == (
+            "jetson_orin_agx_30w"
+        )
+
+    def test_kpu_skus_have_no_calibration(self):
+        for sku in ("kpu_t64", "kpu_t128", "kpu_t256"):
+            assert sku_id_to_calibration_dir(sku) is None
+
+    def test_orin_thermal_profile_passed_through(self):
+        assert sku_id_to_thermal_profile("jetson_orin_agx_64gb") == "30W"
+
+    def test_unknown_sku_returns_none_everywhere(self):
+        assert sku_id_to_calibration_dir("unknown") is None
+        assert sku_id_to_mapper_name("unknown") is None
+        assert sku_id_to_thermal_profile("unknown") is None
+
+
+# --------------------------------------------------------------------
+# MAPE
+# --------------------------------------------------------------------
+
+class TestMAPE:
+    def test_zero_when_perfect(self):
+        assert compute_mape(measured_ms=10.0, predicted_ms=10.0) == 0.0
+
+    def test_overestimate_and_underestimate_symmetric(self):
+        assert compute_mape(10.0, 12.0) == compute_mape(10.0, 8.0) == 20.0
+
+    def test_zero_measured_returns_inf(self):
+        # No predicted vs measured agreement when measured is zero
+        assert compute_mape(0.0, 1.0) == float("inf")
+
+
+# --------------------------------------------------------------------
+# Measurement loader (uses real calibration_data when available)
+# --------------------------------------------------------------------
+
+class TestMeasurementLoader:
+    def test_returns_none_for_sku_without_data(self):
+        m = load_measurement("kpu_t128", "resnet18", "fp32", 1)
+        assert m is None
+
+    def test_returns_none_for_missing_model_file(self):
+        m = load_measurement(
+            "intel_core_i7_12700k", "definitely_not_a_model", "fp32", 1
+        )
+        assert m is None
+
+    def test_loads_known_i7_measurement(self):
+        """The i7-12700k calibration set ships with resnet18 fp32.
+        If this fails, the calibration_data layout has changed."""
+        m = load_measurement("intel_core_i7_12700k", "resnet18", "fp32", 1)
+        if m is None:
+            pytest.skip("i7 calibration data not present in this env")
+        assert m.measured_latency_ms > 0
+        assert m.precision == "fp32"
+        assert m.batch_size == 1
+        assert m.source_path.endswith("resnet18_b1.json")
+
+    def test_list_includes_resnet_family(self):
+        models = list_available_measurements(
+            "intel_core_i7_12700k", precision="fp32"
+        )
+        if not models:
+            pytest.skip("i7 calibration data not present in this env")
+        assert "resnet18" in models
+
+    def test_list_empty_for_kpu(self):
+        assert list_available_measurements("kpu_t128") == []
+
+
+# --------------------------------------------------------------------
+# Synthetic validation summary tests (no UnifiedAnalyzer dependency)
+# --------------------------------------------------------------------
+
+def _synth_result(model: str, prec: str, measured: float,
+                  predicted: float) -> ValidationResult:
+    m = MeasurementRecord(
+        sku_id="x", model=model, precision=prec, batch_size=1,
+        measured_latency_ms=measured,
+    )
+    p = PredictionRecord(
+        sku_id="x", model=model, precision=prec, batch_size=1,
+        predicted_latency_ms=predicted,
+    )
+    return ValidationResult(
+        measurement=m, prediction=p,
+        mape_pct=compute_mape(measured, predicted),
+        ratio=predicted / measured,
+    )
+
+
+class TestSKUValidationSummary:
+    def test_empty_summary(self):
+        s = SKUValidationSummary(sku_id="x")
+        assert s.n_results == 0
+        assert s.mean_mape_pct == 0.0
+        assert s.median_mape_pct == 0.0
+        assert s.overall_within_tolerance is False
+
+    def test_within_tolerance_drives_promotion(self):
+        s = SKUValidationSummary(sku_id="x", results=[
+            _synth_result("a", "fp32", 10.0, 11.0),  # 10%
+            _synth_result("b", "fp32", 10.0, 12.0),  # 20%
+            _synth_result("c", "fp32", 10.0, 12.5),  # 25%
+        ])
+        assert s.median_mape_pct == 20.0
+        assert s.overall_within_tolerance is True
+
+    def test_one_outlier_does_not_demote_median_path(self):
+        """Median resists outliers -- a single bad model shouldn't
+        flip the SKU's aggregate confidence back to THEORETICAL."""
+        s = SKUValidationSummary(sku_id="x", results=[
+            _synth_result("a", "fp32", 10.0, 11.0),
+            _synth_result("b", "fp32", 10.0, 12.0),
+            _synth_result("c", "fp32", 10.0, 50.0),  # 400% MAPE outlier
+        ])
+        # Median stays at 20%; mean is dragged up by the outlier
+        assert s.median_mape_pct == 300.0 or s.median_mape_pct == 20.0
+        # With 3 elements [10, 20, 400], median is 20
+        assert s.median_mape_pct == 20.0
+        assert s.overall_within_tolerance is True
+        assert s.mean_mape_pct > 100.0  # mean is sensitive to outlier
+
+    def test_majority_bad_flips_to_theoretical(self):
+        s = SKUValidationSummary(sku_id="x", results=[
+            _synth_result("a", "fp32", 10.0, 50.0),  # 400%
+            _synth_result("b", "fp32", 10.0, 60.0),  # 500%
+            _synth_result("c", "fp32", 10.0, 11.0),  # 10%
+        ])
+        assert s.median_mape_pct == 400.0
+        assert s.overall_within_tolerance is False
+
+
+# --------------------------------------------------------------------
+# Panel builder (with monkeypatching for speed)
+# --------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Each test gets a clean validation cache."""
+    clear_validation_cache()
+    yield
+    clear_validation_cache()
+
+
+def _monkey_validate(monkeypatch, summary: SKUValidationSummary):
+    """Replace validate_sku in the validation_panel module with a
+    stub that returns a pre-baked summary, dodging the UnifiedAnalyzer
+    cost in tests."""
+    import graphs.reporting.layer_panels.validation_panel as vp
+    monkeypatch.setattr(vp, "validate_sku", lambda sku, **kw: summary)
+
+
+class TestValidationPanel:
+    def test_panel_layer_tag_is_composite(self, monkeypatch):
+        s = SKUValidationSummary(sku_id="intel_core_i7_12700k", results=[
+            _synth_result("resnet18", "fp32", 10.0, 11.0),
+        ])
+        _monkey_validate(monkeypatch, s)
+        panel = build_validation_panel("intel_core_i7_12700k")
+        assert panel.layer is LayerTag.COMPOSITE
+
+    def test_within_tolerance_promotes_to_interpolated(self, monkeypatch):
+        s = SKUValidationSummary(sku_id="intel_core_i7_12700k", results=[
+            _synth_result("a", "fp32", 10.0, 11.0),
+            _synth_result("b", "fp32", 10.0, 12.0),
+            _synth_result("c", "fp32", 10.0, 13.0),
+        ])
+        _monkey_validate(monkeypatch, s)
+        panel = build_validation_panel("intel_core_i7_12700k")
+        assert panel.status == "interpolated"
+
+    def test_above_tolerance_stays_theoretical(self, monkeypatch):
+        s = SKUValidationSummary(sku_id="intel_core_i7_12700k", results=[
+            _synth_result("a", "fp32", 10.0, 50.0),
+            _synth_result("b", "fp32", 10.0, 60.0),
+        ])
+        _monkey_validate(monkeypatch, s)
+        panel = build_validation_panel("intel_core_i7_12700k")
+        assert panel.status == "theoretical"
+
+    def test_metrics_include_n_and_median(self, monkeypatch):
+        s = SKUValidationSummary(sku_id="intel_core_i7_12700k", results=[
+            _synth_result("resnet18", "fp32", 10.0, 11.0),
+            _synth_result("resnet50", "fp32", 50.0, 55.0),
+        ])
+        _monkey_validate(monkeypatch, s)
+        panel = build_validation_panel("intel_core_i7_12700k")
+        assert "Models validated" in panel.metrics
+        assert panel.metrics["Models validated"]["value"] == "2"
+        assert "Median MAPE" in panel.metrics
+
+    def test_sku_without_calibration_renders_empty_state(self):
+        panel = build_validation_panel("kpu_t128")
+        assert panel.status == "not_populated"
+        assert "no measurement" in panel.summary.lower()
+
+    def test_unknown_sku_returns_unpopulated(self):
+        panel = build_validation_panel("definitely_not_a_sku")
+        assert panel.status == "not_populated"
+
+    def test_validation_results_written_back_to_model(self, monkeypatch):
+        """The panel side-effect: per-result MAPE values land in the
+        resource model's validation_results dict for downstream use."""
+        from graphs.reporting.layer_panels.layer1_alu import (
+            resolve_sku_resource_model,
+        )
+        s = SKUValidationSummary(sku_id="intel_core_i7_12700k", results=[
+            _synth_result("resnet18", "fp32", 10.0, 11.0),
+            _synth_result("resnet50", "fp32", 20.0, 24.0),
+        ])
+        _monkey_validate(monkeypatch, s)
+        m = resolve_sku_resource_model("intel_core_i7_12700k")
+        # Reset the dict to simulate first-run state
+        m.validation_results = {}
+        build_validation_panel("intel_core_i7_12700k")
+        m_again = resolve_sku_resource_model("intel_core_i7_12700k")
+        # Note: resolve_sku_resource_model returns a fresh object each
+        # call (factory pattern), so we cannot rely on side-effects
+        # persisting across resolves. Verify the call did not raise.
+        assert isinstance(m_again.validation_results, dict)
+
+
+# --------------------------------------------------------------------
+# Cross-SKU chart
+# --------------------------------------------------------------------
+
+class TestCrossSKUValidationChart:
+    def test_chart_skips_skus_without_data(self, monkeypatch):
+        import graphs.reporting.layer_panels.validation_panel as vp
+
+        def fake_validate(sku, **kw):
+            if sku == "intel_core_i7_12700k":
+                return SKUValidationSummary(sku_id=sku, results=[
+                    _synth_result("a", "fp32", 10.0, 11.0),
+                ])
+            return SKUValidationSummary(sku_id=sku)  # empty
+
+        monkeypatch.setattr(vp, "validate_sku", fake_validate)
+        chart = cross_sku_validation_chart(
+            ["intel_core_i7_12700k", "kpu_t128", "ryzen_9_8945hs"]
+        )
+        # KPU has no calibration dir registered -> never even calls
+        # validate_sku. Ryzen has a registered dir but our stub
+        # returns empty -> skipped.
+        assert "intel_core_i7_12700k" in chart.n_results
+        assert "kpu_t128" not in chart.n_results
+
+    def test_within_tolerance_flag_propagates(self, monkeypatch):
+        import graphs.reporting.layer_panels.validation_panel as vp
+        monkeypatch.setattr(
+            vp, "validate_sku",
+            lambda sku, **kw: SKUValidationSummary(sku_id=sku, results=[
+                _synth_result("a", "fp32", 10.0, 11.0),  # 10%
+            ]),
+        )
+        chart = cross_sku_validation_chart(["intel_core_i7_12700k"])
+        assert chart.within_tolerance["intel_core_i7_12700k"] is True

--- a/tests/reporting/test_measurement_validation.py
+++ b/tests/reporting/test_measurement_validation.py
@@ -1,19 +1,13 @@
 """Tests for the Path A measurement-validation pipeline."""
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from typing import Optional
-
 import pytest
 
+import graphs.reporting.layer_panels.validation_panel as vp
 from graphs.benchmarks.schema import LayerTag
 from graphs.reporting.layer_panels import (
     build_validation_panel,
     cross_sku_validation_chart,
-)
-from graphs.reporting.layer_panels.validation_panel import (
-    clear_validation_cache,
 )
 from graphs.reporting.validation import (
     MeasurementRecord,
@@ -183,16 +177,15 @@ class TestSKUValidationSummary:
 @pytest.fixture(autouse=True)
 def _clear_cache():
     """Each test gets a clean validation cache."""
-    clear_validation_cache()
+    vp.clear_validation_cache()
     yield
-    clear_validation_cache()
+    vp.clear_validation_cache()
 
 
 def _monkey_validate(monkeypatch, summary: SKUValidationSummary):
     """Replace validate_sku in the validation_panel module with a
     stub that returns a pre-baked summary, dodging the UnifiedAnalyzer
     cost in tests."""
-    import graphs.reporting.layer_panels.validation_panel as vp
     monkeypatch.setattr(vp, "validate_sku", lambda sku, **kw: summary)
 
 
@@ -236,34 +229,37 @@ class TestValidationPanel:
         assert "Median MAPE" in panel.metrics
 
     def test_sku_without_calibration_renders_empty_state(self):
+        """SKUs without measurement data return a theoretical-tagged
+        panel so the explanatory text survives the renderer (panels
+        tagged 'not_populated' get collapsed to a generic placeholder
+        that drops the custom summary / notes)."""
         panel = build_validation_panel("kpu_t128")
-        assert panel.status == "not_populated"
+        assert panel.status == "theoretical"
         assert "no measurement" in panel.summary.lower()
 
-    def test_unknown_sku_returns_unpopulated(self):
+    def test_unknown_sku_returns_theoretical_with_text(self):
         panel = build_validation_panel("definitely_not_a_sku")
-        assert panel.status == "not_populated"
+        assert panel.status == "theoretical"
+        assert "unavailable" in panel.summary.lower()
 
-    def test_validation_results_written_back_to_model(self, monkeypatch):
-        """The panel side-effect: per-result MAPE values land in the
-        resource model's validation_results dict for downstream use."""
-        from graphs.reporting.layer_panels.layer1_alu import (
-            resolve_sku_resource_model,
-        )
+    def test_per_result_mape_surfaces_in_panel_metrics(self, monkeypatch):
+        """MAPE for each (model, precision) combination surfaces
+        through the panel's metrics dict (which serializes to JSON).
+        This replaces an earlier side-effect that wrote into a
+        throwaway HardwareResourceModel.validation_results dict --
+        ``resolve_sku_resource_model`` returns a fresh instance each
+        call, so the side-effect was unobservable downstream. Reading
+        from the panel itself (or from ``report.layers[i].metrics``)
+        is the persistent path."""
         s = SKUValidationSummary(sku_id="intel_core_i7_12700k", results=[
             _synth_result("resnet18", "fp32", 10.0, 11.0),
             _synth_result("resnet50", "fp32", 20.0, 24.0),
         ])
         _monkey_validate(monkeypatch, s)
-        m = resolve_sku_resource_model("intel_core_i7_12700k")
-        # Reset the dict to simulate first-run state
-        m.validation_results = {}
-        build_validation_panel("intel_core_i7_12700k")
-        m_again = resolve_sku_resource_model("intel_core_i7_12700k")
-        # Note: resolve_sku_resource_model returns a fresh object each
-        # call (factory pattern), so we cannot rely on side-effects
-        # persisting across resolves. Verify the call did not raise.
-        assert isinstance(m_again.validation_results, dict)
+        panel = build_validation_panel("intel_core_i7_12700k")
+        # Best-3 MAPE entries surface as named metrics
+        keys = [k for k in panel.metrics if "Best (" in k]
+        assert keys, f"Expected per-result Best (...) metrics; got {list(panel.metrics)}"
 
 
 # --------------------------------------------------------------------
@@ -272,8 +268,6 @@ class TestValidationPanel:
 
 class TestCrossSKUValidationChart:
     def test_chart_skips_skus_without_data(self, monkeypatch):
-        import graphs.reporting.layer_panels.validation_panel as vp
-
         def fake_validate(sku, **kw):
             if sku == "intel_core_i7_12700k":
                 return SKUValidationSummary(sku_id=sku, results=[
@@ -292,7 +286,6 @@ class TestCrossSKUValidationChart:
         assert "kpu_t128" not in chart.n_results
 
     def test_within_tolerance_flag_propagates(self, monkeypatch):
-        import graphs.reporting.layer_panels.validation_panel as vp
         monkeypatch.setattr(
             vp, "validate_sku",
             lambda sku, **kw: SKUValidationSummary(sku_id=sku, results=[
@@ -301,3 +294,51 @@ class TestCrossSKUValidationChart:
         )
         chart = cross_sku_validation_chart(["intel_core_i7_12700k"])
         assert chart.within_tolerance["intel_core_i7_12700k"] is True
+
+
+class TestHTMLGating:
+    """The cross-SKU validation section must not silently invoke
+    validate_sku() when --with-validation was off (the validate_sku
+    call triggers UnifiedAnalyzer and pays ~60s/SKU). Render-time
+    gating: only emit the section when at least one report has a
+    LayerTag.COMPOSITE panel attached."""
+
+    def test_render_omits_section_when_no_validation_panel(self):
+        from graphs.reporting.microarch_html_template import (
+            render_comparison_page,
+        )
+        from graphs.reporting.microarch_schema import empty_report
+        from pathlib import Path
+
+        # Build reports without a validation panel -- mirrors
+        # default CLI behaviour (--with-validation off).
+        reports = [
+            empty_report(sku="intel_core_i7_12700k"),
+            empty_report(sku="kpu_t128"),
+        ]
+        html = render_comparison_page(reports, Path("."))
+        assert "Path A: end-to-end measurement validation" not in html
+
+    def test_render_emits_section_when_validation_panel_present(
+        self, monkeypatch,
+    ):
+        from graphs.reporting.microarch_html_template import (
+            render_comparison_page,
+        )
+        from graphs.reporting.microarch_schema import empty_report
+        from pathlib import Path
+
+        # Stub validate_sku so cross_sku_validation_chart returns
+        # data without actually running UnifiedAnalyzer.
+        monkeypatch.setattr(
+            vp, "validate_sku",
+            lambda sku, **kw: SKUValidationSummary(sku_id=sku, results=[
+                _synth_result("a", "fp32", 10.0, 11.0),
+            ]),
+        )
+
+        report = empty_report(sku="intel_core_i7_12700k")
+        # Append a synthetic validation panel so the gate triggers
+        report.layers.append(build_validation_panel("intel_core_i7_12700k"))
+        html = render_comparison_page([report], Path("."))
+        assert "Path A: end-to-end measurement validation" in html


### PR DESCRIPTION
## Summary
- Compare M1-M7 analytical predictions vs measured per-model latency in `calibration_data/`.
- Aggregate-confidence promotion from THEORETICAL -> INTERPOLATED at the SKU level when median MAPE is within +/-30%.
- Opt-in via `--with-validation` CLI flag (default off; adds ~60 s per validated SKU because each prediction triggers a UnifiedAnalyzer run).

## Why
We have extensive measurement data for i7-12700K and Jetson Orin AGX (10 + 15 models, FP32 / FP16 / BF16). Path A wires this data into the M1-M7 report as end-to-end accuracy validation. It doesn't fit any single coefficient (model-level latency is confounded across dozens of primitives), but it tells us *whether* the assembled chain is in the right ballpark.

## Initial validation results

| SKU | Models | Median MAPE | Aggregate confidence |
|---|---|---|---|
| Intel Core i7-12700K | 10 (fp32) | ~5% | INTERPOLATED |
| Jetson Orin AGX 64GB | 15 (fp32) | ~60% | THEORETICAL (drift surfaced) |

i7 lands well within tolerance — the assembled CPU model agrees with measurement to within a few percent on ResNet-class workloads. Orin AGX overshoots by ~2x (predicts faster than reality), which is exactly the kind of finding that motivates Path B microbenchmark calibration. Likely culprits: thermal throttling at sustained 30W, kernel-launch overhead, framework overhead — all of which Path B layer-by-layer microbenchmarks can isolate.

## Architecture

| File | What |
|---|---|
| `src/graphs/reporting/validation/sku_id_resolution.py` | **New.** Bridge microarch SKU ids -> `calibration_data/` dir names + UnifiedAnalyzer mapper names. |
| `src/graphs/reporting/validation/measurement_comparison.py` | **New.** `load_measurement()`, `predict_via_unified_analyzer()`, `validate_sku()`, `SKUValidationSummary` with median / mean MAPE + within_tolerance flag. |
| `src/graphs/reporting/layer_panels/validation_panel.py` | **New.** Tagged `LayerTag.COMPOSITE`; appended (not replacing) the 7 layer panels so the M1-M7 layout stays intact. Module-level cache so UnifiedAnalyzer runs once per SKU per process. |
| `src/graphs/hardware/resource_model.py` | Add `validation_results: Dict[str, float]` for per-(model, precision) MAPE values. |
| `src/graphs/reporting/microarch_html_template.py` | Cross-SKU validation summary table on `compare.html` (only renders when at least one SKU has validation results). |
| `cli/microarch_validation_report.py` | `--with-validation` flag + `_populate_validation` hook. |
| `tests/reporting/test_measurement_validation.py` | **New.** 26 tests: SKU id resolution, MAPE math, measurement loader, synthetic summary aggregation, panel builder (monkeypatched to dodge UnifiedAnalyzer cost), cross-SKU chart. |

## Design choices

- **Median over mean** for the tolerance check — resists outliers (one bad model shouldn't flip the SKU's whole confidence).
- **Energy MAPE deferred to Path B.** The calibration data is latency-only at the model level. Energy validation belongs to bottom-up microbenchmarks.
- **Append rather than replace.** Validation panel uses `LayerTag.COMPOSITE` and is appended after Layer 7 so the existing 7-layer schema stays intact.
- **Lazy UnifiedAnalyzer import.** `predict_via_unified_analyzer` lazy-imports PyTorch-heavy modules so panel introspection doesn't pay that cost.

## Test results

| Suite | Result |
|---|---|
| `tests/reporting/test_measurement_validation.py` | **26 passed** |
| Full unit suite (`tests/`) | 1435 passed, 7 skipped, 1 xfailed |

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Run `cli/microarch_validation_report.py --with-validation` locally and inspect `compare.html` for the Path A table + per-SKU validation panels
- [ ] When CI is green: `gh pr ready <#>`

This is the first concrete bridge between the M1-M7 analytical models and the measurement library; it sets up the empirical level sets discussion for the Path B PRs (cache sweep, STREAM BW, NoC ping-pong) that follow.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional validation panel to microarchitecture reports with per-SKU MAPE metrics and confidence assessment.
  * Added `--with-validation` CLI flag to enable validation reporting across all output formats (HTML, JSON, PPTX).
  * Added cross-SKU validation comparison table in HTML reports showing model validation counts, median MAPE percentages, and aggregate confidence levels.

* **Tests**
  * Added comprehensive test suite for measurement validation pipeline, SKU resolution, and panel generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->