### PR TITLE
fix(partitioning): read symbolic_trace tensor_meta in ATen helpers

### DIFF
--- a/src/graphs/transform/partitioning/fusion_partitioner.py
+++ b/src/graphs/transform/partitioning/fusion_partitioner.py
@@ -648,11 +648,9 @@ class FusionBasedPartitioner:
             if len(node.args) < 2:
                 return 0, 0
 
-            weight_node = node.args[1]
-            if not hasattr(weight_node, 'meta') or 'val' not in weight_node.meta:
+            weight_shape = self._meta_shape(node.args[1])
+            if weight_shape is None or len(weight_shape) != 4:
                 return 0, 0
-
-            weight_shape = weight_node.meta['val'].shape
             # Weight shape: [out_channels, in_channels/groups, kH, kW]
             _, in_channels_per_group, kh, kw = weight_shape
 
@@ -690,18 +688,17 @@ class FusionBasedPartitioner:
             target_str = str(node.target)
 
             if 'linear' in target_str:
-                # aten.linear(input, weight, bias)
+                # aten.linear(input, weight, bias) and the symbolic_trace
+                # equivalent torch.nn.functional.linear(input, weight, bias).
                 # Output shape: [..., out_features]
                 # Weight shape: [out_features, in_features]
 
                 if len(node.args) < 2:
                     return 0, 0
 
-                weight_node = node.args[1]
-                if not hasattr(weight_node, 'meta') or 'val' not in weight_node.meta:
+                weight_shape = self._meta_shape(node.args[1])
+                if weight_shape is None or len(weight_shape) != 2:
                     return 0, 0
-
-                weight_shape = weight_node.meta['val'].shape
                 out_features, in_features = weight_shape
 
                 # Calculate batch size from output shape
@@ -720,17 +717,12 @@ class FusionBasedPartitioner:
                 if len(output_shape) < 2:
                     return 0, 0
 
-                # Get input shapes
-                input_a = node.args[0]
-                input_b = node.args[1]
-
-                if not (hasattr(input_a, 'meta') and 'val' in input_a.meta):
+                if len(node.args) < 2:
                     return 0, 0
-                if not (hasattr(input_b, 'meta') and 'val' in input_b.meta):
+                shape_a = self._meta_shape(node.args[0])
+                shape_b = self._meta_shape(node.args[1])
+                if shape_a is None or shape_b is None:
                     return 0, 0
-
-                shape_a = input_a.meta['val'].shape
-                shape_b = input_b.meta['val'].shape
 
                 # Simple case: 2D x 2D
                 if len(shape_a) == 2 and len(shape_b) == 2:
@@ -760,16 +752,10 @@ class FusionBasedPartitioner:
                 if len(node.args) < 3:
                     return 0, 0
 
-                input_node = node.args[1]
-                weight_node = node.args[2]
-
-                if not (hasattr(input_node, 'meta') and 'val' in input_node.meta):
+                input_shape = self._meta_shape(node.args[1])
+                weight_shape = self._meta_shape(node.args[2])
+                if input_shape is None or weight_shape is None:
                     return 0, 0
-                if not (hasattr(weight_node, 'meta') and 'val' in weight_node.meta):
-                    return 0, 0
-
-                input_shape = input_node.meta['val'].shape
-                weight_shape = weight_node.meta['val'].shape
 
                 # input: [batch, in_features], weight: [in_features, out_features]
                 if len(input_shape) >= 2 and len(weight_shape) >= 2:
@@ -939,17 +925,51 @@ class FusionBasedPartitioner:
         return {'weights': 0, 'input': 0, 'output': 0}
 
     @staticmethod
