### PR TITLE
fix(estimation): add 5us CPU dispatch-overhead floor to roofline predictions

### DIFF
--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -505,6 +505,18 @@ class RooflineAnalyzer:
         overhead = self._estimate_overhead(sg)
         actual_latency = bottleneck_time + overhead
 
+        # CPU dispatch floor (#69): real PyTorch / nn.Module call has ~5us
+        # of Python dispatch + parameter access + bias-add overhead per
+        # forward call. The roofline math doesn't model this, so very small
+        # ops (B=1 linear, tiny matmul) under-predict. Apply as a floor
+        # rather than additive overhead so it only kicks in when the kernel
+        # is too small to dominate -- avoids over-correcting medium ops
+        # where the overhead is amortized by real kernel time.
+        # V4 baseline shows the floor empirically: smallest measured shape
+        # (1,128,128 linear, 33K flops) lands at 5.20us wall-clock.
+        if self.resource_model.hardware_type.name == 'CPU':
+            actual_latency = max(actual_latency, 5e-6)
+
         # Arithmetic intensity
         ai = sg.flops / total_bytes if total_bytes > 0 else 0.0
 

--- a/tests/analysis/test_roofline_cpu_dispatch_floor.py
+++ b/tests/analysis/test_roofline_cpu_dispatch_floor.py
@@ -1,0 +1,145 @@
+"""Regression tests for the CPU dispatch-overhead floor (issue #69).
+
+Real PyTorch / nn.Module forward calls have a ~5us floor on CPU due to
+Python dispatch + parameter access + bias-add overhead. The roofline
+math doesn't model this, so very small ops (B=1 linear, tiny matmul)
+under-predict latency by 50-80%.
+
+The fix in #69 applies a 5us floor in RooflineAnalyzer._analyze_subgraph
+*after* the roofline math: ``actual_latency = max(predicted, 5us)`` for
+CPU. Implemented as a floor (not additive overhead) so it only kicks in
+when the kernel is too small to dominate, avoiding over-correction of
+medium ops where the overhead is amortized by real kernel time.
+
+Empirical anchor: V4 baseline measurement of (1,128,128) linear fp32
+on i7-12700K is 5.20us -- the wall-clock floor for any forward call.
+
+These tests lock in:
+1. CPU-typed hardware: floor is applied; predicted >= 5us
+2. GPU-typed hardware: NOT affected (GPU has its own kernel-launch overhead model)
+3. Floor only kicks in when the kernel is sub-floor; doesn't add to medium ops
+"""
+
+import pytest
+
+from graphs.core.structures import OperationType, SubgraphDescriptor
+from graphs.estimation.roofline import RooflineAnalyzer
+from graphs.hardware.mappers.cpu import create_i7_12700k_mapper
+from graphs.hardware.mappers.gpu import create_h100_sxm5_80gb_mapper
+from graphs.hardware.resource_model import Precision
+
+
+def _tiny_linear_subgraph() -> SubgraphDescriptor:
+    """A 1-op SubgraphDescriptor matching what V4 builds for (1,128,128)
+    linear fp32 -- 33K flops, ~66KB working set."""
+    return SubgraphDescriptor(
+        subgraph_id=0,
+        node_ids=["linear"],
+        node_names=["linear"],
+        operation_types=[OperationType.LINEAR],
+        fusion_pattern="linear",
+        total_flops=2 * 1 * 128 * 128,        # 32,768
+        total_macs=1 * 128 * 128,
+        total_input_bytes=1 * 128 * 4,         # 512
+        total_output_bytes=1 * 128 * 4,        # 512
+        total_weight_bytes=(128 * 128 + 128) * 4,  # 66,048
+    )
+
+
+def _medium_linear_subgraph() -> SubgraphDescriptor:
+    """(32, 384, 768) linear fp32 -- 18.87M flops, well above the floor."""
+    return SubgraphDescriptor(
+        subgraph_id=0,
+        node_ids=["linear"],
+        node_names=["linear"],
+        operation_types=[OperationType.LINEAR],
+        fusion_pattern="linear",
+        total_flops=2 * 32 * 384 * 768,
+        total_macs=32 * 384 * 768,
+        total_input_bytes=32 * 384 * 4,
+        total_output_bytes=32 * 768 * 4,
+        total_weight_bytes=(384 * 768 + 768) * 4,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Floor IS applied for CPU
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_floor_applies_to_tiny_op():
+    """A predicted-sub-floor CPU op must be raised to the 5us floor."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP32)
+    sg = _tiny_linear_subgraph()
+    lat = analyzer._analyze_subgraph(sg)
+    # The floor is 5us; any prediction below it gets raised.
+    assert lat.actual_latency >= 5e-6, (
+        f"CPU floor not applied: actual_latency={lat.actual_latency*1e6:.2f}us"
+    )
+
+
+def test_cpu_floor_does_not_inflate_medium_op():
+    """A predicted-above-floor op must be unchanged by the floor."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP32)
+    sg = _medium_linear_subgraph()
+    lat = analyzer._analyze_subgraph(sg)
+    # Medium op predicts well above 5us; floor must not move it.
+    assert lat.actual_latency > 5e-6  # sanity
+    # The floor would only matter if compute_time + memory_time + overhead
+    # were < 5us; for this 18.87M flop op they're easily larger.
+    no_floor_estimate = max(lat.compute_time, lat.memory_time) + lat.overhead
+    assert lat.actual_latency == pytest.approx(no_floor_estimate, rel=1e-9), (
+        f"Floor incorrectly inflated medium op: "
+        f"actual={lat.actual_latency*1e6:.2f}us, no_floor={no_floor_estimate*1e6:.2f}us"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Floor is NOT applied for non-CPU hardware
+# ---------------------------------------------------------------------------
+
+
+def test_gpu_does_not_get_cpu_floor():
+    """GPU has its own kernel-launch overhead model; the CPU dispatch
+    floor must not bleed into GPU predictions."""
+    hw = create_h100_sxm5_80gb_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+    # Build a tiny op
+    sg = SubgraphDescriptor(
+        subgraph_id=0,
+        node_ids=["x"], node_names=["x"],
+        operation_types=[OperationType.LINEAR],
+        fusion_pattern="linear",
+        total_flops=2 * 1 * 64 * 64,   # tiny
+        total_macs=1 * 64 * 64,
+        total_input_bytes=128, total_output_bytes=128,
+        total_weight_bytes=(64 * 64 + 64) * 2,
+    )
+    lat = analyzer._analyze_subgraph(sg)
+    # GPU has its own 5us launch overhead; the result should equal
+    # bottleneck + overhead with NO additional CPU floor enforcement.
+    no_floor_estimate = max(lat.compute_time, lat.memory_time) + lat.overhead
+    assert lat.actual_latency == pytest.approx(no_floor_estimate, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# V4 baseline: (1,128,128) linear is the canonical anchor
+# ---------------------------------------------------------------------------
+
+
+def test_v4_anchor_shape_predicts_within_band_of_baseline():
+    """The V4 baseline shows (1,128,128) linear fp32 on i7 measured at
+    5.20us (the wall-clock floor). With the dispatch floor the prediction
+    should land within the LAUNCH 30% tolerance band of that measurement."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP32)
+    sg = _tiny_linear_subgraph()
+    lat = analyzer._analyze_subgraph(sg)
+    measured_s = 5.20e-6
+    rel_err = abs(lat.actual_latency - measured_s) / measured_s
+    assert rel_err <= 0.30, (
+        f"Predicted {lat.actual_latency*1e6:.2f}us is {rel_err*100:.0f}% "
+        f"off from baseline 5.20us (LAUNCH band: 30%)"
+    )


### PR DESCRIPTION
## Summary
Resolves #69. Real PyTorch / nn.Module forward calls have a ~5us floor on CPU due to Python dispatch + parameter access + bias-add overhead. The roofline math doesn't model this, so very small ops (B=1 linear, tiny matmul) under-predict by 50-80%.

V4 baseline shows the floor empirically: the smallest measured shape ((1,128,128) linear fp32 on i7-12700K) takes **5.20us wall-clock** — the floor for any forward call on this hardware.

## Diagnostic finding

Tracing the analyzer's per-shape breakdown for tiny linear shapes:

| shape | compute_us | memory_us | overhead_us | predicted | measured |
|---|---:|---:|---:|---:|---:|
| (1, 128, 128) | 0.30 | 1.79 | 0.00 | **1.79** | 5.20 |
| (1, 128, 256) | 0.61 | 3.56 | 0.00 | **3.56** | 8.88 |
| (2, 128, 128) | 0.61 | 1.82 | 0.00 | **1.82** | 9.61 |
| (32, 384, 768) | 51.45 | 35.47 | 0.00 | 51.45 | 54.20 |

Predictions for medium ops are accurate; tiny ops miss by ~3-5x because the dispatch floor isn't modeled.

## Fix
`RooflineAnalyzer._analyze_subgraph` now applies `max(actual_latency, 5e-6)` for CPU. **Floor**, not additive overhead — only kicks in when the kernel is too small to dominate. Medium ops are unaffected.

```python
if self.resource_model.hardware_type.name == 'CPU':
    actual_latency = max(actual_latency, 5e-6)
```

## V4 pass-rate impact (i7-12700K)

|                       | Pre-#69 | Post-#69 |
|---|---:|---:|
| linear calibration    | 3/18    | **4/18** (+1) |
| linear validation     | 10/60   | 10/60 (unchanged) |
| matmul calibration    | 9/18    | 9/18 (no regression) |
| matmul validation     | 35/60   | 35/60 (no regression) |

The single shape that flips: (1, 128, 128) linear fp32. Pre-fix predicted 1.79us vs measured 5.20us (-66% — fail). Post-fix predicted 5.00us vs measured 5.20us (-4% — pass).

The validation sweep doesn't include sub-floor shapes (deliberately, since V4 was designed to sample the regime sweet spots). The fix is **principled and harmless** — predictions are now closer to truth for the smallest kernels even where pass-rate metrics don't reflect it.

## Tests
- `tests/analysis/test_roofline_cpu_dispatch_floor.py` — 4 new cases:
  - Floor IS applied for CPU on tiny ops (raised to 5us)
  - Floor is NOT applied for medium CPU ops (passes through unchanged — guards against over-correcting amortized-overhead shapes)
  - Floor is NOT applied for GPU (GPU has its own kernel-launch model)
  - V4 anchor (1,128,128) linear predicts within LAUNCH 30% band of the 5.20us baseline measurement

Full unit suite: **1783 passed** (was 1779, +4 new), 11 skipped, 1 xfailed.

## Bug surfaced and filed during this work
- **#74 (new)** — i7-12700K medium B=1 large IN/OUT linear shapes are *over-predicted* by 100-260% because `_get_bandwidth_efficiency_scale` returns hardcoded 0.5 for CPU, making memory_time pessimistic when real workloads stream through cache effectively. Same calibration approach (anchor to V4 baseline) that resolved #67 applies here. Filed for follow-up.

## Test plan
- [x] Fast CI passes
- [x] Promote to ready when satisfied: `gh pr ready`

## Related
- Epic: #62
- Resolves: #69
- Surfaced sibling issue: #74 (CPU bandwidth_efficiency_scale)
- Other open V4 drift bugs: #71 (energy under-prediction)

Resolves #69

Generated with [Claude Code](https://claude.com/claude-code)