### PR TITLE
fix(estimation): calibrate CPU energy idle-power + sub-ms RAPL skip

### DIFF
--- a/src/graphs/estimation/energy.py
+++ b/src/graphs/estimation/energy.py
@@ -263,9 +263,21 @@ class EnergyAnalyzer:
     - Static energy: Leakage power, always-on circuits (significant on modern hardware)
     """
 
-    # Idle power fractions (from silicon leakage and always-on circuits)
-    IDLE_POWER_FRACTION = 0.3  # GPUs: ~30% of TDP at idle
-    CPU_IDLE_POWER_FRACTION = 0.1  # CPUs: ~10% of TDP at idle
+    # Average package power during *active* kernel execution, as a fraction
+    # of TDP. The legacy name "IDLE_POWER_FRACTION" is preserved for backward
+    # compatibility, but the semantic is "what fraction of TDP does RAPL
+    # actually measure during a busy matmul kernel" -- not the literal silicon
+    # leakage at zero load.
+    #
+    # For RAPL/NVML-validated hardware:
+    # * GPUs draw ~30-50% of TDP during steady-state matmul (memory subsystem
+    #   active, SM utilization sub-100%, fan ramp).
+    # * CPUs draw ~70-85% of TDP during DRAM-bound matmul (cores at boost,
+    #   uncore/L3/IMC fully active). Issue #71 measured ~110W avg on a
+    #   125W i7-12700K -> 0.7 lands inside the 30% energy tolerance band
+    #   for above-1ms shapes, where RAPL resolution is reliable.
+    IDLE_POWER_FRACTION = 0.3       # GPUs: validated against NVML on H100
+    CPU_IDLE_POWER_FRACTION = 0.7   # CPUs: calibrated to V4 RAPL baseline (#71)
 
     def __init__(
         self,

--- a/src/graphs/estimation/energy.py
+++ b/src/graphs/estimation/energy.py
@@ -352,7 +352,13 @@ class EnergyAnalyzer:
             peak_dynamic_power = peak_flops * self.energy_per_flop
             self.tdp_watts = peak_dynamic_power * 2.0
 
-        # Idle power
+        # "Idle" power -- but see CPU_IDLE_POWER_FRACTION docstring above:
+        # on CPU this is the *average package power during an active kernel*
+        # (~70% of TDP, calibrated to V4 RAPL baseline in #71), not literal
+        # silicon leakage. The attribute name is preserved for backward
+        # compatibility, but downstream consumers should treat this as
+        # "static power during execution" on CPU. On GPU it remains close
+        # to the literal idle-state power (~30% of TDP).
         if self.resource_model.hardware_type.name == 'CPU':
             self.idle_power_watts = self.tdp_watts * self.CPU_IDLE_POWER_FRACTION
         else:

--- a/tests/analysis/test_energy_cpu_active_power.py
+++ b/tests/analysis/test_energy_cpu_active_power.py
@@ -24,12 +24,9 @@ Tests below pin:
    than the 1.5pJ/flop dynamic term ever can).
 """
 
-import pytest
-
 from graphs.core.structures import OperationType, SubgraphDescriptor
 from graphs.estimation.energy import EnergyAnalyzer
 from graphs.hardware.mappers.cpu import create_i7_12700k_mapper
-from graphs.hardware.mappers.gpu import create_h100_sxm5_80gb_mapper
 from graphs.hardware.resource_model import Precision
 
 

--- a/tests/analysis/test_energy_cpu_active_power.py
+++ b/tests/analysis/test_energy_cpu_active_power.py
@@ -103,6 +103,9 @@ def test_static_energy_dominates_typical_cpu_matmul():
     1.5 pJ/flop dynamic term was the only meaningful contributor for
     sub-mJ kernels; post-#71 the active package power swamps it.
 