+    def _meta_shape(arg) -> Optional[Tuple[int, ...]]:
+        """Extract a tensor shape from an FX node arg's meta.
+
+        Supports both tracing styles (issue #63):
+        - ``torch.export`` / Dynamo: ``meta['val']`` is a FakeTensor with
+          ``.shape`` and ``.numel()``.
+        - ``torch.fx.symbolic_trace`` + ``ShapeProp``: ``meta['tensor_meta']``
+          is a TensorMetadata namedtuple with ``.shape`` (no ``.numel()``).
+
+        Returns ``None`` when neither is populated -- e.g., a literal int
+        argument or an untraced node.
+        """
+        if not hasattr(arg, 'meta'):
+            return None
+        val = arg.meta.get('val')
+        if val is not None and hasattr(val, 'shape'):
+            try:
+                return tuple(int(d) for d in val.shape)
+            except Exception:
+                pass
+        tm = arg.meta.get('tensor_meta')
+        if tm is not None and hasattr(tm, 'shape'):
+            try:
+                return tuple(int(d) for d in tm.shape)
+            except Exception:
+                pass
+        return None
+
+    @staticmethod
+    def _meta_numel(arg) -> int:
+        """Numel from an FX node arg's meta, supporting both tracing styles."""
+        shape = FusionBasedPartitioner._meta_shape(arg)
+        if shape is None:
+            return 0
+        n = 1
+        for d in shape:
+            n *= d
+        return n
+
+    @staticmethod
     def _arg_numel(node, idx: int) -> int:
-        """Return numel of an FX node arg's fake-tensor meta, or 0 if unavailable."""
+        """Return numel of an FX node arg's tensor meta, or 0 if unavailable."""
         if idx >= len(node.args):
             return 0
