### PR TITLE
fix(roofline): model KPU weight stationarity in per-subgraph DRAM accounting

### DIFF
--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -975,9 +975,12 @@ class RooflineAnalyzer:
             if weight_bytes <= weight_budget:
                 # Stationary: weight load overlaps previous layer's compute.
                 return base
-            # Weights exceed on-chip: outer-tiled, partial overlap.
+            # Weights exceed on-chip: outer-tiled. Each weight byte is still
+            # loaded *once* total (the slabs are different weight tiles, not
+            # the same tile reloaded); what gets repeated is the activation
+            # stream, which has to cycle through each weight slab.
             outer_loads = max(1, math.ceil(weight_bytes / weight_budget))
-            return base + weight_bytes * outer_loads
+            return base * outer_loads + weight_bytes
 
         return base + weight_bytes
 

--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -22,6 +22,7 @@ Calibration Integration:
 - Falls back to theoretical peaks when no calibration exists
 """
 
+import math
 from dataclasses import dataclass, field
 from typing import List, Optional, Dict, Tuple, TYPE_CHECKING
 from enum import Enum
@@ -472,8 +473,12 @@ class RooflineAnalyzer:
         # Compute time = FLOPs / effective_peak_FLOPS
         compute_time = sg.flops / effective_peak_flops if effective_peak_flops > 0 else 0.0
 
-        # Memory time = bytes / effective_peak_bandwidth
-        total_bytes = sg.total_input_bytes + sg.total_output_bytes + sg.total_weight_bytes
+        # Memory time = bytes / effective_peak_bandwidth.
+        # ``_dram_traffic_bytes`` is hardware-aware: on weight-stationary
+        # accelerators (KPU) it amortizes weight loads across the on-chip
+        # tile fabric instead of treating weights as re-fetched per layer
+        # (issue #51). For other hardware the result is the naive sum.
+        total_bytes = self._dram_traffic_bytes(sg)
         memory_time = total_bytes / effective_peak_bandwidth if effective_peak_bandwidth > 0 else 0.0
 
         # Apply discrete resource correction for accelerators with few compute units
@@ -931,6 +936,50 @@ class RooflineAnalyzer:
 
         # Other hardware: default to moderate efficiency
         return 0.5
+
+    def _dram_traffic_bytes(self, sg: SubgraphDescriptor) -> int:
+        """Bytes that actually cross the DRAM boundary for a subgraph.
+
+        For most hardware this is just ``input + output + weight`` -- the
+        roofline assumes weights stream through DRAM each call.
+
+        For weight-stationary accelerators (KPU), the architecture
+        double-buffers weight prefetch with compute: while layer N runs on
+        weights already resident in the tile fabric, layer N+1's weights are
+        fetched from DRAM in parallel. As long as a subgraph's weight
+        footprint fits in the aggregate on-chip capacity (sum of per-tile
+        L1 + shared L2), the weight load fully overlaps the previous
+        layer's compute and does NOT contribute to this subgraph's memory
+        floor. Per-subgraph DRAM traffic is then just the activation in/out.
+
+        When per-subgraph weights exceed the on-chip budget, the prefetch
+        cannot fully hide weight loads -- model that as ``ceil(weight /
+        weight_budget)`` outer passes that each load a weight slab.
+
+        Without this hook (issue #51), transformer workloads get scored as
+        bandwidth-bound on KPU even though the dataflow is specifically
+        designed to keep weights resident.
+        """
+        base = sg.total_input_bytes + sg.total_output_bytes
+        weight_bytes = sg.total_weight_bytes
+        hw_type = self.resource_model.hardware_type.name
+
+        if hw_type == 'KPU' and weight_bytes > 0:
+            # Aggregate on-chip = sum of per-tile L1 + shared L2.
+            on_chip = (
+                self.resource_model.compute_units * self.resource_model.l1_cache_per_unit
+                + self.resource_model.l2_cache_total
+            )
+            # Reserve 20% of on-chip for the activation working set.
+            weight_budget = max(1, int(on_chip * 0.8))
+            if weight_bytes <= weight_budget:
+                # Stationary: weight load overlaps previous layer's compute.
+                return base
+            # Weights exceed on-chip: outer-tiled, partial overlap.
+            outer_loads = max(1, math.ceil(weight_bytes / weight_budget))
+            return base + weight_bytes * outer_loads
+
+        return base + weight_bytes
 
     def _get_discrete_resource_correction(self, sg: SubgraphDescriptor) -> float:
         """

--- a/src/graphs/hardware/mappers/accelerators/kpu.py
+++ b/src/graphs/hardware/mappers/accelerators/kpu.py
@@ -99,6 +99,15 @@ class KPUMapper(HardwareMapper):
         self.scratchpad_per_tile = resource_model.l1_cache_per_unit  # 256KB
         self.threads_per_tile = resource_model.threads_per_unit  # 256 threads
 
+        # Aggregate on-chip capacity (issue #51): the KPU's reason-for-being is
+        # weight stationarity. Weight-residency decisions need to see the full
+        # tile-fabric L1 + shared L2, not just one tile's scratchpad.
+        # KPU-T64: 64 * 256KB + 4MB = 20 MB; KPU-T256: 256 * 256KB + 16MB = 80 MB.
+        self.l2_cache_total = resource_model.l2_cache_total
+        self.total_on_chip_bytes = (
+            self.num_tiles * self.scratchpad_per_tile + self.l2_cache_total
+        )
+
     def compute_energy_with_idle_power(
         self,
         latency: float,
@@ -158,108 +167,102 @@ class KPUMapper(HardwareMapper):
         precision: Precision
     ) -> TileConfiguration:
         """
-        Analyze tiling requirements for a subgraph.
+        Analyze tiling and on-chip residency for a subgraph.
 
-        Args:
-            subgraph: Fused subgraph to analyze
-            precision: Numerical precision (affects memory footprint)
+        Implements the weight-stationary execution model that is the KPU's
+        architectural reason for existing (issue #51). For each subgraph:
 
-        Returns:
-            TileConfiguration with tiling analysis
+        1. Compare weight footprint against the aggregate on-chip capacity
+           (all tiles' L1 + shared L2), not a single tile's 256KB scratchpad.
+        2. If weights fit on-chip, model weight loads as a one-shot prologue
+           cost and stream activations through the resident weights.
+        3. If weights don't fit, outer-tile execution: weights load once per
+           outer pass over the activation stream, not once per inner tile.
+
+        Note: ``subgraph.total_*_bytes`` are already at the analysis precision
+        (issue #52 / PR #54). The mapper used to multiply by
+        ``bytes_per_element/4`` here, which double-scaled at fp16/int8/int4.
+        That obsolete adjustment has been removed.
         """
         scratchpad_size = self.scratchpad_per_tile
+        on_chip_total = self.total_on_chip_bytes
 
-        # Get bytes per element for this precision
-        bytes_per_element = self._get_bytes_per_element(precision)
-
-        # Calculate memory footprint per operation
-        # For a Conv2D: need input tile + weights + output tile in scratchpad
+        # Memory footprint at analysis precision (no double-scaling).
         input_bytes = subgraph.total_input_bytes
         weight_bytes = subgraph.total_weight_bytes
         output_bytes = subgraph.total_output_bytes
-
-        # Adjust for precision (if different from FP32)
-        # Subgraph bytes are in FP32, scale to actual precision
-        scale_factor = bytes_per_element / 4.0  # 4 bytes = FP32
-        input_bytes = int(input_bytes * scale_factor)
-        weight_bytes = int(weight_bytes * scale_factor)
-        output_bytes = int(output_bytes * scale_factor)
-
         total_bytes = input_bytes + weight_bytes + output_bytes
 
-        # Check if fits in scratchpad
+        # Per-tile fit (legacy diagnostic): does the *entire* working set fit
+        # in a single tile's scratchpad? Useful for very small ops.
         fits_in_scratchpad = total_bytes <= scratchpad_size
 
-        # Initialize variables (will be overwritten below)
-        input_per_tile = input_bytes
-        weight_per_tile = weight_bytes
-        output_per_tile = output_bytes
-        bytes_per_tile = total_bytes
+        # On-chip residency for weights. Reserve a fraction of on-chip for the
+        # activation working set so weights and activations co-exist.
+        # 80% for weights / 20% for activations is a common dataflow heuristic.
+        weight_on_chip_budget = int(on_chip_total * 0.8)
+        weights_fit_on_chip = weight_bytes <= weight_on_chip_budget
 
-        if fits_in_scratchpad:
-            # Entire operation fits - no tiling needed
-            num_tiles_required = 1
-            tiles_per_iteration = 1
-            num_iterations = 1
-            tiling_overhead = 1.0  # No overhead
+        if weights_fit_on_chip:
+            # Weight-stationary: weights load *once* into the tile fabric and
+            # stay resident while activations stream through them.
+            outer_weight_loads = 1
+            # Activation working set per outer pass = on-chip minus weights.
+            activation_budget = max(scratchpad_size, on_chip_total - weight_bytes)
         else:
-            # Need tiling - split operation into chunks
-            # Strategy: Keep weights in scratchpad, tile input/output
+            # Weights exceed the on-chip budget: outer-tile execution. Each
+            # outer pass loads a slab of weights, streams the full activation
+            # set through it, then loads the next slab.
+            outer_weight_loads = max(1, math.ceil(weight_bytes / weight_on_chip_budget))
+            # Half on-chip for weight slab, half for activations.
+            activation_budget = max(scratchpad_size, int(on_chip_total * 0.5))
 
-            # Weights typically smaller and reused
-            if weight_bytes > scratchpad_size * 0.8:
-                # Weights too large - need to tile weights too (rare)
-                # Pessimistic: assume we can fit 80% of scratchpad per tile
-                bytes_per_tile = int(scratchpad_size * 0.8)
-                num_tiles_required = math.ceil(total_bytes / bytes_per_tile)
-            else:
-                # Weights fit, tile input/output
-                # Reserve space for weights, split remaining between input/output
-                remaining_space = scratchpad_size - weight_bytes
+        # How many times the activation stream cycles through DRAM. For
+        # well-fitted activations this is 1; for very large activations (rare
+        # for inference) it grows. Multiplied by outer_weight_loads when
+        # weights are tiled, since each weight slab needs the full activation
+        # pass.
+        io_bytes = input_bytes + output_bytes
+        if io_bytes <= 0:
+            activation_iterations = 1
+        else:
+            activation_iterations = max(1, math.ceil(io_bytes / activation_budget)) * outer_weight_loads
 
-                # Input and output ratio
-                io_bytes = input_bytes + output_bytes
-                if io_bytes > 0:
-                    input_fraction = input_bytes / io_bytes
-                    output_fraction = output_bytes / io_bytes
+        # tiles_per_iteration drives parallelism, not memory traffic. Use the
+        # number of tiles needed to hold one outer pass.
+        tiles_required = max(1, math.ceil(total_bytes / scratchpad_size))
+        tiles_per_iteration = min(tiles_required, self.num_tiles)
+        num_iterations = max(1, math.ceil(tiles_required / tiles_per_iteration))
 
-                    input_per_tile = int(remaining_space * input_fraction * 0.8)  # 80% efficiency
-                    output_per_tile = int(remaining_space * output_fraction * 0.8)
-                else:
-                    input_per_tile = 0
-                    output_per_tile = 0
+        # Small prologue-load overhead when there is more than one outer pass.
+        # Replaces the previous (num_iterations - 1) * 10% blanket inflation,
+        # which compounded with the weight re-fetch bug.
+        tiling_overhead = 1.0 + (max(0, outer_weight_loads - 1)) * 0.05
 
-                weight_per_tile = weight_bytes
-                bytes_per_tile = input_per_tile + weight_per_tile + output_per_tile
+        # Per-tile decomposition (kept for diagnostics in TileConfiguration).
+        input_per_tile = input_bytes // max(1, tiles_per_iteration)
+        weight_per_tile = weight_bytes if weights_fit_on_chip else weight_on_chip_budget
+        output_per_tile = output_bytes // max(1, tiles_per_iteration)
+        bytes_per_tile = input_per_tile + weight_per_tile + output_per_tile
 
-                # Calculate number of tiles needed
-                if input_per_tile > 0:
-                    num_tiles_required = math.ceil(input_bytes / input_per_tile)
-                else:
-                    num_tiles_required = 1
-
-            # How many tiles can run in parallel? (up to total KPU tiles)
-            tiles_per_iteration = min(num_tiles_required, self.num_tiles)
-
-            # How many iterations to process all tiles?
-            num_iterations = math.ceil(num_tiles_required / tiles_per_iteration)
-
-            # Tiling overhead: each iteration has load/store overhead
-            # Estimate 10% overhead per iteration for data movement
-            tiling_overhead = 1.0 + (num_iterations - 1) * 0.10
-
-        return TileConfiguration(
+        config = TileConfiguration(
             scratchpad_size=scratchpad_size,
             input_bytes_per_tile=input_per_tile,
             weight_bytes_per_tile=weight_per_tile,
             output_bytes_per_tile=output_per_tile,
             total_bytes_per_tile=bytes_per_tile,
-            num_tiles_required=num_tiles_required,
+            num_tiles_required=tiles_required,
             tiles_per_iteration=tiles_per_iteration,
             num_iterations=num_iterations,
             fits_in_scratchpad=fits_in_scratchpad,
             tiling_overhead=tiling_overhead,
         )
+        # Stash the residency outputs on the config so map_subgraph can use
+        # them without re-deriving (extra attributes don't break the dataclass).
+        config.weights_fit_on_chip = weights_fit_on_chip
+        config.outer_weight_loads = outer_weight_loads
+        config.activation_iterations = activation_iterations
+        return config
 
     def _get_bytes_per_element(self, precision: Precision) -> int:
         """Get bytes per element for a precision"""
@@ -325,22 +328,30 @@ class KPUMapper(HardwareMapper):
         # Calculate utilization
         utilization = tiles_allocated / self.num_tiles
 
-        # Calculate latency using roofline model
+        # Calculate latency using roofline model.
         ops = subgraph.total_flops if subgraph.total_flops > 0 else subgraph.total_macs * 2
-        bytes_transferred = (
-            subgraph.total_input_bytes +
-            subgraph.total_output_bytes +
-            subgraph.total_weight_bytes
-        )
 
-        # Multiply by tiling overhead (more iterations = more overhead)
-        # This accounts for loading/storing tiles multiple times
+        # Weight-stationary memory accounting (issue #51). Weights load
+        # ``outer_weight_loads`` times (1 when they fit on-chip), not once per
+        # inner activation tile; activations stream ``activation_iterations``
+        # times. Previously the mapper computed
+        # ``(input + output + weight) * num_iterations`` which treats weights
+        # as re-fetched every inner iteration -- exactly the access pattern
+        # the KPU dataflow is designed to avoid.
+        activation_traffic_bytes = (
+            (subgraph.total_input_bytes + subgraph.total_output_bytes)
+            * tile_config.activation_iterations
+        )
+        weight_traffic_bytes = (
+            subgraph.total_weight_bytes * tile_config.outer_weight_loads
+        )
+        bytes_transferred = activation_traffic_bytes + weight_traffic_bytes
+
         ops_with_tiling = int(ops * tile_config.tiling_overhead)
-        bytes_with_tiling = int(bytes_transferred * tile_config.num_iterations)
 
         compute_time, memory_time, bottleneck = self._calculate_latency(
             ops=ops_with_tiling,
-            bytes_transferred=bytes_with_tiling,
+            bytes_transferred=bytes_transferred,
             allocated_units=tiles_allocated,
             occupancy=occupancy,
             precision=precision
@@ -348,7 +359,8 @@ class KPUMapper(HardwareMapper):
 
         estimated_latency = max(compute_time, memory_time)
 
-        # Calculate energy
+        # Calculate energy. Use the same precision-correct, stationary-aware
+        # byte count so DRAM energy reflects what is actually re-fetched.
         compute_energy, memory_energy = self._calculate_energy(
             ops=ops,
             bytes_transferred=bytes_transferred,

--- a/src/graphs/hardware/mappers/accelerators/kpu.py
+++ b/src/graphs/hardware/mappers/accelerators/kpu.py
@@ -211,11 +211,14 @@ class KPUMapper(HardwareMapper):
             activation_budget = max(scratchpad_size, on_chip_total - weight_bytes)
         else:
             # Weights exceed the on-chip budget: outer-tile execution. Each
-            # outer pass loads a slab of weights, streams the full activation
-            # set through it, then loads the next slab.
+            # outer pass loads a *different slab* of weights, streams the
+            # full activation set through it, then loads the next slab. The
+            # slabs together cover the whole weight set exactly once.
             outer_weight_loads = max(1, math.ceil(weight_bytes / weight_on_chip_budget))
-            # Half on-chip for weight slab, half for activations.
-            activation_budget = max(scratchpad_size, int(on_chip_total * 0.5))
+            # Activation working set co-resides with the active weight slab,
+            # so the budget is whatever's left after reserving for weights
+            # (consistent with the 80/20 split above).
+            activation_budget = max(scratchpad_size, on_chip_total - weight_on_chip_budget)
 
         # How many times the activation stream cycles through DRAM. For
         # well-fitted activations this is 1; for very large activations (rare
@@ -331,20 +334,20 @@ class KPUMapper(HardwareMapper):
         # Calculate latency using roofline model.
         ops = subgraph.total_flops if subgraph.total_flops > 0 else subgraph.total_macs * 2
 
-        # Weight-stationary memory accounting (issue #51). Weights load
-        # ``outer_weight_loads`` times (1 when they fit on-chip), not once per
-        # inner activation tile; activations stream ``activation_iterations``
-        # times. Previously the mapper computed
-        # ``(input + output + weight) * num_iterations`` which treats weights
-        # as re-fetched every inner iteration -- exactly the access pattern
-        # the KPU dataflow is designed to avoid.
+        # Weight-stationary memory accounting (issue #51). Each weight byte
+        # is loaded from DRAM exactly once for this subgraph (split across
+        # ``outer_weight_loads`` slabs when weights don't fit on-chip; each
+        # slab covers a different weight tile, never the same one reloaded).
+        # What gets repeated is the activation stream cycling through each
+        # weight slab. Previously the mapper computed
+        # ``(input + output + weight) * num_iterations`` which treats both
+        # weights *and* activations as re-fetched on every inner tile --
+        # exactly the access pattern the KPU dataflow is designed to avoid.
         activation_traffic_bytes = (
             (subgraph.total_input_bytes + subgraph.total_output_bytes)
             * tile_config.activation_iterations
         )
-        weight_traffic_bytes = (
-            subgraph.total_weight_bytes * tile_config.outer_weight_loads
-        )
+        weight_traffic_bytes = subgraph.total_weight_bytes
         bytes_transferred = activation_traffic_bytes + weight_traffic_bytes
 
         ops_with_tiling = int(ops * tile_config.tiling_overhead)

--- a/tests/hardware/test_kpu_weight_stationarity.py
+++ b/tests/hardware/test_kpu_weight_stationarity.py
@@ -1,0 +1,164 @@
+"""Regression tests for issue #51.
+
+The KPU mapper used to model weights as re-fetched from DRAM at every
+output tile, which made every transformer-class workload look ~4x more
+bandwidth-bound than physics allows. The KPU's architectural reason for
+existing is weight stationarity: weights live in the aggregate on-chip
+tile fabric (L1 across all tiles + shared L2), and prefetch overlaps
+compute. These tests lock in:
+
+1. ViT-B/16 INT8 on KPU-T64 reports ~1.8 ms (issue's expected number),
+   not the previous ~4 ms.
+2. RooflineAnalyzer._dram_traffic_bytes excludes per-subgraph weight
+   bytes when they fit in the on-chip budget.
+3. RooflineAnalyzer._dram_traffic_bytes amortizes weights over outer
+   tiles when they exceed the on-chip budget.
+4. KPUMapper aggregate on-chip capacity matches physical specs.
+5. Other accelerators are not affected by the KPU-specific stationarity
+   model.
+"""
+
+import math
+
+import pytest
+import torch
+
+from graphs.estimation.roofline import RooflineAnalyzer
+from graphs.estimation.unified_analyzer import UnifiedAnalyzer
+from graphs.hardware.mappers.accelerators.kpu import create_kpu_t64_mapper
+from graphs.hardware.resource_model import Precision
+from graphs.core.structures import (
+    SubgraphDescriptor,
+    OperationType,
+    ParallelismDescriptor,
+    BottleneckType,
+)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: ViT-B/16 INT8 on KPU-T64 hits the issue's target latency
+# ---------------------------------------------------------------------------
+
+
+def test_vit_b16_int8_on_kpu_t64_meets_stationarity_target():
+    analyzer = UnifiedAnalyzer()
+    result = analyzer.analyze_model(
+        model_name='vit_b_16',
+        hardware_name='kpu-t64',
+        batch_size=1,
+        precision=Precision.INT8,
+    )
+
+    # Issue #51 target: ~1.8 ms (weight-stationary baseline). Allow a wide
+    # 30% band so refinements to other parts of the model don't break this.
+    assert 1.0 <= result.total_latency_ms <= 2.5, (
+        f"ViT-B/16 INT8 on KPU-T64 reported {result.total_latency_ms:.2f} ms; "
+        f"expected ~1.8 ms (issue #51 stationarity target)"
+    )
+
+
+def test_vit_b16_int8_on_kpu_t64_has_compute_bound_ops():
+    """Issue #51: 'attention QKV / MLP projections look bandwidth-bound when
+    they should be compute-bound'. After stationarity, at least some of these
+    must classify as compute-bound."""
+    analyzer = UnifiedAnalyzer()
+    result = analyzer.analyze_model(
+        model_name='vit_b_16',
+        hardware_name='kpu-t64',
+        batch_size=1,
+        precision=Precision.INT8,
+    )
+
+    compute_bound = sum(
+        1 for lr in result.roofline_report.latencies
+        if lr.bottleneck == BottleneckType.COMPUTE_BOUND
+    )
+    assert compute_bound >= 5, (
+        f"Expected >=5 compute-bound ops on ViT-B/16/KPU-T64 after stationarity, "
+        f"got {compute_bound}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# RooflineAnalyzer._dram_traffic_bytes unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_subgraph(input_b: int, output_b: int, weight_b: int) -> SubgraphDescriptor:
+    return SubgraphDescriptor(
+        subgraph_id=1,
+        node_ids=['n1'],
+        node_names=['n1'],
+        operation_types=[OperationType.LINEAR],
+        fusion_pattern='Linear',
+        total_flops=1_000_000,
+        total_macs=500_000,
+        total_input_bytes=input_b,
+        total_output_bytes=output_b,
+        total_weight_bytes=weight_b,
+        internal_bytes=0,
+        num_operators=1,
+        parallelism=ParallelismDescriptor(batch=1, channels=1, spatial=1, total_threads=1),
+        depends_on=[],
+    )
+
+
+@pytest.fixture(scope="module")
+def kpu_t64_resource_model():
+    return create_kpu_t64_mapper().resource_model
+
+
+def test_kpu_aggregate_on_chip_capacity(kpu_t64_resource_model):
+    rm = kpu_t64_resource_model
+    expected = rm.compute_units * rm.l1_cache_per_unit + rm.l2_cache_total
+    # KPU-T64: 64 * 256KB + 4MB = 20 MB
+    assert expected == 64 * 256 * 1024 + 4 * 1024 * 1024
+
+
+def test_kpu_dram_traffic_excludes_weights_when_they_fit(kpu_t64_resource_model):
+    """Per-subgraph weights that fit in the on-chip budget are pre-fetched
+    in parallel with compute and don't contribute to per-layer memory floor."""
+    analyzer = RooflineAnalyzer(kpu_t64_resource_model, precision=Precision.INT8)
+    # 4 MB weights fit in 17 MB budget (= 80% of 20 MB on-chip).
+    sg = _make_subgraph(input_b=1_000_000, output_b=1_000_000, weight_b=4 * 1024 * 1024)
+    bytes_ = analyzer._dram_traffic_bytes(sg)
+    assert bytes_ == 2_000_000  # input + output, no weight contribution
+
+
+def test_kpu_dram_traffic_includes_weights_when_they_exceed_budget(kpu_t64_resource_model):
+    """Per-subgraph weights that exceed the on-chip budget cannot fully
+    overlap; must be amortized over outer tiles."""
+    analyzer = RooflineAnalyzer(kpu_t64_resource_model, precision=Precision.INT8)
+    # 50 MB weights vs ~17 MB budget -> ceil(50/17) = 3 outer loads
+    weight_bytes = 50 * 1024 * 1024
+    sg = _make_subgraph(input_b=1_000_000, output_b=1_000_000, weight_b=weight_bytes)
+    on_chip = 64 * 256 * 1024 + 4 * 1024 * 1024
+    weight_budget = int(on_chip * 0.8)
+    expected_outer = math.ceil(weight_bytes / weight_budget)
+    expected = 2_000_000 + weight_bytes * expected_outer
+    assert analyzer._dram_traffic_bytes(sg) == expected
+    assert expected_outer >= 2  # sanity
+
+
+def test_kpu_dram_traffic_handles_zero_weights(kpu_t64_resource_model):
+    """Activation-only subgraphs (e.g., elementwise ops) get pure activation
+    traffic with no special-case behavior."""
+    analyzer = RooflineAnalyzer(kpu_t64_resource_model, precision=Precision.INT8)
+    sg = _make_subgraph(input_b=500_000, output_b=500_000, weight_b=0)
+    assert analyzer._dram_traffic_bytes(sg) == 1_000_000
+
+
+# ---------------------------------------------------------------------------
+# Non-KPU hardware is unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_gpu_dram_traffic_keeps_naive_accounting():
+    """GPU/CPU/etc. retain the conservative input+output+weight accounting.
+    Issue #51 stationarity is a KPU-specific architectural model."""
+    from graphs.hardware.mappers.gpu import create_h100_sxm5_80gb_mapper
+    rm = create_h100_sxm5_80gb_mapper().resource_model
+    analyzer = RooflineAnalyzer(rm, precision=Precision.FP16)
+    sg = _make_subgraph(input_b=1_000_000, output_b=1_000_000, weight_b=4 * 1024 * 1024)
+    expected_naive = 1_000_000 + 1_000_000 + 4 * 1024 * 1024
+    assert analyzer._dram_traffic_bytes(sg) == expected_naive

--- a/tests/hardware/test_kpu_weight_stationarity.py
+++ b/tests/hardware/test_kpu_weight_stationarity.py
@@ -21,7 +21,6 @@ compute. These tests lock in:
 import math
 
 import pytest
-import torch
 
 from graphs.estimation.roofline import RooflineAnalyzer
 from graphs.estimation.unified_analyzer import UnifiedAnalyzer
@@ -125,17 +124,23 @@ def test_kpu_dram_traffic_excludes_weights_when_they_fit(kpu_t64_resource_model)
     assert bytes_ == 2_000_000  # input + output, no weight contribution
 
 
-def test_kpu_dram_traffic_includes_weights_when_they_exceed_budget(kpu_t64_resource_model):
-    """Per-subgraph weights that exceed the on-chip budget cannot fully
-    overlap; must be amortized over outer tiles."""
+def test_kpu_dram_traffic_outer_tiled_amortizes_correctly(kpu_t64_resource_model):
+    """When weights exceed the on-chip budget, outer-tiled execution loads
+    *different* weight slabs each pass (each weight byte loaded exactly
+    once total), and the *activation* stream is what cycles through every
+    slab. The total DRAM traffic is therefore
+    ``activation_bytes * outer_loads + weight_bytes``, NOT
+    ``weight_bytes * outer_loads + activation_bytes``.
+    """
     analyzer = RooflineAnalyzer(kpu_t64_resource_model, precision=Precision.INT8)
-    # 50 MB weights vs ~17 MB budget -> ceil(50/17) = 3 outer loads
+    # 50 MB weights vs ~17 MB budget -> ceil(50/17) = 3 outer slabs
     weight_bytes = 50 * 1024 * 1024
+    activation_bytes = 2_000_000
     sg = _make_subgraph(input_b=1_000_000, output_b=1_000_000, weight_b=weight_bytes)
     on_chip = 64 * 256 * 1024 + 4 * 1024 * 1024
     weight_budget = int(on_chip * 0.8)
     expected_outer = math.ceil(weight_bytes / weight_budget)
-    expected = 2_000_000 + weight_bytes * expected_outer
+    expected = activation_bytes * expected_outer + weight_bytes
     assert analyzer._dram_traffic_bytes(sg) == expected
     assert expected_outer >= 2  # sanity
 


### PR DESCRIPTION
## Summary
The P0 of the four-issue precision/correctness series. Three layered bugs made every transformer-class workload look ~4x more bandwidth-bound on KPU than physics allows. The KPU's architectural reason for existing -- weights resident in the on-chip tile fabric, prefetch overlapping compute -- was not modeled at all.

## Bugs fixed

| # | Location | Bug |
|---|---|---|
| A | `KPUMapper._analyze_tiling` (lines 183-186, before this PR) | Obsolete `bytes_per_element/4.0` scale_factor double-scaled bytes after #54 fixed the partitioner. Scratchpad-fit decisions under-counted by 4x at INT8. |
| B | `KPUMapper.map_subgraph` (lines 330-339, before this PR) | `bytes_transferred = (input + output + weight) * num_iterations` treated weights as re-fetched on every inner activation tile -- the exact pattern the KPU dataflow is designed to avoid. |
| C | `KPUMapper._analyze_tiling` (line 170, before this PR) | Saw only one tile's L1 (256 KB). Aggregate on-chip = `num_tiles * l1_per_tile + l2_total` (T64: 20 MB; T256: 80 MB). |
| D | `RooflineAnalyzer._analyze_subgraph` (line 476) | Drives `total_latency_ms` and was unaware of (A)/(B)/(C) entirely. Added `_dram_traffic_bytes(sg)` hardware-aware helper. |

## Stationarity model

For KPU, per-subgraph weight footprint is compared to `0.8 * on_chip_capacity`:
- **Fits**: weight load overlaps the previous layer's compute via double-buffered prefetch -> contributes 0 to per-layer memory floor.
- **Exceeds**: outer-tiled execution loads `ceil(weight / budget)` slabs, amortized over the activation stream.

For non-KPU hardware (GPU/CPU/TPU/etc.) the helper returns the previous `input + output + weight` sum -- no behavior change.

## Verification

ViT-B/16 INT8 on KPU-T64:

| Metric | Before this PR | After this PR | Issue target |
|---|---:|---:|---:|
| Latency | 4.13 ms | **1.52 ms** | ~1.8 ms |
| Bandwidth-bound ops | 118/156 | 106/156 | -- |
| Compute-bound ops | 0 | **12** | >0 |

The 12 compute-bound ops are exactly the attention QKV / MLP projections the issue called out as misclassified.

## Changes
- `src/graphs/hardware/mappers/accelerators/kpu.py` -- aggregate on-chip capacity in `__init__`; rewrite of `_analyze_tiling` with stationarity logic; rewrite of `map_subgraph` byte accounting; removed obsolete scale_factor.
- `src/graphs/estimation/roofline.py` -- new `_dram_traffic_bytes(sg)` hook called from `_analyze_subgraph`. Hardware-aware: KPU stationarity model for KPU, naive sum for everything else.
- `tests/hardware/test_kpu_weight_stationarity.py` -- 7 regression tests: ViT-B/16 latency band, emergence of compute-bound ops, fits-on-chip vs exceeds-on-chip byte accounting, aggregate on-chip formula, GPU non-regression.

## Test Results
- New regression suite: 7/7 passed
- Full unit suite: **1587 passed, 11 skipped, 1 xfailed** in 138s (was 1580; +7 new tests, **zero regressions** despite KPU latency dropping ~3x for transformer workloads)

## Test plan
- [x] Fast CI passes
- [x] Re-run the original repro: `branes mcp analyze vit_b_16 kpu-t64 -p int8` should now report ~1.5 ms instead of ~4 ms
- [x] Promote to ready when satisfied: `gh pr ready`

## Related
This is the last in the four-issue series. After landing, every "KPU vs Jetson / KPU vs GPU" comparison through `mcp analyze` is defensible:
- #52 -> #54: precision threading into byte accounting
- #55 -> #56: ATen call_function weight accounting
- #53 -> #57: silent precision-fallback eliminated
- **#51 -> this PR**: weight stationarity

Resolves #51

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance estimation accuracy for weight-stationary accelerators by refining on-chip memory capacity modeling
  * Enhanced latency, energy, and bottleneck classification calculations

* **Tests**
  * Added regression tests validating weight-stationarity behavior and memory traffic calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->