+    Goes through the public ``analyze`` entry point so the test is robust
+    to refactors of the private ``_analyze_subgraph`` signature.
+
     This test would have failed with the pre-#71 0.1 constant for any
     DRAM-bound shape (where flops/byte is low and static dominates)."""
     hw = create_i7_12700k_mapper().resource_model
@@ -110,15 +113,15 @@ def test_static_energy_dominates_typical_cpu_matmul():
     sg = _matmul_subgraph(1024, 1024, 1024)  # ~12 MB working set, in L2
     # Use a representative latency in the V4 baseline range
     latency_s = 5e-3
-    desc = analyzer._analyze_subgraph(sg, latency=latency_s)
-    assert desc.static_energy_j > desc.compute_energy_j, (
-        f"static ({desc.static_energy_j*1e3:.2f}mJ) should dominate compute "
-        f"({desc.compute_energy_j*1e3:.2f}mJ) for a typical CPU matmul; "
+    report = analyzer.analyze(subgraphs=[sg], latencies=[latency_s])
+    assert report.static_energy_j > report.compute_energy_j, (
+        f"static ({report.static_energy_j*1e3:.2f}mJ) should dominate compute "
+        f"({report.compute_energy_j*1e3:.2f}mJ) for a typical CPU matmul; "
         f"likely CPU_IDLE_POWER_FRACTION reverted toward pre-#71 0.1."
     )
-    assert desc.static_energy_j > desc.memory_energy_j, (
-        f"static ({desc.static_energy_j*1e3:.2f}mJ) should dominate memory "
-        f"({desc.memory_energy_j*1e3:.2f}mJ) for a typical CPU matmul."
+    assert report.static_energy_j > report.memory_energy_j, (
+        f"static ({report.static_energy_j*1e3:.2f}mJ) should dominate memory "
+        f"({report.memory_energy_j*1e3:.2f}mJ) for a typical CPU matmul."
     )
 
 
@@ -126,20 +129,23 @@ def test_predicted_total_energy_within_2x_of_v4_anchor():
     """V4 RAPL baseline for matmul (1024,1024,1024) fp32 on i7-12700K is
     in the 100-700 mJ band depending on M/K/N skew (avg power ~110W times
     measured latency 1-6ms). The analyzer prediction with the #71 idle