-        arg = node.args[idx]
-        if not hasattr(arg, 'meta') or 'val' not in arg.meta:
-            return 0
-        try:
-            return int(arg.meta['val'].numel())
-        except Exception:
-            return 0
+        return FusionBasedPartitioner._meta_numel(node.args[idx])
 
     def _aten_weight_bytes(self, node, bpe: float) -> int:
         """Sum parameter-tensor bytes for ATen ops that carry learned weights.

--- a/tests/transform/partitioning/test_symbolic_trace_aten_meta.py
+++ b/tests/transform/partitioning/test_symbolic_trace_aten_meta.py
@@ -1,0 +1,176 @@
+"""Regression tests for issue #63.
+
+The ATen call_function flop/byte helpers in fusion_partitioner.py used to
+read only ``arg.meta['val']`` (set by torch.export / Dynamo). When a model
+was traced via the default ``symbolic_trace + ShapeProp`` path -- which
+sets ``arg.meta['tensor_meta']`` instead -- those helpers silently
+returned 0. Single-Linear and single-matmul models then reported 0 FLOPs
+and 0 weight bytes, leading to nonsense roofline predictions.
+
+These tests lock in:
+
+1. ``_meta_shape`` reads both Dynamo-style ``meta['val']`` and
+   symbolic_trace-style ``meta['tensor_meta']``.
+2. A single ``nn.Linear`` traced via ``symbolic_trace`` reports the
+   correct FLOPs and weight bytes through ``FusionBasedPartitioner``.
+3. A single ``torch.matmul`` traced via ``symbolic_trace`` reports the
+   correct FLOPs (and zero weights, because matmul has no parameters).
+4. ``aten.addmm`` and ``aten.conv2d`` style nodes work too.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.fx import symbolic_trace
+from torch.fx.passes.shape_prop import ShapeProp
+
+from graphs.hardware.resource_model import Precision
+from graphs.transform.partitioning import FusionBasedPartitioner
+
+
+# ---------------------------------------------------------------------------
+# _meta_shape unit tests
+# ---------------------------------------------------------------------------
+
+
+def _trace(model: nn.Module, *inputs) -> "torch.fx.GraphModule":
+    fx = symbolic_trace(model)
+    ShapeProp(fx).propagate(*inputs)
+    return fx
+
+
+def test_meta_shape_reads_tensor_meta_from_symbolic_trace():
+    """symbolic_trace + ShapeProp populates meta['tensor_meta']; the helper
+    must read it."""
+    m = nn.Linear(64, 32).eval()
+    fx = _trace(m, torch.randn(8, 64))
+
+    weight_node = next(n for n in fx.graph.nodes if n.op == "get_attr" and "weight" in n.name)
+    shape = FusionBasedPartitioner._meta_shape(weight_node)
+    assert shape == (32, 64)
+
+
+def test_meta_shape_returns_none_when_meta_absent():
+    """Plain int/literal arguments have no meta; helper must return None
+    rather than crashing."""
+
+    class Dummy:
+        pass
+
+    arg = Dummy()  # no .meta attribute
+    assert FusionBasedPartitioner._meta_shape(arg) is None
+
+
+def test_meta_numel_multiplies_correctly():
+    m = nn.Linear(128, 64).eval()
+    fx = _trace(m, torch.randn(4, 128))
+    weight_node = next(n for n in fx.graph.nodes if "weight" in n.name and n.op == "get_attr")
+    assert FusionBasedPartitioner._meta_numel(weight_node) == 128 * 64
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: single-Linear / single-matmul through symbolic_trace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("B,IN,OUT", [
+    (64, 1024, 1024),
+    (1, 4096, 4096),
+    (256, 768, 3072),
+    (8, 512, 256),
+])
+def test_single_linear_symbolic_trace_reports_correct_flops_and_weights(B, IN, OUT):
+    """Issue #63: single nn.Linear traced via symbolic_trace was reporting
+    0 FLOPs and 0 weight bytes. Lock the correct values in."""
+    m = nn.Linear(IN, OUT).eval()
+    fx = _trace(m, torch.randn(B, IN))
+
+    report = FusionBasedPartitioner(precision=Precision.FP32).partition(fx)
+    sg = report.subgraphs[0]
+
+    expected_flops = 2 * B * IN * OUT
+    # Weight = OUT*IN floats, bias = OUT floats; 4 bytes/elem (fp32)
+    expected_weight_bytes = 4 * (IN * OUT + OUT)
+
+    assert sg.total_flops == expected_flops, (
+        f"Linear({IN},{OUT}) on B={B}: flops={sg.total_flops} expected={expected_flops}"
+    )
+    assert sg.total_weight_bytes == expected_weight_bytes
+
+
+def test_single_linear_no_bias_symbolic_trace():
+    """Linear without bias: weight bytes only count the weight matrix."""
+    m = nn.Linear(512, 256, bias=False).eval()
+    fx = _trace(m, torch.randn(8, 512))
+
+    report = FusionBasedPartitioner(precision=Precision.FP32).partition(fx)
+    sg = report.subgraphs[0]
+
+    assert sg.total_flops == 2 * 8 * 512 * 256
+    assert sg.total_weight_bytes == 4 * 512 * 256  # no bias
+
+
+@pytest.mark.parametrize("M,K,N", [
+    (128, 256, 64),
+    (1, 1024, 1024),
+    (512, 512, 512),
+])
+def test_single_matmul_symbolic_trace_reports_correct_flops(M, K, N):
+    """torch.matmul via symbolic_trace: FLOPs nonzero, weights zero
+    (both inputs are activations, no parameter)."""
+
+    class MM(nn.Module):
+        def forward(self, a, b):
+            return torch.matmul(a, b)
+
+    fx = _trace(MM().eval(), torch.randn(M, K), torch.randn(K, N))
+    report = FusionBasedPartitioner(precision=Precision.FP32).partition(fx)
+    sg = report.subgraphs[0]
+
+    assert sg.total_flops == 2 * M * K * N
+    assert sg.total_weight_bytes == 0
+
+
+def test_precision_scaling_still_works_after_fix():
+    """The fix preserves PR #54's precision-aware byte counts: weight
+    bytes scale with the analysis precision, not just fp32."""
+    m = nn.Linear(1024, 1024).eval()
+    fx = _trace(m, torch.randn(64, 1024))
+
+    fp32 = sum(sg.total_weight_bytes for sg in
+               FusionBasedPartitioner(Precision.FP32).partition(fx).subgraphs)
+    fp16 = sum(sg.total_weight_bytes for sg in
+               FusionBasedPartitioner(Precision.FP16).partition(fx).subgraphs)
+    int8 = sum(sg.total_weight_bytes for sg in
+               FusionBasedPartitioner(Precision.INT8).partition(fx).subgraphs)
+
+    assert fp32 > 0
+    assert fp16 == fp32 // 2
+    assert int8 == fp32 // 4
+
+
+def test_dynamo_export_path_still_works_after_fix():
+    """Negative control: the fix must not regress the Dynamo / torch.export
+    path that PR #56 added. Re-trace via torch.export.export and verify
+    weight bytes are still counted via meta['val']."""
+
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(3, 8, 3, padding=1)
+            self.fc = nn.Linear(8 * 32 * 32, 4)
+
+        def forward(self, x):
+            return self.fc(self.conv(x).flatten(1))
+
+    m = Net().eval()
+    x = torch.randn(1, 3, 32, 32)
+    ep = torch.export.export(m, (x,))
+    fx = ep.module()
+    ShapeProp(fx).propagate(x)
+
+    report = FusionBasedPartitioner(precision=Precision.FP32).partition(fx)
+    total_w = sum(sg.total_weight_bytes for sg in report.subgraphs)
+    # Conv: 3*8*9 + 8 = 224 elems; Linear: 4*8192 + 4 = 32772 elems;
+    # 32996 elems * 4 bytes = 131,984 bytes (matches PR #56 hand-verified number)
+    assert total_w == 32996 * 4


