### PR TITLE
feat(calibration): Path B PR-1 cache-sweep microbenchmark + fitter

### DIFF
--- a/cli/benchmark_cache_sweep.py
+++ b/cli/benchmark_cache_sweep.py
@@ -10,7 +10,7 @@ CALIBRATED provenance into a HardwareResourceModel.
 
 Usage:
 
-    python cli/run_cache_sweep.py --hardware intel_core_i7_12700k \\
+    python cli/benchmark_cache_sweep.py --hardware intel_core_i7_12700k \\
         --output sweeps/i7_12700k_cache_sweep.json
 
 The ``--hardware`` argument is a free-form SKU id used only to tag
@@ -40,16 +40,14 @@ sys.path.insert(0, str(_REPO_ROOT))
 
 from graphs.benchmarks.cache_sweep import (  # noqa: E402
     SweepConfig,
+    rapl_available,
     run_sweep,
-)
-from graphs.benchmarks.cache_sweep.working_set_sweep import (  # noqa: E402
-    _RAPLProbe,
 )
 
 
 def parse_args(argv):
     p = argparse.ArgumentParser(
-        prog="run_cache_sweep",
+        prog="benchmark_cache_sweep",
         description=("Run the Path B cache-sweep microbenchmark on the "
                      "host CPU and persist per-point results to JSON."),
     )
@@ -127,8 +125,7 @@ def main(argv):
         rapl_zone=args.rapl_zone,
     )
 