-    fraction must land within 2x of the lower band edge -- otherwise the
-    energy model has regressed back toward pre-#71 levels."""
+    fraction must land within 2x of the V4 anchor in BOTH directions --
+    a regression below 100 mJ means the fix reverted; growth above
+    1000 mJ would mean the constant overshot active-power calibration."""
     hw = create_i7_12700k_mapper().resource_model
     analyzer = EnergyAnalyzer(hw, precision=Precision.FP32)
     sg = _matmul_subgraph(1024, 1024, 1024)
     latency_s = 5e-3  # representative measured latency for this shape
-    desc = analyzer._analyze_subgraph(sg, latency=latency_s)
-    total_mj = (desc.compute_energy_j + desc.memory_energy_j
-                + desc.static_energy_j) * 1e3
+    report = analyzer.analyze(subgraphs=[sg], latencies=[latency_s])
+    total_mj = (report.compute_energy_j + report.memory_energy_j
+                + report.static_energy_j) * 1e3
     # The V4 baseline median is ~300 mJ for similar 5ms shapes.
     # Pre-#71 prediction at 5ms was ~70 mJ (1.5pJ * 2*1024^3 + 25pJ * 12MB
     # + 12.5W * 5ms = ~70mJ). Post-#71 should be ~440 mJ (87.5W * 5ms +
-    # dynamic). Anything below 100 mJ would mean the fix has reverted.
-    assert total_mj >= 100.0, (
+    # dynamic). Anything below 100 mJ means the fix reverted; anything
+    # above 1000 mJ means CPU_IDLE_POWER_FRACTION overshot.
+    assert 100.0 <= total_mj <= 1000.0, (
         f"Predicted total energy {total_mj:.1f}mJ for (1024,1024,1024) at "
-        f"5ms is below the 100mJ floor; the #71 fix has regressed."
+        f"5ms is outside the V4-anchored 100-1000 mJ band; the #71 "
+        f"calibration has drifted (regressed below floor or overshot)."
     )

--- a/tests/analysis/test_energy_cpu_active_power.py
+++ b/tests/analysis/test_energy_cpu_active_power.py
@@ -1,0 +1,148 @@
+"""Regression tests for the CPU active-package-power constant (issue #71).
+
+The pre-#71 EnergyAnalyzer used CPU_IDLE_POWER_FRACTION = 0.1, which gave
+an idle_power_watts of TDP * 0.1 (e.g., 12.5W for an i7-12700K @ 125W TDP).
+That value is a literal "leakage at zero load" estimate and dramatically
+under-counts the package power that RAPL actually integrates during a
+busy matmul kernel -- where the cores, uncore, IMC, and L3 are all active
+and the package draws ~70-85% of TDP.
+
+The fix in #71 bumps CPU_IDLE_POWER_FRACTION from 0.1 to 0.7. The constant
+is now interpreted as "average package power during an active kernel as
+a fraction of TDP", calibrated against the V4 RAPL baseline. Net effect on
+energy_predicted for above-1ms shapes:
+
+  pre-#71  median energy_pred / energy_meas = 0.10  (90% under-prediction)
+  post-#71 median energy_pred / energy_meas = 0.67  (just below 0.70 band)
+
+Tests below pin:
+1. The CPU constant is at least 0.5 (defends against silent revert).
+2. The GPU constant is unchanged (the #71 fix is CPU-specific).
+3. The computed idle_power_watts on i7-12700K is in the V4-validated band.
+4. Static energy now dominates dynamic for a typical CPU matmul (it should
+   -- a 100W+ active package power eats microjoules per FLOP much faster
+   than the 1.5pJ/flop dynamic term ever can).
+"""
+
+import pytest
+
+from graphs.core.structures import OperationType, SubgraphDescriptor
+from graphs.estimation.energy import EnergyAnalyzer
+from graphs.hardware.mappers.cpu import create_i7_12700k_mapper
+from graphs.hardware.mappers.gpu import create_h100_sxm5_80gb_mapper
+from graphs.hardware.resource_model import Precision
+
+
+# ---------------------------------------------------------------------------
+# Class-level constants -- defend the calibrated values
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_idle_fraction_is_at_least_50_percent():
+    """The pre-#71 value of 0.1 modelled silicon leakage. Real i7-12700K
+    package power during an active matmul is ~70-85% of TDP, per RAPL
+    bracketing in the V4 baseline. Anything below 0.5 is a regression
+    toward the pre-#71 under-prediction of energy by ~10x."""
+    assert EnergyAnalyzer.CPU_IDLE_POWER_FRACTION >= 0.5, (
+        f"CPU_IDLE_POWER_FRACTION={EnergyAnalyzer.CPU_IDLE_POWER_FRACTION} "
+        f"is below 0.5 -- regression toward pre-#71 0.1 constant. The V4 "
+        f"RAPL baseline measured ~110W avg on a 125W TDP i7, requiring "
+        f"a fraction of ~0.7 to stay inside the 30% energy tolerance band."
+    )
+
+
+def test_gpu_idle_fraction_unchanged_by_71_fix():
+    """#71 was a CPU-only fix (RAPL on Intel client). The GPU constant
+    must remain at its NVML-validated value of 0.3."""
+    assert EnergyAnalyzer.IDLE_POWER_FRACTION == 0.3, (
+        f"IDLE_POWER_FRACTION={EnergyAnalyzer.IDLE_POWER_FRACTION} drifted "
+        f"from the GPU NVML-validated 0.3 (the #71 fix was CPU-only)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# i7-12700K idle_power_watts must land in the calibrated band
+# ---------------------------------------------------------------------------
+
+
+def test_i7_idle_power_watts_in_calibrated_band():
+    """i7-12700K TDP=125W. With fraction=0.7, idle_power_watts=87.5W,
+    which matches the RAPL-measured ~80-110W avg power during V4 baseline
+    matmul kernels. The band is intentionally wide -- the point is to
+    catch a silent regression to the pre-#71 12.5W."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer = EnergyAnalyzer(hw, precision=Precision.FP32)
+    # 125 W * 0.7 = 87.5 W; allow +/- 30 W to permit future calibration
+    # within the active-power band (~60 W to ~120 W).
+    assert 50.0 <= analyzer.idle_power_watts <= 130.0, (
+        f"i7 idle_power_watts={analyzer.idle_power_watts:.1f}W outside the "
+        f"V4-calibrated 50-130W band; pre-#71 was 12.5W."
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: V4-style matmul predicts within RAPL noise of measurement
+# ---------------------------------------------------------------------------
+
+
+def _matmul_subgraph(M: int, K: int, N: int) -> SubgraphDescriptor:
+    """A single-op matmul SubgraphDescriptor matching what V4 builds."""
+    return SubgraphDescriptor(
+        subgraph_id=0,
+        node_ids=["mm"], node_names=["mm"],
+        operation_types=[OperationType.MATMUL],
+        fusion_pattern="matmul",
+        total_flops=2 * M * K * N,
+        total_macs=M * K * N,
+        total_input_bytes=(M * K + K * N) * 4,
+        total_output_bytes=M * N * 4,
+        total_weight_bytes=0,
+    )
+
+
+def test_static_energy_dominates_typical_cpu_matmul():
+    """For a typical i7 matmul, static energy (active package power *
+    latency) should be the dominant term after the #71 fix. Pre-#71, the
+    1.5 pJ/flop dynamic term was the only meaningful contributor for
+    sub-mJ kernels; post-#71 the active package power swamps it.
+
+    This test would have failed with the pre-#71 0.1 constant for any
+    DRAM-bound shape (where flops/byte is low and static dominates)."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer = EnergyAnalyzer(hw, precision=Precision.FP32)
+    sg = _matmul_subgraph(1024, 1024, 1024)  # ~12 MB working set, in L2
+    # Use a representative latency in the V4 baseline range
+    latency_s = 5e-3
+    desc = analyzer._analyze_subgraph(sg, latency=latency_s)
+    assert desc.static_energy_j > desc.compute_energy_j, (
+        f"static ({desc.static_energy_j*1e3:.2f}mJ) should dominate compute "
+        f"({desc.compute_energy_j*1e3:.2f}mJ) for a typical CPU matmul; "
+        f"likely CPU_IDLE_POWER_FRACTION reverted toward pre-#71 0.1."
+    )
+    assert desc.static_energy_j > desc.memory_energy_j, (
+        f"static ({desc.static_energy_j*1e3:.2f}mJ) should dominate memory "
+        f"({desc.memory_energy_j*1e3:.2f}mJ) for a typical CPU matmul."
+    )
+
+
+def test_predicted_total_energy_within_2x_of_v4_anchor():
+    """V4 RAPL baseline for matmul (1024,1024,1024) fp32 on i7-12700K is
+    in the 100-700 mJ band depending on M/K/N skew (avg power ~110W times
+    measured latency 1-6ms). The analyzer prediction with the #71 idle
+    fraction must land within 2x of the lower band edge -- otherwise the
+    energy model has regressed back toward pre-#71 levels."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer = EnergyAnalyzer(hw, precision=Precision.FP32)
+    sg = _matmul_subgraph(1024, 1024, 1024)
+    latency_s = 5e-3  # representative measured latency for this shape
+    desc = analyzer._analyze_subgraph(sg, latency=latency_s)
+    total_mj = (desc.compute_energy_j + desc.memory_energy_j
+                + desc.static_energy_j) * 1e3
+    # The V4 baseline median is ~300 mJ for similar 5ms shapes.
+    # Pre-#71 prediction at 5ms was ~70 mJ (1.5pJ * 2*1024^3 + 25pJ * 12MB
+    # + 12.5W * 5ms = ~70mJ). Post-#71 should be ~440 mJ (87.5W * 5ms +
+    # dynamic). Anything below 100 mJ would mean the fix has reverted.
+    assert total_mj >= 100.0, (
+        f"Predicted total energy {total_mj:.1f}mJ for (1024,1024,1024) at "
+        f"5ms is below the 100mJ floor; the #71 fix has regressed."
+    )

--- a/tests/validation_model_v4/test_assertions.py
+++ b/tests/validation_model_v4/test_assertions.py
@@ -229,6 +229,60 @@ def test_assert_record_predicted_energy_missing_skips_check():
     assert rec.all_pass() is True
 
 
+# ---------------------------------------------------------------------------
+# Issue #71: RAPL/NVML noise floor -- skip energy assertion below 1ms
+# ---------------------------------------------------------------------------
+
+
+def test_assert_record_skips_energy_when_measured_latency_sub_ms():
+    """RAPL on Intel client CPUs has 61 uJ resolution and integrates
+    across the whole package; below ~1 ms the relative noise on a single
+    energy reading is 50-100%. The assert_record helper must surface this
+    as pass_energy=None (skipped), not False (failure). See #71.
+
+    Critically, we use a measured_latency that's well below 1ms AND a
+    huge predicted/measured energy mismatch -- if the skip wasn't
+    happening, the band check would flip pass_energy to False."""
+    rec = assert_record(**_good_kwargs(
+        measured_latency_s=500e-6,    # 500 us, below the RAPL-reliable threshold
+        latency_predicted_s=400e-6,   # within 30% to keep latency passing
+        energy_predicted_j=0.001,     # wildly off from measured_energy_j=0.10
+        measured_energy_j=0.10,
+    ))
+    assert rec.pass_energy is None, (
+        "Energy assertion must be skipped (None) for sub-ms measurements; "
+        "RAPL noise makes single-shot energy measurements unreliable below "
+        "1ms. Got pass_energy=" + repr(rec.pass_energy)
+    )
+    # The latency check should still happen normally
+    assert rec.pass_latency is True
+
+
+def test_assert_record_evaluates_energy_when_measured_latency_above_ms():
+    """Above the RAPL-reliable threshold, energy is scored normally.
+    Negative control for the sub-ms skip behavior."""
+    rec = assert_record(**_good_kwargs(
+        measured_latency_s=2e-3,      # 2 ms, above threshold
+        latency_predicted_s=1.8e-3,
+        energy_predicted_j=0.001,     # wildly off
+        measured_energy_j=0.10,
+    ))
+    assert rec.pass_energy is False, (
+        "Above-1ms energy must be scored normally; got "
+        f"pass_energy={rec.pass_energy} (expected False)"
+    )
+
+
+def test_assert_record_skip_threshold_is_exactly_1ms():
+    """Pin the threshold constant -- regression guard against silent
+    drift (e.g., to 100 us or 10 ms)."""
+    from validation.model_v4.harness.assertions import ENERGY_RELIABLE_LATENCY_S
+    assert ENERGY_RELIABLE_LATENCY_S == 1e-3, (
+        f"ENERGY_RELIABLE_LATENCY_S={ENERGY_RELIABLE_LATENCY_S} drifted "
+        f"from the calibrated 1ms RAPL/NVML reliable-measurement floor."
+    )
+
+
 def test_assert_record_l2_predicted_ambiguous_measured_passes():
     """v4-1 soft match: L2_BOUND predicted, AMBIGUOUS measured (low
     utilization on every layer) still counts as a pass for the regime

--- a/tests/validation_model_v4/test_assertions.py
+++ b/tests/validation_model_v4/test_assertions.py
@@ -16,6 +16,7 @@ import math
 import pytest
 
 from validation.model_v4.harness.assertions import (
+    ENERGY_RELIABLE_LATENCY_S,
     MeasurementContext,
     TOL_ENERGY,
     TOL_LATENCY,
@@ -260,23 +261,31 @@ def test_assert_record_skips_energy_when_measured_latency_sub_ms():
 
 def test_assert_record_evaluates_energy_when_measured_latency_above_ms():
     """Above the RAPL-reliable threshold, energy is scored normally.
-    Negative control for the sub-ms skip behavior."""
+    Negative control for the sub-ms skip behavior.
+
+    Working set bumped to 200 MB so that bw_util = 200MB / 2ms / 100GB/s
+    = 1.0, keeping the inferred regime as DRAM_BOUND (above the 0.7
+    UTILIZATION_THRESHOLD). Otherwise the test would inadvertently flip
+    pass_regime as well, conflating two assertion paths."""
     rec = assert_record(**_good_kwargs(
         measured_latency_s=2e-3,      # 2 ms, above threshold
         latency_predicted_s=1.8e-3,
         energy_predicted_j=0.001,     # wildly off
         measured_energy_j=0.10,
+        working_set_bytes=200 * 1024 * 1024,  # keeps bw_util >= 0.7
     ))
     assert rec.pass_energy is False, (
         "Above-1ms energy must be scored normally; got "
         f"pass_energy={rec.pass_energy} (expected False)"
     )
+    # The energy assertion is the only signal -- regime + latency stay clean.
+    assert rec.pass_regime is True
+    assert rec.pass_latency is True
 
 
 def test_assert_record_skip_threshold_is_exactly_1ms():
     """Pin the threshold constant -- regression guard against silent
     drift (e.g., to 100 us or 10 ms)."""
-    from validation.model_v4.harness.assertions import ENERGY_RELIABLE_LATENCY_S
     assert ENERGY_RELIABLE_LATENCY_S == 1e-3, (
         f"ENERGY_RELIABLE_LATENCY_S={ENERGY_RELIABLE_LATENCY_S} drifted "
         f"from the calibrated 1ms RAPL/NVML reliable-measurement floor."

--- a/tests/validation_model_v4/test_v4_against_baseline.py
+++ b/tests/validation_model_v4/test_v4_against_baseline.py
@@ -11,9 +11,13 @@ should bump these numbers (and that's the whole point of the V4 dev
 loop). If a change makes the harness pass MORE than the floor, the
 test still passes; only a regression below the floor fails.
 
-Note: ``pass_energy`` is not asserted here. Issue #71 tracks the
-systematic energy under-prediction for short ops; until that's
-addressed, energy assertions cannot pass at any meaningful rate.
+Note on ``pass_energy``: issue #71 calibrated CPU_IDLE_POWER_FRACTION
+to the V4 RAPL baseline (0.1 -> 0.7) and added a sub-ms RAPL-noise skip
+to assert_record. Post-#71, matmul reaches 12/60 pass_energy with 30/60
+skipped (sub-ms RAPL-unreliable); linear stays at 0/60 pass with 60/60
+skipped (every linear shape in the sweep is sub-ms). The remaining
+matmul energy failures are the skinny DRAM-bound shapes whose latency
+under-predicts -- a separate analyzer issue, not an energy-model issue.
 """
 
 from pathlib import Path
@@ -83,6 +87,28 @@ def test_i7_matmul_pass_latency_floor():
         f"(floor: 30, was 0/60 before #67 fix). Compute efficiency curve in "
         f"RooflineAnalyzer._get_compute_efficiency_scale (CPU branch) likely "
         f"reverted toward pre-#67 values."
+    )
+
+
+def test_i7_matmul_pass_energy_floor():
+    """Issue #71 fix: at least 10 of 60 matmul records must pass the
+    per-regime energy tolerance band (was 0/60 before #71). The fix has
+    two parts:
+      1. CPU_IDLE_POWER_FRACTION 0.1 -> 0.7 (calibrated to V4 RAPL baseline)
+      2. Skip energy assertion when measured_latency < 1 ms (RAPL noise)
+
+    Sub-ms shapes (~30 of 60) get pass_energy=None (skipped), not False.
+    Of the remaining ~30 above-1ms shapes, ~12 pass and ~18 fail -- the
+    failing cohort all have under-predicted latency (separate issue);
+    static_energy = active_power * latency, so when latency is wrong,
+    energy is wrong by the same factor."""
+    total, _, _, passes_energy = _validation_pass_rate("matmul")
+    assert passes_energy >= 10, (
+        f"matmul pass_energy regressed below floor: {passes_energy}/{total} "
+        f"(floor: 10, was 0/60 before #71 fix). Likely root cause: "
+        f"CPU_IDLE_POWER_FRACTION in EnergyAnalyzer reverted toward pre-#71 "
+        f"0.1 (the literal-leakage interpretation), or the sub-ms RAPL skip "
+        f"was removed from assert_record."
     )
 
 

--- a/tests/validation_model_v4/test_v4_against_baseline.py
+++ b/tests/validation_model_v4/test_v4_against_baseline.py
@@ -42,6 +42,10 @@ def _validation_pass_rate(op: str) -> tuple[int, int, int, int]:
     total = len(result.records)
     passes_regime = sum(1 for r in result.records if r.pass_regime)
     passes_latency = sum(1 for r in result.records if r.pass_latency)
+    # pass_energy is tri-state (True / False / None); only True is counted as
+    # a pass. None (skipped, e.g. sub-ms RAPL per #71) and False (band miss)
+    # are both excluded. Mirrors the explicit `is False` pattern used in
+    # validation/model_v4/harness/report.py for failure counts.
     passes_energy = sum(1 for r in result.records if r.pass_energy)
     return total, passes_regime, passes_latency, passes_energy
 

--- a/validation/model_v4/harness/assertions.py
+++ b/validation/model_v4/harness/assertions.py
@@ -60,6 +60,16 @@ TOL_ENERGY: dict[Regime, float] = {
 UTILIZATION_THRESHOLD = 0.70
 
 
+# RAPL energy counter resolution on Intel client CPUs is 61 uJ; on top of
+# that, the counter integrates across the *whole package* including
+# unrelated background activity. Below ~1 ms of measurement, the relative
+# noise on a single-trial energy reading easily reaches 50-100%, so the
+# energy assertion is suppressed below this threshold (issue #71).
+# NVML on NVIDIA GPUs has similar lower-bound resolution (~1 ms power
+# samples), so the same threshold applies for GPU ground truth.
+ENERGY_RELIABLE_LATENCY_S = 1e-3
+
+
 # ---------------------------------------------------------------------------
 # ValidationRecord -- one per (shape, hardware) measurement
 # ---------------------------------------------------------------------------
@@ -254,6 +264,10 @@ def assert_record(
 
     if energy_predicted_j is None or measured_energy_j is None:
         pass_egy: Optional[bool] = None
+    elif measured_latency_s < ENERGY_RELIABLE_LATENCY_S:
+        # RAPL/NVML below ~1 ms is too noisy to score an energy band;
+        # treat as "not measured" rather than fail. See #71.
+        pass_egy = None
     else:
         pass_egy = _within_band(energy_predicted_j, measured_energy_j, tol_egy)
 


### PR DESCRIPTION
## Summary
- Bumps `CPU_IDLE_POWER_FRACTION` 0.1 -> 0.7 in `EnergyAnalyzer`. The constant is reinterpreted as \"average package power during an active kernel as a fraction of TDP\", calibrated against V4 RAPL baseline on i7-12700K (~110W avg on 125W TDP).
- Adds `ENERGY_RELIABLE_LATENCY_S = 1e-3` skip in `assert_record`. RAPL on Intel client CPUs is 61 uJ resolution and integrates whole-package power, so single-shot energy below ~1 ms is 50-100% noisy. Below the threshold, `pass_energy` is `None` (skipped) instead of `False` (failed).
- GPU `IDLE_POWER_FRACTION` (0.3) is unchanged -- the #71 fix is CPU-specific.

## Diagnostic motivating the fix

V4 i7-12700K matmul validation, only RAPL-reliable (>=1ms) shapes:

| Metric | pre-#71 | post-#71 |
|---|---|---|
| median energy_pred / energy_meas | 0.10 | 0.67 |
| matmul pass_energy | 0/60 | 12/60 |
| matmul pass_energy=None (skipped, sub-ms) | 0 | 30 |
| matmul pass_energy=False (above-ms, still failing) | 60 | 18 |

The remaining 18 above-ms failures all have under-predicted **latency** (ratio 0.5-0.8) -- they are skinny DRAM-bound shapes (one tiny dim like K=64 or M=64). When `static_energy = active_power * latency` dominates and latency is wrong, energy tracks 1:1 -- this is a separate analyzer issue, not an energy-model issue. A follow-up should track that.

Linear stays at 0/60 pass with 60/60 skipped because every linear shape in the current validation sweep is sub-ms; a follow-up should add larger linear shapes so `pass_energy` can be scored.

## Changes
- `src/graphs/estimation/energy.py` -- bump `CPU_IDLE_POWER_FRACTION`; rewrite the constant docstring to reflect the active-power semantic.
- `validation/model_v4/harness/assertions.py` -- add `ENERGY_RELIABLE_LATENCY_S` constant; add the sub-ms skip in `assert_record`.
- `tests/analysis/test_energy_cpu_active_power.py` -- new file, 5 regression tests.
- `tests/validation_model_v4/test_assertions.py` -- 3 new tests for the sub-ms skip behavior.
- `tests/validation_model_v4/test_v4_against_baseline.py` -- new floor test pinning matmul `pass_energy >= 10/60`.

## Test results
| Target | Result |
|---|---|
| tests/analysis/test_energy_cpu_active_power.py | PASS (5/5) |
| tests/validation_model_v4/test_assertions.py | PASS (24/24) |
| tests/validation_model_v4/test_v4_against_baseline.py | PASS (8/8) |
| Full tests/{analysis,validation_model_v4,hardware} | PASS (388/388) |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] CodeRabbit review

Resolves #71

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced energy modeling with per-unit power-state tracking and power-gating support.
  * Added hardware allocation integration for more accurate energy computations.
  * Expanded energy reports with detailed breakdowns of allocated vs. unallocated unit consumption.

* **Bug Fixes**
  * Improved measurement reliability by skipping energy assertions for sub-millisecond latencies to reduce RAPL/NVML noise impact.
  * Recalibrated CPU idle power estimates for improved accuracy.

* **Tests**
  * Added comprehensive regression tests for energy model validation and CPU power constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->