### PR TITLE
fix(hardware): correct i7-12700K FP32 spec to dual-FMA architectural truth

### DIFF
--- a/src/graphs/hardware/mappers/cpu.py
+++ b/src/graphs/hardware/mappers/cpu.py
@@ -697,9 +697,16 @@ def create_i7_12700k_mapper() -> CPUMapper:
     # ========================================================================
     # COMPUTE RESOURCE (AVX2 - 8-wide FP32)
     # ========================================================================
-    # AVX2: 8 FP32 ops/cycle per core (FMA: 2 ops × 8 lanes × 2 units = 32 ops/cycle peak)
-    # But realistic is ~16 ops/cycle (1 FMA unit active, not both)
-    ops_per_core_per_cycle_fp32 = 16  # Conservative: 1 FMA unit
+    # AVX2 + dual-FMA: 8 FP32 lanes * 2 ops/lane (FMA) * 2 FMA units/core
+    #   = 32 ops/cycle/core peak
+    # Pre-#68 spec used 16 ops/cycle (single FMA unit). MKL's optimized GEMM
+    # routinely saturates BOTH FMA units; V4 baseline shows real cube matmul
+    # at 909 GFLOPS, which is 126% of the old 720-GFLOPS spec -- physically
+    # impossible relative to that spec, demonstrating the underspec.
+    # The downstream efficiency_factor in the thermal profile (0.5) and
+    # compute_efficiency_scale in RooflineAnalyzer derate this theoretical
+    # peak to realistic sustained throughput per workload class.
+    ops_per_core_per_cycle_fp32 = 32  # AVX2 + dual FMA (#68)
     ops_per_core_per_cycle_int8 = 32  # VNNI: better INT8 throughput
 
     avx2_compute = ComputeResource(
@@ -713,8 +720,8 @@ def create_i7_12700k_mapper() -> CPUMapper:
         clock_domain=clock,
     )
 
-    # Peak FP32: 10 cores × 16 ops/cycle × 4.5 GHz = 720 GFLOPS sustained
-    # Peak INT8: 10 cores × 32 ops/cycle × 4.5 GHz = 1.44 TOPS sustained
+    # Peak FP32: 10 cores * 32 ops/cycle * 4.5 GHz = 1440 GFLOPS theoretical
+    # Peak INT8: 10 cores * 32 ops/cycle * 4.5 GHz = 1.44 TOPS sustained
 
     # ========================================================================
     # THERMAL PROFILE (Consumer CPU - realistic for continuous workload)
@@ -729,25 +736,32 @@ def create_i7_12700k_mapper() -> CPUMapper:
                 compute_resource=avx2_compute,
                 instruction_efficiency=0.65,  # Lower than Xeon (hybrid scheduling)
                 memory_bottleneck_factor=0.25,
-                # Measured efficiency across ResNet/ViT workloads: median ~50% of
-                # theoretical peak (range 37-63%). CPUs have no tile quantization
-                # so tile_utilization=1.0; efficiency_factor captures AVX2 ISA
-                # overhead, cache miss rate, and hybrid core scheduling.
-                efficiency_factor=0.50,
+                # efficiency_factor halved (was 0.50, now 0.25) to compensate for
+                # the spec correction in #68: theoretical peak doubled from
+                # 720 (1 FMA unit) to 1440 GFLOPS (dual FMA, the architectural
+                # truth). Effective sustained peak (theoretical * efficiency_factor)
+                # stays at 360 GFLOPS, matching V4 baseline median achieved.
+                # The previous 0.50 was anchored to ResNet/ViT median ~50% of
+                # the under-counted 720 GFLOPS spec.
+                efficiency_factor=0.25,
                 tile_utilization=1.0,
                 native_acceleration=True,
             ),
             Precision.FP16: PerformanceCharacteristics(
                 precision=Precision.FP16,
                 compute_resource=avx2_compute,
-                efficiency_factor=0.25,  # Emulated, worse than FP32
+                # Halved from 0.25 -> 0.125 to compensate for #68 spec bump
+                # (same effective rate as before).
+                efficiency_factor=0.125,
                 tile_utilization=1.0,
                 native_acceleration=False,
             ),
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
                 compute_resource=avx2_compute,
-                efficiency_factor=0.45,  # Better with VNNI
+                # INT8 path is unchanged at the spec level (32 ops/cycle was
+                # already correct for VNNI dp4a) -- keep efficiency_factor.
+                efficiency_factor=0.45,
                 tile_utilization=1.0,
                 native_acceleration=True,
             ),