### PR DESCRIPTION
## Summary
- ATen call_function flop and weight-byte helpers in `fusion_partitioner.py` only checked `arg.meta['val']` (Dynamo / `torch.export`). When a model traced via the default `symbolic_trace + ShapeProp` path -- which sets `arg.meta['tensor_meta']` -- those helpers silently returned 0.
- A single `nn.Linear` traced via `trace_and_partition` (default `prefer_modules=True`) reported **0 FLOPs and 0 weight bytes**, leading to a degenerate roofline prediction.
- Surfaced while building the v4 validation harness (#62), where every workload is exactly one Linear or matmul. ResNet/MobileNet weren't visibly affected because the head Linear's zero contribution is small relative to the conv stack; ViT was muted because `MultiheadAttention` goes through the `call_module` path.

## Root cause
- `nn.Linear` is not an FX leaf module by default, so symbolic_trace lowers it to `call_function torch.nn.functional.linear`. Same for `torch.matmul`.
- PR #56 added `_aten_weight_bytes` / `_arg_numel` and `_flops_*_aten` helpers but tested only against Dynamo export, missing the symbolic_trace meta key.

## Changes
- `src/graphs/transform/partitioning/fusion_partitioner.py`
  - new `_meta_shape(arg)` helper returns a tuple of ints by reading `meta['val'].shape` (Dynamo) or `meta['tensor_meta'].shape` (symbolic_trace), `None` if neither is populated
  - new `_meta_numel(arg)` for callers needing total element count
  - `_arg_numel`, `_flops_conv2d_aten`, `_flops_linear_aten` (linear / matmul / addmm branches), `_flops_addmm_aten` all flow through the new helpers
- `tests/transform/partitioning/test_symbolic_trace_aten_meta.py` -- 13 new regression cases:
  - helper unit tests (reads `tensor_meta`, returns `None` when absent, `_meta_numel` math)
  - single `nn.Linear` via symbolic_trace at 4 shapes
  - single `torch.matmul` via symbolic_trace at 3 shapes
  - no-bias Linear
  - precision scaling preservation (regression check on PR #54)
  - **Dynamo-path negative control** (regression check on PR #56) -- this PR must not regress the original Dynamo flow

## Verification

Single Linear (B=64, IN=1024, OUT=1024) fp32 via symbolic_trace:

| Metric | Before this PR | After this PR | Expected |
|---|---:|---:|---:|
| `total_flops` | 0 | **134,217,728** | 2 × 64 × 1024² = 134,217,728 |
| `total_weight_bytes` | 0 | **4,198,400** | 4 × (1024² + 1024) = 4,198,400 |

Single matmul (M=128, K=256, N=64) fp32 via symbolic_trace:

| Metric | Before | After | Expected |
|---|---:|---:|---:|
| `total_flops` | 0 | **4,194,304** | 2 × 128 × 256 × 64 |
| `total_weight_bytes` | 0 | **0** | 0 (both args are activations) |

## Test Results
- New regression suite: 13/13 passed
- Full unit suite: **1600 passed**, 11 skipped, 1 xfailed in 138s (was 1587; +13 new tests, **zero regressions** including the Dynamo-path negative control).

## Test plan
- [x] Fast CI passes
- [x] Promote to ready when satisfied: `gh pr ready`

## Related
- Surfaced during V4-2 implementation (epic #62).
- Builds on PR #54 (precision-aware byte counts) and PR #56 (call_function weight extraction); the negative-control test in this PR locks both in for the symbolic_trace path too.

Resolves #63

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced FLOPs and memory accounting accuracy for neural network operations by robustly handling tensor metadata across different tracing methods.

* **Tests**
  * Added regression tests for FLOPs and memory byte accounting accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->