-    rapl = _RAPLProbe(zone=args.rapl_zone)
-    rapl_ok = (not args.no_energy) and rapl.available
+    rapl_ok = (not args.no_energy) and rapl_available(zone=args.rapl_zone)
     if not rapl_ok:
         print(
             "warning: RAPL energy capture unavailable -- result will be "
@@ -172,7 +169,7 @@ def main(argv):
 
     payload = {
         "schema_version": "1.0",
-        "tool": "cli/run_cache_sweep.py",
+        "tool": "cli/benchmark_cache_sweep.py",
         "hardware_id": args.hardware,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "config": {

--- a/cli/run_cache_sweep.py
+++ b/cli/run_cache_sweep.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+"""
+Run the Path B cache-sweep microbenchmark and persist results.
+
+Sweeps a streaming kernel over a logarithmic range of working-set
+sizes and writes per-point bandwidth (and per-byte energy when RAPL
+is available) to JSON. The result file feeds
+``graphs.calibration.fitters.cache_sweep_fitter`` which writes
+CALIBRATED provenance into a HardwareResourceModel.
+
+Usage:
+
+    python cli/run_cache_sweep.py --hardware intel_core_i7_12700k \\
+        --output sweeps/i7_12700k_cache_sweep.json
+
+The ``--hardware`` argument is a free-form SKU id used only to tag
+the output file -- the sweep itself runs whatever CPU is hosting
+the Python process.
+
+Energy capture is best-effort:
+
+  * On Linux x86 with intel-rapl, the RAPL package energy counter
+    is read before / after each measurement.
+  * On other platforms, or when RAPL access is denied, energy
+    columns come back ``None`` and downstream analysis falls back
+    to the analytical TechnologyProfile estimate. The CLI emits a
+    clear warning so the operator knows the result is time-only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Add repo root so `graphs.*` imports work when invoked directly.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from graphs.benchmarks.cache_sweep import (  # noqa: E402
+    SweepConfig,
+    run_sweep,
+)
+from graphs.benchmarks.cache_sweep.working_set_sweep import (  # noqa: E402
+    _RAPLProbe,
+)
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(
+        prog="run_cache_sweep",
+        description=("Run the Path B cache-sweep microbenchmark on the "
+                     "host CPU and persist per-point results to JSON."),
+    )
+    p.add_argument(
+        "--hardware",
+        required=True,
+        help="SKU id used to tag the output (e.g., intel_core_i7_12700k).",
+    )
+    p.add_argument(
+        "--output", "-o",
+        required=True,
+        help="Output JSON path.",
+    )
+    p.add_argument(
+        "--min-bytes",
+        type=int,
+        default=8 * 1024,
+        help="Smallest working-set size in bytes (default 8 KiB).",
+    )
+    p.add_argument(
+        "--max-bytes",
+        type=int,
+        default=64 * 1024 * 1024,
+        help="Largest working-set size in bytes (default 64 MiB).",
+    )
+    p.add_argument(
+        "--num-points",
+        type=int,
+        default=24,
+        help="Number of log-spaced size points (default 24).",
+    )
+    p.add_argument(
+        "--seconds-per-point",
+        type=float,
+        default=0.5,
+        help="Wallclock target per size point (default 0.5 s).",
+    )
+    p.add_argument(
+        "--repeats",
+        type=int,
+        default=3,
+        help="Number of repeats per size point; min wallclock kept "
+             "(default 3).",
+    )
+    p.add_argument(
+        "--no-energy",
+        action="store_true",
+        help="Skip RAPL energy capture even when available.",
+    )
+    p.add_argument(
+        "--rapl-zone",
+        default="intel-rapl:0",
+        help="RAPL zone path under /sys/class/powercap/ (default intel-rapl:0).",
+    )
+    p.add_argument(
+        "--quiet", "-q",
+        action="store_true",
+        help="Suppress per-point progress output.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+    out_path = Path(args.output).resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    config = SweepConfig(
+        min_bytes=args.min_bytes,
+        max_bytes=args.max_bytes,
+        num_points=args.num_points,
+        target_seconds_per_point=args.seconds_per_point,
+        repeats_per_point=args.repeats,
+        capture_energy=not args.no_energy,
+        rapl_zone=args.rapl_zone,
+    )
+
+    rapl = _RAPLProbe(zone=args.rapl_zone)
+    rapl_ok = (not args.no_energy) and rapl.available
+    if not rapl_ok:
+        print(
+            "warning: RAPL energy capture unavailable -- result will be "
+            "time-only. Energy/byte columns will be null.",
+            file=sys.stderr,
+        )
+
+    if not args.quiet:
+        print(
+            f"running cache_sweep on {args.hardware}: "
+            f"{config.num_points} points "
+            f"in [{config.min_bytes // 1024} KiB, "
+            f"{config.max_bytes // (1024 * 1024)} MiB], "
+            f"~{config.target_seconds_per_point:.1f}s/point, "
+            f"{config.repeats_per_point} repeat(s)"
+        )
+
+    points = []
+    for i, point in enumerate(run_sweep(config)):
+        if not args.quiet:
+            energy_str = (
+                f"  energy={point.energy_per_byte_pj:.2f} pJ/B"
+                if point.energy_per_byte_pj is not None
+                else ""
+            )
+            print(
+                f"  [{i+1:>2}/{config.num_points}] "
+                f"{point.bytes_resident:>10} B  "
+                f"{point.bandwidth_gbps:>6.1f} GB/s"
+                f"{energy_str}"
+            )
+        points.append({
+            "bytes_resident": point.bytes_resident,
+            "iterations": point.iterations,
+            "elapsed_seconds": point.elapsed_seconds,
+            "bandwidth_gbps": point.bandwidth_gbps,
+            "energy_joules": point.energy_joules,
+            "energy_per_byte_pj": point.energy_per_byte_pj,
+            "extra": point.extra,
+        })
+
+    payload = {
+        "schema_version": "1.0",
+        "tool": "cli/run_cache_sweep.py",
+        "hardware_id": args.hardware,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "config": {
+            "min_bytes": config.min_bytes,
+            "max_bytes": config.max_bytes,
+            "num_points": config.num_points,
+            "target_seconds_per_point": config.target_seconds_per_point,
+            "repeats_per_point": config.repeats_per_point,
+            "capture_energy": config.capture_energy,
+            "rapl_available": rapl_ok,
+        },
+        "points": points,
+    }
+    out_path.write_text(json.dumps(payload, indent=2))
+    print(f"wrote {len(points)} points to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/calibration/cache_sweep.md
+++ b/docs/calibration/cache_sweep.md
@@ -19,7 +19,7 @@ calibrates the per-cache-level energy coefficients on
 ```json
 {
   "schema_version": "1.0",
-  "tool": "cli/run_cache_sweep.py",
+  "tool": "cli/benchmark_cache_sweep.py",
   "hardware_id": "intel_core_i7_12700k",
   "timestamp": "2026-04-29T...",
   "config": {
@@ -58,18 +58,18 @@ calibrates the per-cache-level energy coefficients on
 
 ```bash
 # Default 24-point sweep on the host CPU, ~12 s + warmup:
-python cli/run_cache_sweep.py \
+python cli/benchmark_cache_sweep.py \
     --hardware intel_core_i7_12700k \
     --output sweeps/i7_12700k.json
 
 # Tighter sweep for quick iteration:
-python cli/run_cache_sweep.py \
+python cli/benchmark_cache_sweep.py \
     --hardware intel_core_i7_12700k \
     --output sweeps/i7_quick.json \
     --num-points 16 --seconds-per-point 0.3 --repeats 2
 
 # Force time-only (no RAPL):
-python cli/run_cache_sweep.py \
+python cli/benchmark_cache_sweep.py \
     --hardware intel_core_i7_12700k \
     --output sweeps/i7_time_only.json \
     --no-energy
@@ -80,7 +80,7 @@ python cli/run_cache_sweep.py \
 A clean run on a 12-core x86 CPU (i7-12700K) shows plateaus at
 roughly:
 
-```
+```text
 working_set     bandwidth     plateau
 8 - 32 KiB      ~rising       (call-overhead amortization region)
 50 KiB - 1 MiB  ~75 GB/s      (L1 + L2 - kernel is bandwidth-bound)

--- a/docs/calibration/cache_sweep.md
+++ b/docs/calibration/cache_sweep.md
@@ -1,5 +1,10 @@
 # Cache-sweep microbenchmark — Path B PR-1
 
+For the complementary *model-level* validation overlay (Path A),
+see [docs/validation/measurement-overlay.md](../validation/measurement-overlay.md).
+Path A flips an SKU's aggregate confidence badge; Path B (this doc)
+flips per-field provenance on `HardwareResourceModel`.
+
 ## What it measures
 
 A working-set-size sweep that streams an in-place kernel over a

--- a/docs/calibration/cache_sweep.md
+++ b/docs/calibration/cache_sweep.md
@@ -1,0 +1,138 @@
+# Cache-sweep microbenchmark — Path B PR-1
+
+## What it measures
+
+A working-set-size sweep that streams an in-place kernel over a
+log-spaced range of buffer sizes (default 8 KiB → 64 MiB) and
+records the bandwidth-vs-size curve. The plateaus identify the
+L1, L2, L3, and DRAM regions; the per-byte energy at each plateau
+calibrates the per-cache-level energy coefficients on
+`HardwareResourceModel`.
+
+## Output schema
+
+```json
+{
+  "schema_version": "1.0",
+  "tool": "cli/run_cache_sweep.py",
+  "hardware_id": "intel_core_i7_12700k",
+  "timestamp": "2026-04-29T...",
+  "config": {
+    "min_bytes": 8192,
+    "max_bytes": 67108864,
+    "num_points": 24,
+    "target_seconds_per_point": 0.5,
+    "repeats_per_point": 3,
+    "capture_energy": true,
+    "rapl_available": true
+  },
+  "points": [
+    {
+      "bytes_resident": 8192,
+      "iterations": 12345,
+      "elapsed_seconds": 0.512,
+      "bandwidth_gbps": 200.0,
+      "energy_joules": 0.024,
+      "energy_per_byte_pj": 0.18,
+      "extra": {...}
+    }, ...
+  ]
+}
+```
+
+## Hardware requirements
+
+| SKU | Energy capture | Notes |
+|---|---|---|
+| Intel x86 (Linux) | RAPL via `/sys/class/powercap/intel-rapl:0/energy_uj` | Requires read access; usually available to the user, sometimes root-only after kernel patches |
+| AMD x86 (Linux) | RAPL via `intel-rapl:0` (despite the name) | Same access pattern |
+| Jetson Orin AGX | Not yet wired (PR-3 will add `tegrastats` integration) | Sweep runs time-only |
+| Other | None | `--no-energy` recommended; expect time-only output |
+
+## Running
+
+```bash
+# Default 24-point sweep on the host CPU, ~12 s + warmup:
+python cli/run_cache_sweep.py \
+    --hardware intel_core_i7_12700k \
+    --output sweeps/i7_12700k.json
+
+# Tighter sweep for quick iteration:
+python cli/run_cache_sweep.py \
+    --hardware intel_core_i7_12700k \
+    --output sweeps/i7_quick.json \
+    --num-points 16 --seconds-per-point 0.3 --repeats 2
+
+# Force time-only (no RAPL):
+python cli/run_cache_sweep.py \
+    --hardware intel_core_i7_12700k \
+    --output sweeps/i7_time_only.json \
+    --no-energy
+```
+
+## Interpreting the bandwidth curve
+
+A clean run on a 12-core x86 CPU (i7-12700K) shows plateaus at
+roughly:
+
+```
+working_set     bandwidth     plateau
+8 - 32 KiB      ~rising       (call-overhead amortization region)
+50 KiB - 1 MiB  ~75 GB/s      (L1 + L2 - kernel is bandwidth-bound)
+2 - 11 MiB      ~33 GB/s      (L3)
+20 - 64 MiB     ~20 GB/s      (DRAM)
+```
+
+The L1-vs-L2 transition is hard to see because the in-place XOR
+kernel saturates both cache levels at roughly the same bandwidth
+on modern x86 CPUs (the L2 prefetcher kicks in early). A future
+PR may add a second kernel variant that's more sensitive to L1
+boundaries; the L2-L3 and L3-DRAM transitions are clear enough
+to back the calibration we want today.
+
+## Applying the result
+
+```python
+import json
+from graphs.benchmarks.cache_sweep import WorkingSetPoint
+from graphs.calibration.fitters.cache_sweep_fitter import CacheSweepFitter
+from graphs.hardware.models.edge.intel_core_i7_12700k import (
+    intel_core_i7_12700k_resource_model,
+)
+
+data = json.load(open("sweeps/i7_12700k.json"))
+points = [WorkingSetPoint(
+    bytes_resident=p["bytes_resident"],
+    iterations=p["iterations"],
+    elapsed_seconds=p["elapsed_seconds"],
+    bandwidth_gbps=p["bandwidth_gbps"],
+    energy_joules=p["energy_joules"],
+    energy_per_byte_pj=p["energy_per_byte_pj"],
+) for p in data["points"]]
+
+model = intel_core_i7_12700k_resource_model()
+fitter = CacheSweepFitter()
+fit = fitter.fit(points, sku_name="intel_core_i7_12700k")
+fitter.apply_to_model(model, fit)
+
+# model.field_provenance now carries CALIBRATED tags for the
+# detected levels:
+for k, v in model.field_provenance.items():
+    if "cache_energy" in k:
+        print(f"{k}: {v}")
+```
+
+## Future work
+
+- **Kernel variants.** An additional pointer-chase kernel would
+  isolate L1 latency more cleanly and would not be amortized away
+  by the L2 streaming prefetcher.
+- **Jetson energy.** PR-3 wires `tegrastats` for Orin AGX so the
+  same sweep harness produces calibrated coefficients on Jetson.
+- **Apply CLI.** A dedicated `cli/apply_calibration.py` runner that
+  reads a sweep JSON, locates the matching SKU resource model, and
+  persists the fit result back into the in-tree model files (or a
+  side calibration cache).
+- **Cross-validation.** Compare measured DRAM bandwidth against
+  the M7 `peak_bandwidth` field; surface the delta in the Layer 7
+  panel.

--- a/docs/validation/measurement-overlay.md
+++ b/docs/validation/measurement-overlay.md
@@ -98,7 +98,7 @@ sections are worse than visible empty sections.
 
 ## Data flow
 
-```
+```text
 calibration_data/<dir>/measurements/<prec>/<model>_b<batch>.json
                          |
                          v

--- a/docs/validation/measurement-overlay.md
+++ b/docs/validation/measurement-overlay.md
@@ -1,0 +1,161 @@
+# Measurement-overlay validation panel — Path A
+
+## What it is
+
+An optional layer panel appended to the micro-architectural report
+that compares the M1-M7 *analytical* latency predictions against
+*measured* model-level latencies in `calibration_data/`. Tagged
+`LayerTag.COMPOSITE` so it renders alongside the seven layer panels
+without changing the layer enum.
+
+Path A answers a single question: *"Does the analytical chain we
+built layer-by-layer in M1-M7 actually agree with the silicon?"* It
+is the bridge between the bottom-up theoretical model and the
+top-down measurement data, and is the only way an SKU's aggregate
+confidence can promote from `THEORETICAL` to `INTERPOLATED` today.
+
+For per-cache-level energy calibration (a *finer-grained* upgrade
+that touches `field_provenance` rather than the aggregate
+confidence), see [docs/calibration/cache_sweep.md](../calibration/cache_sweep.md)
+— that's Path B.
+
+## Running
+
+The validation panel is **opt-in**: each validated SKU adds ~60 s
+to the report build because every measurement triggers a
+`UnifiedAnalyzer` prediction. Pass `--with-validation`:
+
+```bash
+./cli/microarch_validation_report.py \
+    --hardware intel_core_i7_12700k jetson_orin_agx_64gb \
+    --with-validation \
+    --output reports/microarch_model/with_validation
+```
+
+Without the flag, the renderer's `LayerTag.COMPOSITE` gate
+suppresses the cross-SKU validation table in `compare.html` and the
+per-SKU panel never gets appended — the report builds in seconds
+and looks identical to a pre-Path-A run.
+
+## Where it lands
+
+| File | What appears with `--with-validation` |
+|---|---|
+| `hardware/<sku>.html` | "Validation: predicted vs measured" panel after Layers 1-7. Status badge = `INTERPOLATED` (within tolerance) or `THEORETICAL` (drift surfaced). |
+| `compare.html` | Cross-SKU table with one row per validated SKU: models validated, median MAPE, tolerance badge. |
+| `index.html` | Per-SKU confidence column reflects the promotion when median MAPE is within tolerance. |
+| `data/<sku>.json` | Same data as the panel, machine-readable, including top-3 best / top-3 worst per-model MAPEs. |
+
+## Promotion rule
+
+Encoded in `validation_panel.build_validation_panel`:
+
+- `median_mape_pct <= 30%` -> panel status `interpolated`,
+  `report.overall_confidence` promoted from `THEORETICAL` to
+  `INTERPOLATED`.
+- `median_mape_pct >  30%` -> panel status `theoretical`, numeric
+  MAPE surfaced for inspection. The drift is reported per-model so
+  a Path B microbenchmark campaign can target the layers most
+  responsible.
+
+The `_populate_validation` hook (`cli/microarch_validation_report.py`)
+only promotes when the layer-level confidence is still `THEORETICAL`
+— it never demotes.
+
+## SKU coverage today
+
+Coverage is gated by what's in `calibration_data/` plus an explicit
+mapping from microarch-report SKU id to calibration directory and
+to `UnifiedAnalyzer` mapper name. The mapping table lives in
+`src/graphs/reporting/validation/sku_id_resolution.py`:
+
+| Microarch SKU id | calibration_data/ dir | UnifiedAnalyzer mapper | Status |
+|---|---|---|---|
+| `intel_core_i7_12700k` | `intel_core_i7_12700k` | `i7-12700k` | ~5% MAPE on 10 fp32 models -> promoted INTERPOLATED |
+| `jetson_orin_agx_64gb` | `jetson_orin_agx_30w` (30W matches the M1-M7 baseline) | `jetson-orin-agx-64gb` | ~60% MAPE -> stays THEORETICAL; drift surfaced for Path B follow-up |
+| `ryzen_9_8945hs` | `ryzen_9_8945hs` | `ryzen` | Mapping registered; outcome depends on measurement set present |
+| `kpu_t64`, `kpu_t128`, `kpu_t256`, `coral_edge_tpu`, `hailo8`, `hailo10h` | -- | -- | No measurement data; panel renders the empty-state explanation |
+
+Adding a SKU is a three-row edit in `sku_id_resolution.py`
+(`_SKU_TO_CALIBRATION_DIR`, `_SKU_TO_MAPPER_NAME`, optionally
+`_SKU_TO_THERMAL_PROFILE`) plus a measurement directory under
+`calibration_data/`. No panel-side changes are required.
+
+## Empty-state behaviour
+
+A SKU without measurement data is not an error. The panel renders
+with status `theoretical` and an explanatory summary:
+
+> "No measurement data registered for `<sku>`; the SKU's aggregate
+> confidence stays at THEORETICAL until a calibration campaign
+> lands."
+
+A SKU registered but with zero matching measurements (the
+calibration directory exists but every model file failed to load)
+also renders cleanly with a pointer to check `calibration_data/`
+contents. Neither case suppresses the panel — silent empty
+sections are worse than visible empty sections.
+
+## Data flow
+
+```
+calibration_data/<dir>/measurements/<prec>/<model>_b<batch>.json
+                         |
+                         v
+              GroundTruthLoader.load() / .list_models()
+                         |
+                         v   (per data-hygiene rule —
+                              never json.loads directly)
+                         |
+                MeasurementSummary record
+                         |
+                         v
+       UnifiedAnalyzer.analyze_model(<mapper>, <model>, ...)
+                         |
+                         v
+                 PredictionRecord (analytical latency)
+                         |
+                         v
+                  ValidationResult (MAPE)
+                         |
+                         v
+                SKUValidationSummary (median, mean, n_within_tolerance)
+                         |
+                         v
+                LayerPanel(LayerTag.COMPOSITE)
+                         |
+                         v
+                  hardware/<sku>.html  +  compare.html  +  data/<sku>.json
+```
+
+Predictions are cached at module level (`_CACHE` in
+`validation_panel.py`) so a re-render within a single process
+doesn't re-pay the `UnifiedAnalyzer` cost. Tests can drop the cache
+via `clear_validation_cache()`.
+
+## Why this is opt-in
+
+The `UnifiedAnalyzer` import alone pulls in PyTorch, FX, and the
+full mapper registry. The pre-existing micro-arch report build
+runs in single-digit seconds and is used for cross-SKU tables that
+do not need predictions. Forcing every report build to pay
+~60 s/SKU for validation would make the M0/M1-M7 layer panels
+visibly slower for users who don't need the empirical overlay.
+The render-time gate in `microarch_html_template.py` is intentional:
+no `LayerTag.COMPOSITE` in any report's layers -> no validation
+section anywhere in the bundle.
+
+## Relationship to Path B
+
+Path A validates *the model as a whole*: it tells you whether the
+end-to-end analytical prediction matches measured latency. When it
+fails (Orin AGX today), it does not tell you *which layer* is
+responsible for the drift.
+
+Path B (the cache-sweep work in PR #45 and beyond) calibrates
+*individual layer coefficients* — per-cache-level read energy,
+DRAM bandwidth, NoC ping-pong cost. Where Path A flips the
+aggregate confidence badge, Path B flips per-field provenance
+entries on `HardwareResourceModel` from `THEORETICAL` to
+`CALIBRATED`. The two paths are complementary: Path A surfaces a
+failed prediction, Path B narrows down the layer to fix.

--- a/src/graphs/benchmarks/cache_sweep/__init__.py
+++ b/src/graphs/benchmarks/cache_sweep/__init__.py
@@ -1,0 +1,47 @@
+"""
+Cache-sweep microbenchmark package (Path B PR-1).
+
+Sweeps a streaming kernel over a logarithmic range of working-set
+sizes and reports per-size effective bandwidth + measured energy.
+The transition points in the bandwidth-vs-working-set curve reveal
+the L1 / L2 / L3 capacity boundaries; the per-byte energy at each
+plateau calibrates the per-level energy coefficients on
+``HardwareResourceModel``.
+
+Pipeline:
+
+    cli/run_cache_sweep.py
+        -> cache_sweep.working_set_sweep.run_sweep()    [ runs on hardware ]
+        -> JSON file                                      [ persisted ]
+        -> cache_sweep.analysis.detect_levels()           [ pure analysis ]
+        -> cache_sweep_fitter.apply_to_model()            [ writes CALIBRATED ]
+
+The runtime kernel uses NumPy memory operations rather than calling
+out to a C binary -- this keeps the package portable across CPU and
+Jetson SoCs while still measuring the cache hierarchy cleanly. Real
+silicon shows distinct bandwidth plateaus across L1 / L2 / L3 / DRAM
+even with NumPy-level overhead.
+"""
+from .working_set_sweep import (
+    SweepConfig,
+    WorkingSetPoint,
+    run_sweep,
+)
+from .analysis import (
+    CacheLevel,
+    DetectedLevels,
+    PerLevelEnergy,
+    detect_levels,
+    estimate_per_level_energy,
+)
+
+__all__ = [
+    "SweepConfig",
+    "WorkingSetPoint",
+    "run_sweep",
+    "CacheLevel",
+    "DetectedLevels",
+    "PerLevelEnergy",
+    "detect_levels",
+    "estimate_per_level_energy",
+]

--- a/src/graphs/benchmarks/cache_sweep/__init__.py
+++ b/src/graphs/benchmarks/cache_sweep/__init__.py
@@ -10,7 +10,7 @@ plateau calibrates the per-level energy coefficients on
 
 Pipeline:
 
-    cli/run_cache_sweep.py
+    cli/benchmark_cache_sweep.py
         -> cache_sweep.working_set_sweep.run_sweep()    [ runs on hardware ]
         -> JSON file                                      [ persisted ]
         -> cache_sweep.analysis.detect_levels()           [ pure analysis ]
@@ -25,6 +25,7 @@ even with NumPy-level overhead.
 from .working_set_sweep import (
     SweepConfig,
     WorkingSetPoint,
+    rapl_available,
     run_sweep,
 )
 from .analysis import (
@@ -38,6 +39,7 @@ from .analysis import (
 __all__ = [
     "SweepConfig",
     "WorkingSetPoint",
+    "rapl_available",
     "run_sweep",
     "CacheLevel",
     "DetectedLevels",

--- a/src/graphs/benchmarks/cache_sweep/analysis.py
+++ b/src/graphs/benchmarks/cache_sweep/analysis.py
@@ -1,0 +1,193 @@
+"""
+Analyse a working-set-size sweep to recover per-cache-level energy.
+
+A bandwidth-vs-working-set curve has plateaus at L1, L2, L3, and
+DRAM with steep transitions at the cache capacity boundaries. The
+plateau bandwidth gives the *effective* per-level throughput; the
+plateau energy (when RAPL is available) divided by bytes streamed
+gives the per-byte energy.
+
+Algorithm (deliberately simple to keep the test surface small):
+
+1. Sort points by working-set size ascending.
+2. Compute log-scale derivative of bandwidth: drops above a
+   threshold mark transition steps.
+3. Plateaus between transitions identify L1 / L2 / L3 / DRAM.
+4. For each plateau, average the bandwidth and the per-byte energy.
+
+Real silicon shows clean plateaus on x86 CPUs; on Jetson SoCs the
+L1-vs-L2 transition is sometimes blurred by the unified L2/SLC.
+The detector reports the plateaus it found and leaves missing
+levels as ``None`` rather than fabricating boundaries.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional, Sequence
+
+from graphs.benchmarks.cache_sweep.working_set_sweep import WorkingSetPoint
+
+
+# Per-level bandwidth ratio (prev / curr) that qualifies as a real
+# transition. Tuned for a NumPy in-place XOR kernel on a modern x86
+# CPU: empirically the L2->L3 step is ~1.4x (clear), L3->DRAM is
+# only ~1.2x because the in-place kernel's write traffic stays
+# coherent at the cache controller. 1.2 captures both transitions
+# without firing on plateau noise (intra-plateau ratios stay below
+# 1.1 in practice).
+_TRANSITION_RATIO = 1.2
+
+
+class CacheLevel(Enum):
+    L1 = "L1"
+    L2 = "L2"
+    L3 = "L3"
+    DRAM = "DRAM"
+
+
+@dataclass
+class DetectedLevels:
+    """Working-set bounds for each detected plateau.
+
+    Each entry is ``(min_bytes, max_bytes)`` covering the points
+    assigned to the level. None means "no plateau identified" --
+    for example, on an SoC where L1 is too small to fit any sweep
+    point, or when the operator cut the max range below the L3
+    boundary.
+    """
+    levels: Dict[CacheLevel, Optional[tuple]] = field(default_factory=dict)
+
+
+@dataclass
+class PerLevelEnergy:
+    """Per-cache-level effective bandwidth + per-byte energy."""
+    bandwidth_gbps: Dict[CacheLevel, Optional[float]] = field(
+        default_factory=dict
+    )
+    energy_per_byte_pj: Dict[CacheLevel, Optional[float]] = field(
+        default_factory=dict
+    )
+
+    def has_calibrated_energy(self, level: CacheLevel) -> bool:
+        """True when the sweep captured a non-None per-byte energy
+        for the level (RAPL was available + a plateau was found)."""
+        return self.energy_per_byte_pj.get(level) is not None
+
+
+# --------------------------------------------------------------------
+# Plateau detection
+# --------------------------------------------------------------------
+
+def _find_transition_indices(
+    points: Sequence[WorkingSetPoint],
+) -> List[int]:
+    """Indices where bandwidth drops by at least ``_TRANSITION_RATIO``
+    relative to the previous point.
+
+    A transition is the FIRST index in the new (lower-bandwidth)
+    plateau, so a 4-point sequence [L1, L1, L2, L2] returns [2].
+    """
+    transitions: List[int] = []
+    for i in range(1, len(points)):
+        prev = points[i - 1].bandwidth_gbps
+        curr = points[i].bandwidth_gbps
+        if prev <= 0 or curr <= 0:
+            continue
+        if prev / curr >= _TRANSITION_RATIO:
+            transitions.append(i)
+    return transitions
+
+
+def detect_levels(points: Sequence[WorkingSetPoint]) -> DetectedLevels:
+    """Partition the sweep into L1 / L2 / L3 / DRAM plateaus.
+
+    Returns plateaus assigned in order: the first plateau is L1,
+    the next is L2, and so on. When fewer than 4 plateaus are
+    detected the missing levels are mapped to ``None`` so the
+    caller can fall back to analytical defaults rather than
+    fabricating a boundary.
+    """
+    sorted_points = sorted(points, key=lambda p: p.bytes_resident)
+    if len(sorted_points) < 2:
+        return DetectedLevels()
+
+    transitions = _find_transition_indices(sorted_points)
+    # Plateau boundaries: [0, t1, t2, ..., tn, len]
+    bounds = [0] + transitions + [len(sorted_points)]
+    plateau_ranges = [
+        (bounds[i], bounds[i + 1])
+        for i in range(len(bounds) - 1)
+        if bounds[i + 1] > bounds[i]
+    ]
+
+    levels = DetectedLevels()
+    level_order = [CacheLevel.L1, CacheLevel.L2, CacheLevel.L3, CacheLevel.DRAM]
+
+    # Initialise every level to None
+    for lvl in level_order:
+        levels.levels[lvl] = None
+
+    for level, (start, end) in zip(level_order, plateau_ranges):
+        plateau_points = sorted_points[start:end]
+        if not plateau_points:
+            continue
+        levels.levels[level] = (
+            plateau_points[0].bytes_resident,
+            plateau_points[-1].bytes_resident,
+        )
+    return levels
+
+
+# --------------------------------------------------------------------
+# Per-level energy estimation
+# --------------------------------------------------------------------
+
+def estimate_per_level_energy(
+    points: Sequence[WorkingSetPoint],
+    levels: Optional[DetectedLevels] = None,
+) -> PerLevelEnergy:
+    """Average bandwidth and per-byte energy across each plateau.
+
+    When ``levels`` is omitted, runs ``detect_levels`` first.
+    """
+    if levels is None:
+        levels = detect_levels(points)
+
+    sorted_points = sorted(points, key=lambda p: p.bytes_resident)
+    out = PerLevelEnergy()
+    for lvl in CacheLevel:
+        out.bandwidth_gbps[lvl] = None
+        out.energy_per_byte_pj[lvl] = None
+
+    for level, byte_range in levels.levels.items():
+        if byte_range is None:
+            continue
+        lo, hi = byte_range
+        plateau = [
+            p for p in sorted_points if lo <= p.bytes_resident <= hi
+        ]
+        if not plateau:
+            continue
+
+        bws = [p.bandwidth_gbps for p in plateau if p.bandwidth_gbps > 0]
+        if bws:
+            out.bandwidth_gbps[level] = sum(bws) / len(bws)
+
+        epbs = [
+            p.energy_per_byte_pj for p in plateau
+            if p.energy_per_byte_pj is not None
+        ]
+        if epbs:
+            out.energy_per_byte_pj[level] = sum(epbs) / len(epbs)
+
+    return out
+
+
+__all__ = [
+    "CacheLevel",
+    "DetectedLevels",
+    "PerLevelEnergy",
+    "detect_levels",
+    "estimate_per_level_energy",
+]

--- a/src/graphs/benchmarks/cache_sweep/working_set_sweep.py
+++ b/src/graphs/benchmarks/cache_sweep/working_set_sweep.py
@@ -94,7 +94,15 @@ class _RAPLProbe:
         self._path = Path(
             f"/sys/class/powercap/{zone}/energy_uj"
         )
-        self._available = self._path.exists() and self._path.is_file()
+        # Existence alone isn't enough: on some kernels the RAPL sysfs
+        # node is root-only and exists() returns True for an
+        # unreadable file. Mirror RAPLPowerCollector's behaviour and
+        # try an actual read.
+        try:
+            self._path.read_text()
+            self._available = True
+        except (OSError, ValueError):
+            self._available = False
 
     @property
     def available(self) -> bool:
@@ -108,6 +116,16 @@ class _RAPLProbe:
         except (OSError, ValueError):
             return None
         return uj / 1e6  # joules
+
+
+def rapl_available(zone: str = "intel-rapl:0") -> bool:
+    """Return True when the named RAPL zone is readable.
+
+    Public helper for CLI / external callers that need to detect
+    energy-capture availability without instantiating the private
+    probe class.
+    """
+    return _RAPLProbe(zone=zone).available
 
 
 # --------------------------------------------------------------------
@@ -190,6 +208,7 @@ def run_sweep(
         # Repeats: take the min wallclock + average energy
         best_elapsed = float("inf")
         energy_samples: List[float] = []
+        energy_wraps = 0
         for _ in range(config.repeats_per_point):
             energy_start = rapl.sample() if rapl_ok else None
             t0 = time.perf_counter()
@@ -200,9 +219,14 @@ def run_sweep(
             if elapsed < best_elapsed:
                 best_elapsed = elapsed
             if (energy_start is not None
-                    and energy_end is not None
-                    and energy_end >= energy_start):
-                energy_samples.append(energy_end - energy_start)
+                    and energy_end is not None):
+                if energy_end >= energy_start:
+                    energy_samples.append(energy_end - energy_start)
+                else:
+                    # RAPL counter wrapped during the measurement
+                    # interval. Drop the sample but surface the count
+                    # so the operator can spot pathological cases.
+                    energy_wraps += 1
 
         bytes_streamed = float(size) * iters
         bandwidth_gbps = (
@@ -229,6 +253,7 @@ def run_sweep(
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "rapl_available": rapl_ok,
                 "repeats": config.repeats_per_point,
+                "energy_wraps": energy_wraps,
             },
         )
 
@@ -237,4 +262,5 @@ __all__ = [
     "SweepConfig",
     "WorkingSetPoint",
     "run_sweep",
+    "rapl_available",
 ]

--- a/src/graphs/benchmarks/cache_sweep/working_set_sweep.py
+++ b/src/graphs/benchmarks/cache_sweep/working_set_sweep.py
@@ -1,0 +1,240 @@
+"""
+Working-set-size sweep for cache-bandwidth measurement.
+
+Logarithmic sweep over buffer sizes from L1-fitting (8 KiB) to
+deep-DRAM (64 MiB by default). For each size, runs a stream-style
+kernel for a target wallclock duration and emits effective
+bandwidth + measured energy when available.
+
+The resulting curve has plateaus at L1, L2, L3, and DRAM with
+transition steps at the cache capacity boundaries. The transition
+points are interpreted by ``cache_sweep.analysis.detect_levels``.
+
+Energy capture is best-effort:
+- On Linux x86, RAPL is read via ``/sys/class/powercap/intel-rapl``.
+- On other platforms (or when RAPL is unavailable), the sweep
+  reports ``energy_joules=None`` and downstream analysis falls back
+  to the analytical TechnologyProfile estimate. The CLI emits a
+  clear warning so the operator knows the result is time-only.
+"""
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+try:
+    import numpy as np
+    _HAVE_NUMPY = True
+except ImportError:
+    np = None  # type: ignore
+    _HAVE_NUMPY = False
+
+
+# Default sweep range: 8 KiB up to 64 MiB. Covers L1 (~32-48 KiB),
+# L2 (~256 KiB - 2 MiB), L3 (~16 - 64 MiB), and a few points into
+# DRAM. Log-spaced so the bandwidth curve has comparable resolution
+# at each level.
+_DEFAULT_MIN_BYTES = 8 * 1024
+_DEFAULT_MAX_BYTES = 64 * 1024 * 1024
+_DEFAULT_POINTS = 24
+
+
+@dataclass
+class SweepConfig:
+    """Parameters for a working-set-size sweep."""
+    min_bytes: int = _DEFAULT_MIN_BYTES
+    max_bytes: int = _DEFAULT_MAX_BYTES
+    num_points: int = _DEFAULT_POINTS
+    target_seconds_per_point: float = 0.5  # wallclock per size point
+    repeats_per_point: int = 3              # take min latency over N runs
+    capture_energy: bool = True             # try RAPL on Linux x86
+    rapl_zone: str = "intel-rapl:0"         # package energy zone
+
+    def working_set_sizes(self) -> List[int]:
+        """Log-spaced byte counts spanning the configured range."""
+        if self.num_points < 2:
+            return [self.min_bytes]
+        log_min = math.log2(self.min_bytes)
+        log_max = math.log2(self.max_bytes)
+        return [
+            int(round(2 ** (log_min + i * (log_max - log_min)
+                            / (self.num_points - 1))))
+            for i in range(self.num_points)
+        ]
+
+
+@dataclass
+class WorkingSetPoint:
+    """One (working_set_size, bandwidth, energy) measurement."""
+    bytes_resident: int            # working-set size in bytes
+    iterations: int                # times the buffer was streamed
+    elapsed_seconds: float         # min wallclock across repeats
+    bandwidth_gbps: float          # bytes_resident * iterations / elapsed
+    energy_joules: Optional[float] = None
+    energy_per_byte_pj: Optional[float] = None
+    extra: dict = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------
+# RAPL energy probe
+# --------------------------------------------------------------------
+
+class _RAPLProbe:
+    """Read package energy from /sys/class/powercap/intel-rapl.
+
+    Returns ``None`` from ``sample()`` when RAPL is unavailable or the
+    counter wraps. Best-effort -- the caller treats ``None`` as
+    "no energy capture available."
+    """
+    def __init__(self, zone: str = "intel-rapl:0"):
+        self._path = Path(
+            f"/sys/class/powercap/{zone}/energy_uj"
+        )
+        self._available = self._path.exists() and self._path.is_file()
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    def sample(self) -> Optional[float]:
+        if not self._available:
+            return None
+        try:
+            uj = int(self._path.read_text().strip())
+        except (OSError, ValueError):
+            return None
+        return uj / 1e6  # joules
+
+
+# --------------------------------------------------------------------
+# Stream kernel
+# --------------------------------------------------------------------
+
+def _stream_once(buf, iterations: int) -> None:
+    """Touch every byte of ``buf`` ``iterations`` times.
+
+    Uses an in-place bitwise XOR (``np.bitwise_xor(buf, 1, out=buf)``)
+    rather than a sum-reduce: in-place ops do a full read + write pass
+    over every element with no side-allocation, and an XOR with 1
+    cannot be optimised away because the result is observable
+    (the buffer mutates between iterations). On modern CPUs this
+    saturates the cache / memory bandwidth at every working-set size,
+    which is what makes the L1 / L2 / L3 / DRAM plateaus visible in
+    the bandwidth-vs-size curve.
+
+    A pure ``np.add.reduce`` was tried first but is dominated by
+    NumPy call overhead on sub-megabyte buffers, masking the cache
+    transitions.
+    """
+    for _ in range(iterations):
+        np.bitwise_xor(buf, 1, out=buf)
+
+
+def _calibrate_iterations(buf, target_seconds: float) -> int:
+    """Find an iteration count that hits ~target_seconds for ``buf``.
+
+    Doubles the iteration count until the kernel takes at least
+    ``target_seconds / 8``, then projects the iteration count so the
+    measurement loop targets ``target_seconds``. Single-shot
+    measurement at the projected count goes back to the caller.
+    """
+    iters = 1
+    elapsed = 0.0
+    while elapsed < target_seconds / 8 and iters < 1 << 20:
+        t0 = time.perf_counter()
+        _stream_once(buf, iters)
+        elapsed = time.perf_counter() - t0
+        if elapsed < target_seconds / 8:
+            iters *= 2
+    if elapsed <= 0:
+        return iters
+    return max(1, int(iters * target_seconds / elapsed))
+
+
+# --------------------------------------------------------------------
+# Main sweep entry point
+# --------------------------------------------------------------------
+
+def run_sweep(
+    config: Optional[SweepConfig] = None,
+) -> Iterator[WorkingSetPoint]:
+    """Run the working-set-size sweep and yield per-point results.
+
+    Streaming generator so the CLI can checkpoint each point as it
+    completes -- a 24-point sweep at 0.5 s / point is ~24 s of useful
+    work, but a few points may take longer on slow systems.
+
+    Raises ``ImportError`` if NumPy is unavailable; the kernel is
+    NumPy-vectorised by construction.
+    """
+    if not _HAVE_NUMPY:
+        raise ImportError(
+            "cache_sweep requires NumPy. Install it with `pip install numpy`."
+        )
+    if config is None:
+        config = SweepConfig()
+
+    rapl = _RAPLProbe(zone=config.rapl_zone) if config.capture_energy else None
+    rapl_ok = rapl is not None and rapl.available
+
+    for size in config.working_set_sizes():
+        # int8 array sized exactly to the working-set target. NumPy
+        # arrays are 64-byte aligned by default -> cache lines align.
+        buf = np.zeros(size, dtype=np.int8)
+        iters = _calibrate_iterations(buf, config.target_seconds_per_point)
+
+        # Repeats: take the min wallclock + average energy
+        best_elapsed = float("inf")
+        energy_samples: List[float] = []
+        for _ in range(config.repeats_per_point):
+            energy_start = rapl.sample() if rapl_ok else None
+            t0 = time.perf_counter()
+            _stream_once(buf, iters)
+            elapsed = time.perf_counter() - t0
+            energy_end = rapl.sample() if rapl_ok else None
+
+            if elapsed < best_elapsed:
+                best_elapsed = elapsed
+            if (energy_start is not None
+                    and energy_end is not None
+                    and energy_end >= energy_start):
+                energy_samples.append(energy_end - energy_start)
+
+        bytes_streamed = float(size) * iters
+        bandwidth_gbps = (
+            bytes_streamed / best_elapsed / 1e9
+            if best_elapsed > 0 else 0.0
+        )
+        energy_j = (
+            sum(energy_samples) / len(energy_samples)
+            if energy_samples else None
+        )
+        energy_per_byte_pj = (
+            (energy_j / bytes_streamed) * 1e12
+            if energy_j is not None and bytes_streamed > 0 else None
+        )
+
+        yield WorkingSetPoint(
+            bytes_resident=size,
+            iterations=iters,
+            elapsed_seconds=best_elapsed,
+            bandwidth_gbps=bandwidth_gbps,
+            energy_joules=energy_j,
+            energy_per_byte_pj=energy_per_byte_pj,
+            extra={
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "rapl_available": rapl_ok,
+                "repeats": config.repeats_per_point,
+            },
+        )
+
+
+__all__ = [
+    "SweepConfig",
+    "WorkingSetPoint",
+    "run_sweep",
+]

--- a/src/graphs/calibration/fitters/cache_sweep_fitter.py
+++ b/src/graphs/calibration/fitters/cache_sweep_fitter.py
@@ -34,13 +34,12 @@ Design notes:
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Dict, Optional, Sequence
+from dataclasses import dataclass
+from typing import Optional, Sequence
 
 from graphs.benchmarks.cache_sweep.analysis import (
     CacheLevel,
     DetectedLevels,
-    PerLevelEnergy,
     detect_levels,
     estimate_per_level_energy,
 )

--- a/src/graphs/calibration/fitters/cache_sweep_fitter.py
+++ b/src/graphs/calibration/fitters/cache_sweep_fitter.py
@@ -1,0 +1,171 @@
+"""
+Cache-sweep fitter (Path B PR-1).
+
+Consumes the output of ``graphs.benchmarks.cache_sweep.run_sweep``
+and writes per-cache-level calibrated coefficients into a
+``HardwareResourceModel``'s ``field_provenance`` map.
+
+Fields written (when the corresponding plateau was detected with a
+non-None per-byte energy):
+
+  - ``l1_cache_energy_per_byte`` -> CALIBRATED
+  - ``l2_cache_energy_per_byte`` -> CALIBRATED
+  - ``l3_cache_energy_per_byte`` -> CALIBRATED
+
+Fields stay at THEORETICAL when:
+  - the corresponding plateau wasn't found
+  - RAPL was unavailable (energy column is None)
+
+In both cases the panel renders the analytical TechnologyProfile
+default and surfaces the THEORETICAL badge -- matching the pattern
+established in M3-M5.
+
+Design notes:
+
+- The fitter does NOT mutate the energy model directly. It writes
+  to ``field_provenance`` so the existing panel readers can pick
+  up the upgrade. Future PRs may add a dedicated apply-to-tech-
+  profile path; for now the calibrated values surface in the panel
+  notes / metrics.
+
+- Bandwidth values are recorded in ``provenance.source`` rather
+  than overwriting any field, since the resource model has no
+  per-level effective-bandwidth field today.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Sequence
+
+from graphs.benchmarks.cache_sweep.analysis import (
+    CacheLevel,
+    DetectedLevels,
+    PerLevelEnergy,
+    detect_levels,
+    estimate_per_level_energy,
+)
+from graphs.benchmarks.cache_sweep.working_set_sweep import WorkingSetPoint
+from graphs.core.confidence import EstimationConfidence
+
+
+# Map cache-sweep CacheLevel -> resource_model field name we tag.
+_LEVEL_TO_FIELD = {
+    CacheLevel.L1: "l1_cache_energy_per_byte",
+    CacheLevel.L2: "l2_cache_energy_per_byte",
+    CacheLevel.L3: "l3_cache_energy_per_byte",
+}
+
+
+@dataclass
+class CacheFitResult:
+    """Fitted per-cache-level coefficients ready to apply."""
+
+    sku_name: str = ""
+
+    # Calibrated per-byte energies from the sweep (pJ/byte).
+    # None when the level had no plateau or no energy capture.
+    l1_energy_per_byte_pj: Optional[float] = None
+    l2_energy_per_byte_pj: Optional[float] = None
+    l3_energy_per_byte_pj: Optional[float] = None
+
+    # Effective bandwidth per level (GB/s); kept for reporting.
+    l1_bandwidth_gbps: Optional[float] = None
+    l2_bandwidth_gbps: Optional[float] = None
+    l3_bandwidth_gbps: Optional[float] = None
+
+    # Plateaus actually detected (range of working-set sizes).
+    detected: Optional[DetectedLevels] = None
+
+    # Number of sweep points consumed.
+    num_points: int = 0
+
+
+class CacheSweepFitter:
+    """
+    Fit per-cache-level coefficients from a working-set sweep.
+
+    Mirrors the M1 / M2 fitter shape: ``fit`` produces a
+    ``CacheFitResult``; ``apply_to_model`` writes CALIBRATED
+    provenance entries into the resource model's
+    ``field_provenance``.
+    """
+
+    def fit(
+        self,
+        points: Sequence[WorkingSetPoint],
+        sku_name: str = "",
+    ) -> CacheFitResult:
+        levels = detect_levels(points)
+        per_level = estimate_per_level_energy(points, levels=levels)
+
+        result = CacheFitResult(
+            sku_name=sku_name,
+            num_points=len(points),
+            detected=levels,
+        )
+
+        # Bandwidth (always available when a plateau exists)
+        result.l1_bandwidth_gbps = per_level.bandwidth_gbps.get(CacheLevel.L1)
+        result.l2_bandwidth_gbps = per_level.bandwidth_gbps.get(CacheLevel.L2)
+        result.l3_bandwidth_gbps = per_level.bandwidth_gbps.get(CacheLevel.L3)
+
+        # Energy (None when RAPL was unavailable)
+        result.l1_energy_per_byte_pj = (
+            per_level.energy_per_byte_pj.get(CacheLevel.L1)
+        )
+        result.l2_energy_per_byte_pj = (
+            per_level.energy_per_byte_pj.get(CacheLevel.L2)
+        )
+        result.l3_energy_per_byte_pj = (
+            per_level.energy_per_byte_pj.get(CacheLevel.L3)
+        )
+        return result
+
+    @staticmethod
+    def apply_to_model(
+        resource_model: object,
+        fit_result: CacheFitResult,
+    ) -> None:
+        """Write CALIBRATED provenance for every level the fit
+        returned a non-None per-byte energy for. Levels without an
+        energy capture stay at their pre-existing provenance.
+        """
+        if not hasattr(resource_model, "set_provenance"):
+            return
+
+        per_level_energies = {
+            CacheLevel.L1: fit_result.l1_energy_per_byte_pj,
+            CacheLevel.L2: fit_result.l2_energy_per_byte_pj,
+            CacheLevel.L3: fit_result.l3_energy_per_byte_pj,
+        }
+        per_level_bandwidth = {
+            CacheLevel.L1: fit_result.l1_bandwidth_gbps,
+            CacheLevel.L2: fit_result.l2_bandwidth_gbps,
+            CacheLevel.L3: fit_result.l3_bandwidth_gbps,
+        }
+
+        for level, pj_per_byte in per_level_energies.items():
+            if pj_per_byte is None:
+                continue
+            field_name = _LEVEL_TO_FIELD[level]
+            bw = per_level_bandwidth.get(level)
+            source_parts = [
+                f"cache_sweep_fitter/{fit_result.sku_name or 'unknown'}",
+                f"{pj_per_byte:.3f} pJ/byte",
+            ]
+            if bw is not None:
+                source_parts.append(f"{bw:.1f} GB/s effective")
+            source_parts.append(f"{fit_result.num_points} sweep points")
+            resource_model.set_provenance(
+                field_name,
+                EstimationConfidence.calibrated(
+                    score=0.85,
+                    source="; ".join(source_parts),
+                ),
+            )
+
+
+__all__ = [
+    "CacheFitResult",
+    "CacheSweepFitter",
+]

--- a/tests/benchmarks/test_cache_sweep.py
+++ b/tests/benchmarks/test_cache_sweep.py
@@ -7,11 +7,8 @@ synthetic curves with known plateau structure.
 """
 from __future__ import annotations
 
-import pytest
-
 from graphs.benchmarks.cache_sweep import (
     CacheLevel,
-    PerLevelEnergy,
     SweepConfig,
     WorkingSetPoint,
     detect_levels,

--- a/tests/benchmarks/test_cache_sweep.py
+++ b/tests/benchmarks/test_cache_sweep.py
@@ -1,0 +1,216 @@
+"""Tests for the cache_sweep analysis (Path B PR-1).
+
+Hardware-touching code paths (`run_sweep`, RAPL probe) are not
+exercised in CI -- they're nondeterministic and depend on hardware
+energy counters. Instead we test the pure-analysis logic against
+synthetic curves with known plateau structure.
+"""
+from __future__ import annotations
+
+import pytest
+
+from graphs.benchmarks.cache_sweep import (
+    CacheLevel,
+    PerLevelEnergy,
+    SweepConfig,
+    WorkingSetPoint,
+    detect_levels,
+    estimate_per_level_energy,
+)
+
+
+def _point(bytes_resident: int, bandwidth: float,
+           energy_pj: float = None) -> WorkingSetPoint:
+    return WorkingSetPoint(
+        bytes_resident=bytes_resident,
+        iterations=1,
+        elapsed_seconds=0.1,
+        bandwidth_gbps=bandwidth,
+        energy_per_byte_pj=energy_pj,
+    )
+
+
+# A canonical synthetic curve that mimics a CPU with clean
+# transitions. L1 ~32 KiB, L2 ~1 MiB, L3 ~16 MiB.
+_CANONICAL_I7 = [
+    _point(8 * 1024,    200.0, 0.20),
+    _point(32 * 1024,   200.0, 0.20),
+    _point(256 * 1024,   80.0, 0.50),  # L2 transition (200 -> 80 = 2.5x)
+    _point(1024 * 1024,  80.0, 0.50),
+    _point(4 * 1024**2,  35.0, 1.20),  # L3 transition (80 -> 35 = 2.3x)
+    _point(16 * 1024**2, 35.0, 1.20),
+    _point(64 * 1024**2,  8.0, 15.0),  # DRAM transition (35 -> 8 = 4.4x)
+]
+
+
+# --------------------------------------------------------------------
+# SweepConfig sanity
+# --------------------------------------------------------------------
+
+class TestSweepConfig:
+    def test_default_size_range_log_spaced(self):
+        cfg = SweepConfig()
+        sizes = cfg.working_set_sizes()
+        assert len(sizes) == cfg.num_points
+        assert sizes[0] == cfg.min_bytes
+        assert sizes[-1] == cfg.max_bytes
+        # Log-spaced -> consecutive ratios approximately equal
+        ratios = [sizes[i+1] / sizes[i] for i in range(len(sizes) - 1)]
+        avg = sum(ratios) / len(ratios)
+        for r in ratios:
+            assert abs(r / avg - 1.0) < 0.1, (
+                "Sizes should be log-uniform"
+            )
+
+    def test_custom_range(self):
+        cfg = SweepConfig(min_bytes=1024, max_bytes=1024 * 1024,
+                          num_points=11)
+        sizes = cfg.working_set_sizes()
+        assert sizes[0] == 1024
+        assert sizes[-1] == 1024 * 1024
+        assert len(sizes) == 11
+
+    def test_single_point_returns_min(self):
+        cfg = SweepConfig(num_points=1, min_bytes=4096)
+        assert cfg.working_set_sizes() == [4096]
+
+
+# --------------------------------------------------------------------
+# Plateau detection
+# --------------------------------------------------------------------
+
+class TestPlateauDetection:
+    def test_canonical_curve_finds_four_plateaus(self):
+        levels = detect_levels(_CANONICAL_I7)
+        # Every level should be detected
+        assert levels.levels[CacheLevel.L1] is not None
+        assert levels.levels[CacheLevel.L2] is not None
+        assert levels.levels[CacheLevel.L3] is not None
+        assert levels.levels[CacheLevel.DRAM] is not None
+
+    def test_plateaus_are_byte_ranges_in_order(self):
+        levels = detect_levels(_CANONICAL_I7)
+        l1_lo, l1_hi = levels.levels[CacheLevel.L1]
+        l2_lo, l2_hi = levels.levels[CacheLevel.L2]
+        l3_lo, l3_hi = levels.levels[CacheLevel.L3]
+        dram_lo, _ = levels.levels[CacheLevel.DRAM]
+        assert l1_hi <= l2_lo
+        assert l2_hi <= l3_lo
+        assert l3_hi <= dram_lo
+
+    def test_flat_curve_yields_single_plateau(self):
+        """A curve with no transitions should produce one plateau
+        (assigned to L1) and leave L2/L3/DRAM as None."""
+        flat = [
+            _point(8 * 1024,    100.0),
+            _point(64 * 1024,   100.0),
+            _point(1024 * 1024, 100.0),
+        ]
+        levels = detect_levels(flat)
+        assert levels.levels[CacheLevel.L1] is not None
+        assert levels.levels[CacheLevel.L2] is None
+        assert levels.levels[CacheLevel.L3] is None
+        assert levels.levels[CacheLevel.DRAM] is None
+
+    def test_only_two_plateaus_assigns_l1_l2(self):
+        two_step = [
+            _point(8 * 1024,    100.0),
+            _point(32 * 1024,   100.0),
+            _point(1024 * 1024, 50.0),    # only one transition
+            _point(16 * 1024**2, 50.0),
+        ]
+        levels = detect_levels(two_step)
+        assert levels.levels[CacheLevel.L1] is not None
+        assert levels.levels[CacheLevel.L2] is not None
+        assert levels.levels[CacheLevel.L3] is None
+        assert levels.levels[CacheLevel.DRAM] is None
+
+    def test_empty_input(self):
+        levels = detect_levels([])
+        assert levels.levels == {} or all(
+            v is None for v in levels.levels.values()
+        )
+
+    def test_single_point_input(self):
+        levels = detect_levels([_point(8192, 100.0)])
+        assert levels.levels == {} or all(
+            v is None for v in levels.levels.values()
+        )
+
+    def test_transition_threshold_resists_noise(self):
+        """A 5-10% bandwidth wobble within a plateau must not register
+        as a transition (the threshold is 1.2x)."""
+        wobbly = [
+            _point(8 * 1024,   100.0),
+            _point(32 * 1024,   95.0),  # 5% drop
+            _point(64 * 1024,  102.0),  # 7% rise
+            _point(256 * 1024,  98.0),  # 4% drop
+        ]
+        levels = detect_levels(wobbly)
+        # All four points should be in the L1 plateau
+        l1_lo, l1_hi = levels.levels[CacheLevel.L1]
+        assert l1_lo == 8 * 1024 and l1_hi == 256 * 1024
+        assert levels.levels[CacheLevel.L2] is None
+
+
+# --------------------------------------------------------------------
+# Per-level energy estimation
+# --------------------------------------------------------------------
+
+class TestPerLevelEnergy:
+    def test_canonical_curve_recovers_energy(self):
+        ee = estimate_per_level_energy(_CANONICAL_I7)
+        assert ee.energy_per_byte_pj[CacheLevel.L1] == 0.20
+        assert ee.energy_per_byte_pj[CacheLevel.L2] == 0.50
+        assert ee.energy_per_byte_pj[CacheLevel.L3] == 1.20
+        assert ee.energy_per_byte_pj[CacheLevel.DRAM] == 15.0
+
+    def test_canonical_curve_recovers_bandwidth(self):
+        ee = estimate_per_level_energy(_CANONICAL_I7)
+        assert ee.bandwidth_gbps[CacheLevel.L1] == 200.0
+        assert ee.bandwidth_gbps[CacheLevel.L2] == 80.0
+        assert ee.bandwidth_gbps[CacheLevel.L3] == 35.0
+        assert ee.bandwidth_gbps[CacheLevel.DRAM] == 8.0
+
+    def test_no_energy_capture_yields_none(self):
+        """When every point has energy_per_byte_pj=None (RAPL
+        unavailable), per-level energy is None but bandwidth is
+        still populated."""
+        no_energy = [
+            _point(8 * 1024,   200.0, None),
+            _point(64 * 1024,  200.0, None),
+            _point(1024 * 1024, 80.0, None),
+        ]
+        ee = estimate_per_level_energy(no_energy)
+        assert ee.energy_per_byte_pj[CacheLevel.L1] is None
+        assert ee.energy_per_byte_pj[CacheLevel.L2] is None
+        assert ee.bandwidth_gbps[CacheLevel.L1] == 200.0
+        assert ee.bandwidth_gbps[CacheLevel.L2] == 80.0
+
+    def test_has_calibrated_energy_predicate(self):
+        ee = estimate_per_level_energy(_CANONICAL_I7)
+        assert ee.has_calibrated_energy(CacheLevel.L1)
+        assert ee.has_calibrated_energy(CacheLevel.DRAM)
+
+        no_energy = [_point(8 * 1024, 100.0, None)]
+        ee2 = estimate_per_level_energy(no_energy)
+        assert not ee2.has_calibrated_energy(CacheLevel.L1)
+
+
+# --------------------------------------------------------------------
+# Mixed-energy edge cases
+# --------------------------------------------------------------------
+
+class TestMixedEnergy:
+    def test_partial_energy_capture(self):
+        """Some points have energy, some don't (counter wrap mid-sweep)."""
+        mixed = [
+            _point(8 * 1024,   200.0, 0.20),
+            _point(32 * 1024,  200.0, None),  # missing
+            _point(256 * 1024,  80.0, 0.50),
+            _point(1024 * 1024, 80.0, None),  # missing
+        ]
+        ee = estimate_per_level_energy(mixed)
+        # L1 plateau: only one point with energy -> use it
+        assert ee.energy_per_byte_pj[CacheLevel.L1] == 0.20
+        assert ee.energy_per_byte_pj[CacheLevel.L2] == 0.50

--- a/tests/benchmarks/test_cache_sweep.py
+++ b/tests/benchmarks/test_cache_sweep.py
@@ -7,6 +7,8 @@ synthetic curves with known plateau structure.
 """
 from __future__ import annotations
 
+from typing import Optional
+
 from graphs.benchmarks.cache_sweep import (
     CacheLevel,
     SweepConfig,
@@ -17,7 +19,7 @@ from graphs.benchmarks.cache_sweep import (
 
 
 def _point(bytes_resident: int, bandwidth: float,
-           energy_pj: float = None) -> WorkingSetPoint:
+           energy_pj: Optional[float] = None) -> WorkingSetPoint:
     return WorkingSetPoint(
         bytes_resident=bytes_resident,
         iterations=1,

--- a/tests/calibration/test_cache_sweep_fitter.py
+++ b/tests/calibration/test_cache_sweep_fitter.py
@@ -1,6 +1,8 @@
 """Tests for CacheSweepFitter (Path B PR-1)."""
 from __future__ import annotations
 
+from typing import Optional
+
 from graphs.benchmarks.cache_sweep import WorkingSetPoint
 from graphs.calibration.fitters.cache_sweep_fitter import (
     CacheFitResult,
@@ -10,7 +12,7 @@ from graphs.core.confidence import ConfidenceLevel
 
 
 def _point(bytes_resident: int, bandwidth: float,
-           energy_pj: float = None) -> WorkingSetPoint:
+           energy_pj: Optional[float] = None) -> WorkingSetPoint:
     return WorkingSetPoint(
         bytes_resident=bytes_resident,
         iterations=1,

--- a/tests/calibration/test_cache_sweep_fitter.py
+++ b/tests/calibration/test_cache_sweep_fitter.py
@@ -1,0 +1,125 @@
+"""Tests for CacheSweepFitter (Path B PR-1)."""
+from __future__ import annotations
+
+from graphs.benchmarks.cache_sweep import WorkingSetPoint
+from graphs.calibration.fitters.cache_sweep_fitter import (
+    CacheFitResult,
+    CacheSweepFitter,
+)
+from graphs.core.confidence import ConfidenceLevel
+
+
+def _point(bytes_resident: int, bandwidth: float,
+           energy_pj: float = None) -> WorkingSetPoint:
+    return WorkingSetPoint(
+        bytes_resident=bytes_resident,
+        iterations=1,
+        elapsed_seconds=0.1,
+        bandwidth_gbps=bandwidth,
+        energy_per_byte_pj=energy_pj,
+    )
+
+
+_CANONICAL = [
+    _point(8 * 1024,    200.0, 0.20),
+    _point(32 * 1024,   200.0, 0.20),
+    _point(256 * 1024,   80.0, 0.50),
+    _point(1024 * 1024,  80.0, 0.50),
+    _point(4 * 1024**2,  35.0, 1.20),
+    _point(16 * 1024**2, 35.0, 1.20),
+    _point(64 * 1024**2,  8.0, 15.0),
+]
+
+
+class _StubModel:
+    """Minimal HardwareResourceModel stand-in for testing
+    apply_to_model without pulling in the full dataclass."""
+
+    def __init__(self):
+        self.field_provenance = {}
+
+    def set_provenance(self, name, conf):
+        self.field_provenance[name] = conf
+
+
+class TestCacheSweepFitter:
+    def test_fit_returns_per_level_energies(self):
+        result = CacheSweepFitter().fit(_CANONICAL, sku_name="i7-12700k")
+        assert isinstance(result, CacheFitResult)
+        assert result.l1_energy_per_byte_pj == 0.20
+        assert result.l2_energy_per_byte_pj == 0.50
+        assert result.l3_energy_per_byte_pj == 1.20
+        assert result.l1_bandwidth_gbps == 200.0
+        assert result.l2_bandwidth_gbps == 80.0
+        assert result.l3_bandwidth_gbps == 35.0
+        assert result.num_points == len(_CANONICAL)
+
+    def test_fit_records_sku_name(self):
+        result = CacheSweepFitter().fit(_CANONICAL, sku_name="i7-12700k")
+        assert result.sku_name == "i7-12700k"
+
+    def test_apply_to_model_writes_calibrated(self):
+        model = _StubModel()
+        result = CacheSweepFitter().fit(_CANONICAL, sku_name="i7-12700k")
+        CacheSweepFitter.apply_to_model(model, result)
+
+        for field in ("l1_cache_energy_per_byte",
+                      "l2_cache_energy_per_byte",
+                      "l3_cache_energy_per_byte"):
+            assert field in model.field_provenance
+            conf = model.field_provenance[field]
+            assert conf.level is ConfidenceLevel.CALIBRATED
+            assert "cache_sweep_fitter" in conf.source
+
+    def test_apply_to_model_skips_levels_without_energy(self):
+        """When RAPL is unavailable for some levels, only the levels
+        with measured energy get tagged CALIBRATED; the rest stay
+        at whatever the model already had (THEORETICAL by default)."""
+        no_energy = [
+            _point(8 * 1024,   200.0, None),   # L1: no energy
+            _point(32 * 1024,  200.0, None),
+            _point(256 * 1024,  80.0, 0.50),   # L2: has energy
+            _point(4 * 1024**2, 35.0, 1.20),   # L3: has energy
+        ]
+        model = _StubModel()
+        result = CacheSweepFitter().fit(no_energy, sku_name="x")
+        CacheSweepFitter.apply_to_model(model, result)
+
+        assert "l1_cache_energy_per_byte" not in model.field_provenance
+        assert "l2_cache_energy_per_byte" in model.field_provenance
+        assert "l3_cache_energy_per_byte" in model.field_provenance
+
+    def test_provenance_source_includes_bandwidth_and_point_count(self):
+        model = _StubModel()
+        result = CacheSweepFitter().fit(_CANONICAL, sku_name="i7-12700k")
+        CacheSweepFitter.apply_to_model(model, result)
+        src = model.field_provenance["l1_cache_energy_per_byte"].source
+        assert "i7-12700k" in src
+        assert "200" in src or "0.2" in src or "GB/s" in src
+        assert "sweep points" in src
+
+    def test_apply_handles_model_without_set_provenance(self):
+        """Models that don't expose set_provenance (legacy paths)
+        should not crash apply_to_model."""
+
+        class Legacy:
+            pass
+
+        result = CacheSweepFitter().fit(_CANONICAL, sku_name="x")
+        CacheSweepFitter.apply_to_model(Legacy(), result)  # no exception
+
+
+class TestNoCalibration:
+    def test_empty_sweep_returns_empty_result(self):
+        result = CacheSweepFitter().fit([], sku_name="x")
+        assert result.l1_energy_per_byte_pj is None
+        assert result.l2_energy_per_byte_pj is None
+        assert result.l3_energy_per_byte_pj is None
+        assert result.num_points == 0
+
+    def test_empty_sweep_apply_writes_nothing(self):
+        model = _StubModel()
+        CacheSweepFitter.apply_to_model(
+            model, CacheSweepFitter().fit([], sku_name="x")
+        )
+        assert model.field_provenance == {}


### PR DESCRIPTION
## Summary
- Working-set-size sweep that streams an in-place NumPy XOR kernel over a log-spaced range (8 KiB → 64 MiB by default), recording per-point bandwidth + RAPL energy when available.
- Plateau detector identifies L1 / L2 / L3 / DRAM regions from the bandwidth curve.
- Fitter consumes the sweep output and writes CALIBRATED `EstimationConfidence` for `l1_cache_energy_per_byte`, `l2_cache_energy_per_byte`, `l3_cache_energy_per_byte` on a `HardwareResourceModel` via the existing `set_provenance` API.
- CLI runner persists results to JSON for downstream consumption.

This is Path B PR-1 of the calibration plan -- the highest-leverage path to bringing the Orin AGX MAPE down from ~60% (Path A finding) toward the i7's ~5%.

## Empirical validation
Real run on i7-12700K (16-point sweep, 0.3 s/point):

```
running cache_sweep on intel_core_i7_12700k: 16 points in [8 KiB, 64 MiB]
  [ 8/16]     549084 B    77.1 GB/s    <- peak L1/L2 plateau
  [ 9/16]    1001224 B    48.0 GB/s    <- L2 -> L3 transition
  [13/16]   11068835 B    33.0 GB/s    <- L3 plateau
  [16/16]   67108864 B    19.6 GB/s    <- DRAM plateau
```

Detector finds 4 plateaus with the 1.2x threshold; all three calibrated cache levels get CALIBRATED provenance.

## Files

| File | What |
|---|---|
| `src/graphs/benchmarks/cache_sweep/working_set_sweep.py` | **New.** Log-spaced sweep + in-place XOR kernel + RAPL probe. Streaming generator with per-point checkpoint. |
| `src/graphs/benchmarks/cache_sweep/analysis.py` | **New.** Plateau detection + per-level energy/bandwidth aggregation. |
| `src/graphs/calibration/fitters/cache_sweep_fitter.py` | **New.** `CacheSweepFitter.fit/apply_to_model` mirroring the M1/M2 fitter shape. |
| `cli/run_cache_sweep.py` | **New.** Runner. `--hardware <sku> --output <json>` plus tunables (num-points, seconds-per-point, repeats, no-energy, rapl-zone). |
| `tests/benchmarks/test_cache_sweep.py` | **New.** 15 tests on synthetic curves (no hardware in CI). |
| `tests/calibration/test_cache_sweep_fitter.py` | **New.** 8 tests on the fitter; uses a stub model. |
| `docs/calibration/cache_sweep.md` | **New.** How-to: hardware requirements, RAPL access, expected runtime, output schema, apply-to-model recipe. |

## Design choices

- **In-place XOR kernel** beats sum-reduce. `np.add.reduce(buf)` is dominated by Python call overhead on sub-megabyte buffers, masking the cache transitions. `np.bitwise_xor(buf, 1, out=buf)` saturates memory bandwidth at every working-set size and produces visible plateaus.
- **1.2x ratio threshold** for transition detection. Calibrated against a real i7 sweep where the L3 → DRAM step is only ~1.2x (the in-place kernel's write traffic stays coherent at the cache controller). Lower would fire on plateau noise; higher misses real transitions.
- **No hardware in CI.** All tests run on synthetic curves with known plateau structure.
- **Fitter writes provenance, not field values.** Per the M-series pattern, calibrated values flow through `field_provenance` rather than mutating `tech_profile.l*_cache_energy_per_byte_pj`. PR-2 will add the apply-CLI that persists fit results back into the in-tree resource models.

## Workflow this enables

```bash
# On i7-12700K (local, ~12 s + warmup):
python cli/run_cache_sweep.py --hardware intel_core_i7_12700k \
    --output sweeps/i7_12700k.json

# When PR-2 lands:
python cli/apply_calibration.py --input sweeps/i7_12700k.json \
    --sku intel_core_i7_12700k

# Path A revalidation: the per-SKU page now shows CALIBRATED for
# l3-l5 read energies on i7.
python cli/microarch_validation_report.py --with-validation
```

## Test results

| Suite | Result |
|---|---|
| `tests/benchmarks/test_cache_sweep.py` | **15 passed** |
| `tests/calibration/test_cache_sweep_fitter.py` | **8 passed** |
| Full unit suite | 1460 passed, 7 skipped, 1 xfailed |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Run `cli/run_cache_sweep.py` locally on i7 and inspect the JSON for sane plateau structure
- [x] When CI is green: `gh pr ready <#>`

## Next (PR-2)
- `cli/apply_calibration.py` — read a sweep JSON, locate the matching SKU resource model, persist the fit result back. Cross-validate measured DRAM bandwidth against the M7 `peak_bandwidth` field; surface the delta in the Layer 7 panel.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cache-sweep CLI command to benchmark bandwidth and energy across working-set sizes with JSON output.
  * Added an opt-in validation overlay comparing predicted latencies against measured model calibration data.

* **Documentation**
  * Documented cache-sweep microbenchmark workflow for calibrating per-cache-level energy coefficients.
  * Documented the validation measurement overlay feature and expected output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->