@@ -769,7 +783,7 @@ def create_i7_12700k_mapper() -> CPUMapper:
         precision_profiles={
             Precision.FP32: PrecisionProfile(
                 precision=Precision.FP32,
-                peak_ops_per_sec=720e9,  # 720 GFLOPS sustained
+                peak_ops_per_sec=1440e9,  # 1440 GFLOPS theoretical (AVX2 + dual FMA, #68)
                 tensor_core_supported=False,
                 relative_speedup=1.0,
                 bytes_per_element=4,
@@ -928,7 +942,7 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
     # ========================================================================
     # COMPUTE RESOURCE (same - AVX2 8-wide FP32)
     # ========================================================================
-    ops_per_core_per_cycle_fp32 = 16  # 1 FMA unit
+    ops_per_core_per_cycle_fp32 = 32  # AVX2 + dual FMA (#68)
     ops_per_core_per_cycle_int8 = 32  # VNNI
 
     avx2_compute = ComputeResource(
@@ -942,7 +956,8 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
         clock_domain=clock,
     )
 
-    # Peak FP32: 10 cores × 16 ops/cycle × 4.5 GHz = 720 GFLOPS sustained
+    # Peak FP32: 10 cores * 32 ops/cycle * 4.5 GHz = 1440 GFLOPS theoretical
+    # (AVX2 + dual FMA, see #68)
 
     # ========================================================================
     # THERMAL PROFILE - LARGE MODEL TUNING
@@ -956,10 +971,13 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
             Precision.FP32: PerformanceCharacteristics(
                 precision=Precision.FP32,
                 compute_resource=avx2_compute,
-                instruction_efficiency=0.80,  # ↑ from 0.65 (better loop optimization)
-                memory_bottleneck_factor=0.65,  # ↑↑ from 0.25 (compute-bound!)
-                efficiency_factor=0.60,  # ↑↑↑ from 0.20 (better amortization)
-                tile_utilization=0.80,  # ↑ from 0.50 (better core saturation)
+                instruction_efficiency=0.80,  # better loop optimization for large models
+                memory_bottleneck_factor=0.65,  # large = compute-bound
+                # Halved from 0.60 -> 0.30 to compensate for #68 spec bump
+                # (theoretical doubled from 720 to 1440 GFLOPS); effective
+                # peak unchanged.
+                efficiency_factor=0.30,
+                tile_utilization=0.80,
                 native_acceleration=True,
             ),
             Precision.FP16: PerformanceCharacteristics(
@@ -967,7 +985,8 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
                 compute_resource=avx2_compute,
                 instruction_efficiency=0.70,
                 memory_bottleneck_factor=0.60,
-                efficiency_factor=0.30,  # ↑ from 0.10 (emulated but better amortized)
+                # Halved from 0.30 -> 0.15 (#68 compensation).
+                efficiency_factor=0.15,
                 tile_utilization=0.75,
                 native_acceleration=False,
             ),
@@ -998,7 +1017,7 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
         precision_profiles={
             Precision.FP32: PrecisionProfile(
                 precision=Precision.FP32,
-                peak_ops_per_sec=720e9,  # 720 GFLOPS sustained
+                peak_ops_per_sec=1440e9,  # 1440 GFLOPS theoretical (AVX2 + dual FMA, #68)
                 tensor_core_supported=False,
                 relative_speedup=1.0,
                 bytes_per_element=4,

--- a/tests/hardware/test_i7_12700k_fp32_spec.py
+++ b/tests/hardware/test_i7_12700k_fp32_spec.py
@@ -1,0 +1,108 @@
+"""Regression tests for the i7-12700K FP32 spec correction (issue #68).
+
+The pre-#68 spec used 16 ops/cycle/core for FP32, assuming a single
+FMA unit. Real Alder Lake P-cores have two FMA units that MKL routinely
+saturates -- V4 baseline measured 909 GFLOPS achieved on a 2048^3 cube
+matmul, exceeding the spec's 720 GFLOPS theoretical peak (physically
+impossible relative to that spec).
+
+This PR doubled the theoretical peak (16 -> 32 ops/cycle, 720 -> 1440
+GFLOPS) AND halved efficiency_factor (0.50 -> 0.25 in the consumer-
+continuous thermal profile, 0.60 -> 0.30 in the consumer-continuous-
+large profile) so the EFFECTIVE peak is unchanged at 360 GFLOPS. The
+spec is now architecturally honest; effective sustained throughput is
+preserved.
+
+These tests lock in:
+1. theoretical peak is now 1440 GFLOPS (matches AVX2 + dual-FMA math)
+2. effective peak (post-thermal-derate) is unchanged at 360 GFLOPS
+3. precision_profiles.peak_ops_per_sec matches the theoretical headline
+4. ops_per_unit_per_clock for FP32 is 32 (not 16)
+"""
+
+import pytest
+
+from graphs.estimation.roofline import RooflineAnalyzer
+from graphs.hardware.mappers.cpu import (
+    create_i7_12700k_mapper,
+    create_i7_12700k_large_mapper,
+)
+from graphs.hardware.resource_model import Precision
+
+
+# ---------------------------------------------------------------------------
+# Tiny variant (default)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def i7_tiny():
+    return create_i7_12700k_mapper().resource_model
+
+
+def test_i7_tiny_theoretical_peak_fp32_is_dual_fma(i7_tiny):
+    """Theoretical headline must reflect dual FMA (#68): 1440 GFLOPS."""
+    assert i7_tiny.get_peak_ops(Precision.FP32) == 1440e9
+
+
+def test_i7_tiny_effective_peak_fp32_unchanged(i7_tiny):
+    """The whole point of the compensating efficiency_factor halve: the
+    EFFECTIVE peak (what RooflineAnalyzer uses) stays at 360 GFLOPS.
+    No V4 pass-rate disruption from a pure spec correction."""
+    effective = RooflineAnalyzer._get_effective_peak_ops(i7_tiny, Precision.FP32)
+    assert effective == 360e9
+
+
+def test_i7_tiny_precision_profile_matches_theoretical(i7_tiny):
+    """precision_profiles.peak_ops_per_sec carries the theoretical
+    headline so the legacy fallback path (when thermal_operating_points
+    is missing) returns the right value."""
+    assert i7_tiny.precision_profiles[Precision.FP32].peak_ops_per_sec == 1440e9
+
+
+# ---------------------------------------------------------------------------
+# Large variant
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def i7_large():
+    return create_i7_12700k_large_mapper().resource_model
+
+
+def test_i7_large_theoretical_peak_fp32_matches_tiny(i7_large):
+    """Same physical hardware -> same theoretical peak. Only the thermal
+    derate values differ between the tiny and large variants."""
+    assert i7_large.get_peak_ops(Precision.FP32) == 1440e9
+
+
+def test_i7_large_effective_peak_fp32_unchanged(i7_large):
+    """large variant: effective = sustained_ops * tile_utilization * efficiency_factor.
+    Pre-#68:  720 * 0.80 * 0.60 = 345.6 GFLOPS
+    Post-#68: 1440 * 0.80 * 0.30 = 345.6 GFLOPS (theoretical doubled,
+    efficiency_factor halved -> net unchanged)."""
+    effective = RooflineAnalyzer._get_effective_peak_ops(i7_large, Precision.FP32)
+    assert effective == pytest.approx(345.6e9, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Behavioral check: "above peak" no longer happens
+# ---------------------------------------------------------------------------
+
+
+def test_i7_max_measured_is_below_theoretical_peak(i7_tiny):
+    """V4 baseline measured 909 GFLOPS as the max single-kernel matmul
+    on i7-12700K. After #68 the theoretical spec accommodates this --
+    no measurement exceeds the spec."""
+    measured_max_gflops = 909.0  # from V4 baseline (2048^3 fp32)
+    spec_theoretical_gflops = i7_tiny.get_peak_ops(Precision.FP32) / 1e9
+    assert measured_max_gflops < spec_theoretical_gflops, (
+        f"Measured {measured_max_gflops} GFLOPS still exceeds spec "
+        f"{spec_theoretical_gflops} -- spec correction insufficient."
+    )
+    # Also: measured max should be a reasonable fraction of theoretical.
+    # MKL on Alder Lake achieves ~63% of dual-FMA theoretical for cubes.
+    util = measured_max_gflops / spec_theoretical_gflops
+    assert 0.40 < util < 0.80, (
+        f"Implausible utilization {util*100:.0f}% -- check spec or measurement."
+    )

--- a/tests/validation_model_v4/test_classify.py
+++ b/tests/validation_model_v4/test_classify.py
@@ -75,15 +75,24 @@ def test_op_footprint_rejects_unknown_op():
 
 def test_i7_12700k_capacities_fp32():
     """i7-12700K: 16 cores * 32KB L1 = 512KB L1 total. L2_cache_total
-    holds the LLC value (25MB Intel L3 by M1 schema convention)."""
+    holds the LLC value (25MB Intel L3 by M1 schema convention).
+
+    cap.peak_flops is the EFFECTIVE peak (after thermal / efficiency
+    derate), not the raw theoretical spec from precision_profiles. See
+    the docstring of hardware_capacities for the rationale (#68)."""
+    from graphs.estimation.roofline import RooflineAnalyzer
     hw = create_i7_12700k_mapper().resource_model
     cap = hardware_capacities(hw, Precision.FP32)
     assert cap.l1_total_bytes == hw.compute_units * hw.l1_cache_per_unit
     assert cap.l2_total_bytes == hw.l2_cache_total
     assert cap.on_chip_total_bytes == cap.l1_total_bytes + cap.l2_total_bytes
     assert cap.peak_dram_bandwidth_bps == hw.peak_bandwidth
-    assert cap.peak_flops == hw.get_peak_ops(Precision.FP32)
+    # Effective peak (used for AI breakpoint), NOT theoretical spec
+    expected_peak = RooflineAnalyzer._get_effective_peak_ops(hw, Precision.FP32)
+    assert cap.peak_flops == expected_peak
     assert cap.ai_breakpoint == cap.peak_flops / cap.peak_dram_bandwidth_bps
+    # Sanity: effective should be derated from theoretical
+    assert cap.peak_flops < hw.get_peak_ops(Precision.FP32)
 
 
 def test_h100_capacities_fp16():

--- a/validation/model_v4/sweeps/classify.py
+++ b/validation/model_v4/sweeps/classify.py
@@ -159,14 +159,46 @@ def hardware_capacities(
 ) -> HardwareCapacities:
     """Pull the capacity and roofline numbers the classifier needs.
 
+    The classifier asks "is this shape compute-bound or memory-bound on
+    this hardware?" The honest answer requires the **effective** peak
+    (what real workloads can attain after thermal / efficiency derate),
+    not the raw theoretical spec. Otherwise a hardware whose theoretical
+    peak doubles (e.g., #68 corrected i7-12700K from 720 -> 1440 GFLOPS)
+    would silently shift sweep regime labels even though achievable
+    throughput is unchanged.
+
+    Effective peak comes from RooflineAnalyzer._get_effective_peak_ops,
+    which honors thermal_operating_points -> default_thermal_profile ->
+    legacy precision_profiles in priority order. Same code path the
+    analyzer's roofline math uses.
+
     Only fields that already exist on HardwareResourceModel are used; if
-    we add explicit L1/L2 bandwidth peaks later, this is the one place
-    that needs to grow.
+    we add explicit L1/L2 bandwidth peaks later (#61), this is the one
+    place that needs to grow.
     """
+    # Late import: classify.py is the bottom of the v4 dependency stack;
+    # graphs.estimation.roofline imports lots of things. Late binding
+    # keeps the classifier importable in lightweight contexts (sweep
+    # generation, unit tests with mocked analyzers).
+    from graphs.estimation.roofline import RooflineAnalyzer
+
+    # Two distinct peak queries:
+    # 1. ``hw.get_peak_ops(precision)`` -- STRICT supported-precision check.
+    #    Raises if the precision is not in ``precision_profiles``. This
+    #    drives the UNSUPPORTED path: i7 has no native fp16, so trying to
+    #    classify fp16 work on i7 raises here and the caller returns
+    #    Regime.UNSUPPORTED.
+    # 2. ``RooflineAnalyzer._get_effective_peak_ops`` -- effective peak after
+    #    thermal / efficiency derate. This drives the AI breakpoint and the
+    #    launch-bound threshold. Using effective (not theoretical) peak
+    #    means a spec correction that changes only the theoretical headline
+    #    (#68: 720 -> 1440 GFLOPS, with compensating efficiency_factor halve)
+    #    does not silently shift sweep regime labels.
+    hw.get_peak_ops(precision)  # raises -> caller -> Regime.UNSUPPORTED
     l1_total = hw.compute_units * hw.l1_cache_per_unit
     l2_total = hw.l2_cache_total or 0
     on_chip = l1_total + l2_total
-    peak_flops = hw.get_peak_ops(precision)
+    peak_flops = RooflineAnalyzer._get_effective_peak_ops(hw, precision)
     peak_bw = hw.peak_bandwidth
     ai_breakpoint = peak_flops / peak_bw if peak_bw > 0 else math.inf
     return HardwareCapacities(


### PR DESCRIPTION
## Summary
Resolves #68. Pre-this-PR i7 spec used `ops_per_core_per_cycle_fp32 = 16`, declaring 720 GFLOPS theoretical peak — assuming only one FMA unit active. Real Alder Lake has **two** FMA units that MKL routinely saturates. V4 baseline measured **909 GFLOPS** achieved (2048^3 cube matmul), which exceeded the 720 spec — physically nonsensical relative to that spec.

This PR makes the spec match what hardware can actually do, **without** changing V4 effective predictions (compensating efficiency_factor halve).

## Changes

### `src/graphs/hardware/mappers/cpu.py`
| Variant | knob | pre | post |
|---|---|---|---|
| both | `ops_per_core_per_cycle_fp32` | 16 | **32** |
| both | `precision_profiles[FP32].peak_ops_per_sec` | 720e9 | **1440e9** |
| tiny | `efficiency_factor` (FP32) | 0.50 | **0.25** |
| tiny | `efficiency_factor` (FP16) | 0.25 | 0.125 |
| large | `efficiency_factor` (FP32) | 0.60 | **0.30** |
| large | `efficiency_factor` (FP16) | 0.30 | 0.15 |

Net effective peak unchanged:
- tiny: `1440 * 1.0 * 0.25 = 360 GFLOPS` (was `720 * 1.0 * 0.50 = 360`)
- large: `1440 * 0.80 * 0.30 = 345.6 GFLOPS` (was `720 * 0.80 * 0.60 = 345.6`)

### `validation/model_v4/sweeps/classify.py`
The spec doubling exposed a classifier-side issue: it used `hw.get_peak_ops()` (theoretical), so the 720→1440 bump would have silently shifted regime labels (e.g., 18.87M matmul fp32 dropped from L2_BOUND to LAUNCH_BOUND because launch threshold = compute_time < 5 * launch_overhead, and compute_time depends on peak).

Restructured to use both peaks per the right contract:
- `hw.get_peak_ops()` — STRICT supported-precision check (raises → UNSUPPORTED)
- `RooflineAnalyzer._get_effective_peak_ops` — EFFECTIVE peak for AI breakpoint + launch threshold

Same code path the analyzer's roofline math uses; pure spec corrections no longer drift sweep labels.

## V4 pass-rate impact
**Unchanged** (the whole point of compensating efficiency_factor):
- matmul: regime 30/60, latency **35/60**, energy 0/60 (same as post-#67)
- linear: regime 47/60, latency **10/60**, energy 0/60 (same as post-#67)

## Tests
- `tests/hardware/test_i7_12700k_fp32_spec.py` — 6 new cases:
  - theoretical peak now 1440 GFLOPS (matches AVX2 + dual-FMA math)
  - effective peak unchanged: 360 (tiny) / 345.6 (large) GFLOPS
  - precision_profiles.peak_ops_per_sec carries the theoretical headline
  - V4 measured max 909 GFLOPS is now physically below spec
- `tests/validation_model_v4/test_classify.py` — updated `test_i7_12700k_capacities_fp32` to assert effective (not theoretical) peak

Full unit suite: **1785 passed** (was 1779, +6 new), 11 skipped, 1 xfailed in 138s. Zero regressions.

## Why this matters now
- Spec is architecturally honest. A future re-run of V4 capture against an even-better-tuned MKL won't produce the "above peak" warning.
- Effective peak preserved, so #67's V4 calibration still holds.
- Sweep label stability: the classifier→effective-peak refactor protects future spec corrections from silently moving sweep regime labels.

## Test plan
- [x] Fast CI passes
- [x] Promote to ready when satisfied: `gh pr ready`

## Related
- Epic: #62
- Resolves: #68
- Sibling issues still open: #69 (small-linear under-prediction; in-model overhead), #71 (energy under-prediction; static-power floor)

Resolves #68

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected i7-12700K CPU FP32 performance specifications to align with actual hardware capabilities.
  * Updated peak performance calculations to reflect effective performance after system derating rather than theoretical maximum.

* **Tests**
  * Added regression tests validating the i7-12700K FP32 specification corrections.
  * Updated validation tests to verify performance metrics against effective peak calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->