### PR TITLE
feat(validation): V4-4 Phase A -- pytorch_cuda + pytorch_jetson measurers

### DIFF
--- a/bin/v4-capture-h100.sh
+++ b/bin/v4-capture-h100.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# ============================================================================
+# H100 SXM5 80GB -- V4 baseline capture runbook
+#
+# Run this ON the H100 host (rented cloud instance, on-prem server, ...),
+# not on the dev box. Wall time: ~2 minutes total. The H100 is fast enough
+# that most of the sweep is sub-millisecond -- a fundamentally different
+# regime from the Jetson runbook.
+#
+# Treat the steps as separate "checkpoints" -- run one at a time, verify
+# the output before proceeding. The script does NOT execute end-to-end
+# with `bash` -- it's a runbook with copy-pasteable commands.
+# ============================================================================
+
+set -euo pipefail   # for any block you do choose to run as a script
+
+# ----------------------------------------------------------------------------
+# Step 1: Get the code and deps onto the H100 host
+# ----------------------------------------------------------------------------
+git clone https://github.com/branes-ai/graphs.git
+cd graphs
+# After PR #80 merges to main, drop this checkout. Until then:
+git checkout feat/v4-4-gpu-jetson-ground-truth
+
+# H100 hosts typically have a CUDA-enabled torch already (cloud images,
+# nvidia/pytorch container). Verify:
+python3 -c "import torch; print('torch:', torch.__version__,
+  'cuda:', torch.cuda.is_available(),
+  'device:', torch.cuda.get_device_name() if torch.cuda.is_available() else 'none')"
+# CHECKPOINT 1: cuda:True and device should report 'NVIDIA H100' (or similar).
+# If you're on a multi-GPU host, set CUDA_VISIBLE_DEVICES=0 to pin.
+
+pip install -e . pynvml
+
+# ----------------------------------------------------------------------------
+# Step 2: Verify NVML is queryable
+# ----------------------------------------------------------------------------
+nvidia-smi   # confirms the driver is loaded and reports the GPU(s)
+
+# Sanity-check the probe detector picks the right backend (total-energy
+# preferred, power-fallback acceptable):
+PYTHONPATH=src python3 -c "
+from validation.model_v4.ground_truth.pytorch_cuda import _detect_nvml
+probe = _detect_nvml()
+if probe is None:
+    print('NVML probe FAILED -- pynvml missing, driver mismatch, or both queries unsupported')
+else:
+    print(f'name={probe.name!r}, total_energy={probe.supports_total_energy}')
+    print(f'power now: {probe.read_power_mw()} mW')
+    if probe.supports_total_energy:
+        print(f'energy counter now: {probe.read_energy_mj()} mJ')
+"
+# CHECKPOINT 2: name should match your GPU; total_energy=True is preferred
+# (H100 supports it). Power should be ~50-100 W idle.
+
+# ----------------------------------------------------------------------------
+# Step 3: Smoke test with --limit 3 (~5 seconds total)
+# ----------------------------------------------------------------------------
+PYTHONPATH=src python3 -m validation.model_v4.cli.capture_ground_truth \
+    --hw h100_sxm5_80gb --op matmul --purpose validation --limit 3
+
+# Inspect the smoke-test CSV:
+cat validation/model_v4/results/baselines/h100_sxm5_80gb_matmul.csv
+# CHECKPOINT 3: 3 rows. latency_ms will be VERY small (microseconds to a
+# few ms), energy_mJ should still be present. If energy is 'n/a', go back
+# to Step 2 -- the power-fallback path is acceptable but the total-energy
+# path is preferred for H100.
+
+# Clear the smoke-test CSV before the full run:
+rm validation/model_v4/results/baselines/h100_sxm5_80gb_matmul.csv
+
+# ----------------------------------------------------------------------------
+# Step 4: Lock the GPU clocks for consistent measurements
+# ----------------------------------------------------------------------------
+# Disable autoboost / lock to a fixed clock pair. Skip this on shared cloud
+# instances if you don't have permission -- the kernel-level cudaEvent
+# timings are still valid, just noisier between trials.
+sudo nvidia-smi -pm 1                                    # persistence mode on
+sudo nvidia-smi -ac 2619,1980                            # H100 SXM5 default mem,gfx
+# (If the above fails, fall back to: sudo nvidia-smi -lgc 1980)
+
+# ----------------------------------------------------------------------------
+# Step 5: Full capture (~2 minutes total)
+# ----------------------------------------------------------------------------
+# Make the GPU otherwise idle. Confirm with nvidia-smi -- "Volatile GPU-Util"
+# should be 0% before you start.
+for op in matmul linear; do
+  for purpose in calibration validation; do
+    PYTHONPATH=src python3 -m validation.model_v4.cli.capture_ground_truth \
+        --hw h100_sxm5_80gb --op $op --purpose $purpose
+  done
+done
+
+# Unlike Orin Nano, H100 has 80 GB so OOMs are unlikely on the current
+# sweep shapes. If anything fails, capture the error -- it might surface
+# a real bug in the workload builder for very large shapes.
+
+# ----------------------------------------------------------------------------
+# Step 6: Sanity-check the CSVs
+# ----------------------------------------------------------------------------
+ls -la validation/model_v4/results/baselines/h100_sxm5_80gb_*.csv
+wc -l validation/model_v4/results/baselines/h100_sxm5_80gb_*.csv
+# Expect each CSV to be ~78 rows (18 cal + 60 val).
+
+head -5 validation/model_v4/results/baselines/h100_sxm5_80gb_matmul.csv
+# Spot-check: latency_ms is small (sub-ms for most shapes); energy_mJ
+# correlates with latency at ~300-700 W average power (H100 SXM5 TDP).
+
+# Note: many H100 shapes will be sub-1ms, which means the V4 harness will
+# skip pass_energy assertion for them per the #71 RAPL/NVML noise floor.
+# That's expected; the floor tests for H100 will need to be calibrated to
+# whatever fraction of shapes ARE above the threshold.
+
+# ----------------------------------------------------------------------------
+# Step 7: Restore default clocks (optional cleanup)
+# ----------------------------------------------------------------------------
+sudo nvidia-smi -rac           # reset to default app clocks
+# Skip if you'll keep using the box for V4 work.
+
+# ----------------------------------------------------------------------------
+# Step 8: Commit and push
+# ----------------------------------------------------------------------------
+DRIVER_VER=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader,nounits | head -1)
+git checkout -b feat/v4-4-phase-b-h100-baseline
+git add validation/model_v4/results/baselines/h100_sxm5_80gb_*.csv
+git commit -m "feat(validation): V4-4 Phase B -- H100 SXM5 80GB baseline (matmul + linear)
+
+Captured via PyTorchCUDAMeasurer (cudaEvent + NVML total-energy).
+Driver ${DRIVER_VER}, locked clocks (mem=2619, gfx=1980), persistence mode on.
+"
+git push -u origin feat/v4-4-phase-b-h100-baseline
+
+# Then open the PR from your dev box:
+#   gh pr create --draft --title "feat(validation): V4-4 Phase B -- H100 baseline"
+# and request the floor-test follow-up.

--- a/bin/v4-capture-jetson-orin-nano.sh
+++ b/bin/v4-capture-jetson-orin-nano.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Jetson Orin Nano 8GB -- V4 baseline capture runbook
+#
+# Run this ON the Jetson, not on the dev box. Wall time: ~40 minutes
+# (~10 min per CSV; the validation sweeps have ~78 shapes each at 11
+# trials each).
+#
+# Treat the steps as separate "checkpoints" -- run one at a time, verify
+# the output before proceeding to the next. The script does NOT execute
+# end-to-end with `bash` -- it's a runbook with copy-pasteable commands.
+# ============================================================================
+
+set -euo pipefail   # for any block you do choose to run as a script
+
+# ----------------------------------------------------------------------------
+# Step 1: Get the code and deps onto the Jetson
+# ----------------------------------------------------------------------------
+git clone https://github.com/branes-ai/graphs.git
+cd graphs
+# After PR #80 merges to main, drop this checkout. Until then:
+git checkout feat/v4-4-gpu-jetson-ground-truth
+
+# Verify torch sees CUDA. Use the JetPack-matched wheel -- DON'T `pip install
+# torch` from PyPI (those wheels are CPU-only or x86-only).
+python3 -c "import torch; print('torch:', torch.__version__,
+  'cuda:', torch.cuda.is_available(),
+  'device:', torch.cuda.get_device_name() if torch.cuda.is_available() else 'none')"
+# CHECKPOINT 1: cuda:True is required. If False:
+#   https://docs.nvidia.com/deeplearning/frameworks/install-pytorch-jetson-platform/
+
+pip install -e .
+
+# ----------------------------------------------------------------------------
+# Step 2: Verify INA3221 sysfs is readable
+# ----------------------------------------------------------------------------
+# Newer JetPack puts rails under /sys/bus/i2c/drivers/ina3221/.../hwmon/
+ls /sys/bus/i2c/drivers/ina3221/*/hwmon/hwmon*/in*_label 2>/dev/null
+
+# If that dir is missing OR you get permission denied:
+sudo chmod -R a+r /sys/bus/i2c/drivers/ina3221/
+
+# Sanity-check the probe detector picks up rails:
+PYTHONPATH=src python3 -c "
+from validation.model_v4.ground_truth.pytorch_jetson import _detect_ina3221
+probe = _detect_ina3221()
+if probe is None:
+    print('NO RAILS DETECTED -- check sysfs paths / permissions')
+else:
+    print(f'backend={probe.backend}, rails={[r.name for r in probe.rails]}')
+    print(f'total power now: {probe.read_total_power_mw()} mW')
+"
+# CHECKPOINT 2: must see rail names + a plausible mW reading (typically
+# 2000-7000 mW for an idle Orin Nano). If you see a stale reading or
+# only one rail, widen the rail_pattern in pytorch_jetson.py temporarily
+# to inspect what's available, then update the default if needed.
+
+# ----------------------------------------------------------------------------
+# Step 3: Smoke test with --limit 3 (~30 seconds total)
+# ----------------------------------------------------------------------------
+PYTHONPATH=src python3 -m validation.model_v4.cli.capture_ground_truth \
+    --hw jetson_orin_nano_8gb --op matmul --purpose validation --limit 3
+
+# Inspect the smoke-test CSV:
+cat validation/model_v4/results/baselines/jetson_orin_nano_8gb_matmul.csv
+# CHECKPOINT 3: 3 rows; latency_ms sub-100ms for the small shapes;
+# energy_mJ should be present (not 'n/a'). If you see 'INA3221: probe
+# not available' in the notes column, go back to Step 2.
+
+# Clear the smoke-test CSV before the full run (clean start is easier
+# to reason about than per-key overwrites):
+rm validation/model_v4/results/baselines/jetson_orin_nano_8gb_matmul.csv
+
+# ----------------------------------------------------------------------------
+# Step 4: Lock the chip at full clocks for the full capture
+# ----------------------------------------------------------------------------
+# Otherwise DVFS smears measurements across runs. Reverts on reboot.
+sudo nvpmodel -m 0
+sudo jetson_clocks
+
+# ----------------------------------------------------------------------------
+# Step 5: Full capture (~40 minutes total)
+# ----------------------------------------------------------------------------
+# Make the box otherwise idle. Close browsers, kill background CUDA work.
+for op in matmul linear; do
+  for purpose in calibration validation; do
+    PYTHONPATH=src python3 -m validation.model_v4.cli.capture_ground_truth \
+        --hw jetson_orin_nano_8gb --op $op --purpose $purpose
+  done
+done
+
+# OOM handling: the Orin Nano has only 8 GB shared CPU/GPU. The validation
+# sweep includes shapes (e.g. 16384^3 fp16) that won't fit. The capture
+# script prints which shape failed; note the list -- a follow-up will
+# mark those UNSUPPORTED in _augment.py for orin_nano. Don't rerun in a
+# way that hides the OOMs.
+
+# ----------------------------------------------------------------------------
+# Step 6: Sanity-check the CSVs
+# ----------------------------------------------------------------------------
+ls -la validation/model_v4/results/baselines/jetson_orin_nano_8gb_*.csv
+wc -l validation/model_v4/results/baselines/jetson_orin_nano_8gb_*.csv
+# Expect each CSV to be ~78 rows (18 cal + 60 val, minus skips/OOMs).
+
+head -5 validation/model_v4/results/baselines/jetson_orin_nano_8gb_matmul.csv
+# Spot-check: latency_ms grows with shape size; energy_mJ grows with
+# latency (active power roughly constant ~5-15 W across the sweep).
+
+# ----------------------------------------------------------------------------
+# Step 7: Commit and push
+# ----------------------------------------------------------------------------
+JETPACK_VER=$(cat /etc/nv_tegra_release | head -1 | sed 's/.*R\([0-9]*\).*/L4T R\1/' || echo "unknown")
+git checkout -b feat/v4-4-phase-b-jetson-orin-nano-baseline
+git add validation/model_v4/results/baselines/jetson_orin_nano_8gb_*.csv
+git commit -m "feat(validation): V4-4 Phase B -- Jetson Orin Nano 8GB baseline (matmul + linear)
+
+Captured on ${JETPACK_VER} via PyTorchJetsonMeasurer (cudaEvent + INA3221).
+Power mode: MAXN (nvpmodel -m 0), jetson_clocks locked.
+"
+git push -u origin feat/v4-4-phase-b-jetson-orin-nano-baseline
+
+# Then open the PR from your dev box:
+#   gh pr create --draft --title "feat(validation): V4-4 Phase B -- Jetson Orin Nano baseline"
+# and request the floor-test follow-up.

--- a/docs/plans/v4-capture-on-target.md
+++ b/docs/plans/v4-capture-on-target.md
@@ -1,0 +1,165 @@
+# V4 ground-truth capture: how to run on a target box
+
+The V4 validation harness has two phases that run on **different** machines:
+
+* **Capture-on-target** (this doc) — runs the workload on the actual silicon
+  with a `Measurer` backend (RAPL/NVML/INA3221), writes a CSV baseline.
+* **Validate-anywhere** — reads the committed CSV baseline, compares against
+  the analyzer's predictions. Hardware-agnostic: runs on any developer
+  laptop or in CI.
+
+Capture is a one-time-per-hardware operation (re-run only when the analyzer
+changes the *measurement* contract or you want fresher numbers). The CSV
+gets committed under `validation/model_v4/results/baselines/<hw>_<op>.csv`
+and from then on every developer can validate without the target box.
+
+---
+
+## Currently supported targets
+
+| Hardware key                | Backend                | Measurer file                                                |
+|-----------------------------|------------------------|--------------------------------------------------------------|
+| `i7_12700k`                 | wall-clock + Intel RAPL | `validation/model_v4/ground_truth/pytorch_cpu.py`            |
+| `h100_sxm5_80gb`            | cudaEvent + NVML        | `validation/model_v4/ground_truth/pytorch_cuda.py`           |
+| `jetson_orin_nano_8gb`      | cudaEvent + INA3221     | `validation/model_v4/ground_truth/pytorch_jetson.py`         |
+| `jetson_orin_agx_64gb`      | cudaEvent + INA3221     | `validation/model_v4/ground_truth/pytorch_jetson.py`         |
+| `jetson_orin_nx_16gb`       | cudaEvent + INA3221     | `validation/model_v4/ground_truth/pytorch_jetson.py`         |
+
+---
+
+## Adding a new hardware target
+
+Single point of change is `validation/model_v4/sweeps/_augment.py`:
+
+1. Add a `_Target(hw_key=..., dtype=..., factory=...)` entry to `KNOWN_TARGETS`.
+2. Run `python -m validation.model_v4.sweeps._augment --hw <new_hw_key>` to
+   classify the existing sweep entries against the new mapper. This is purely
+   additive — the original i7 / H100 / Jetson regimes stay byte-identical.
+3. Add the same key to `_MEASURER_FACTORY` in
+   `validation/model_v4/cli/capture_ground_truth.py` mapped to the right
+   backend tag (`pytorch_cuda`, `pytorch_jetson`, `pytorch_cpu`, etc.).
+4. Add the same key to `SWEEP_HW_TO_MAPPER` in
+   `validation/model_v4/harness/runner.py` so the validate path can resolve
+   it back to a mapper-registry name.
+5. Update `tests/validation_model_v4/test_sweeps.py` `hw` fixture so
+   `test_recorded_regime_labels_still_match_classifier` covers the new key.
+
+---
+
+## Capture procedure (target box)
+
+The flow is identical for all targets — only the dependencies change.
+
+### Common preflight (any target)
+
+```bash
+git clone https://github.com/branes-ai/graphs.git
+cd graphs
+pip install -e .
+pip install pytest               # only needed if you want to run tests
+```
+
+The `cli/capture_ground_truth.py` script writes a CSV per `(hardware, op)`
+pair. The validate-anywhere path expects exactly two CSVs per hardware
+(matmul + linear). Both calibration and validation sweep entries are
+captured into the same CSV — the harness picks which to use at validate
+time based on the sweep file name.
+
+### Target-specific dependencies
+
+#### CPU (Intel, RAPL)
+
+* Read access to `/sys/class/powercap/intel-rapl:0/energy_uj` (typically
+  works for any user; some hardened systems may require `setcap` or root).
+
+#### Desktop / server NVIDIA (H100, A100, RTX, ...)
+
+```bash
+pip install pynvml torch        # torch with CUDA wheels
+nvidia-smi                       # confirm the driver is loaded
+```
+
+#### Jetson (Orin Nano / NX / AGX, Thor)
+
+```bash
+# JetPack already provides torch with cuda; verify:
+python -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name())"
+
+# INA3221 sysfs is present on all Jetson devices but may need a one-time
+# permission grant for non-root reads. The exact path varies by JetPack
+# version; the measurer auto-detects both layouts.
+ls /sys/bus/i2c/drivers/ina3221*/
+```
+
+If the rails come back empty, run as root once or `chmod -R a+r` the
+ina3221 hwmon tree (some JetPack base images don't grant read to
+non-root users).
+
+### Capture command
+
+```bash
+# Replace <hw> with the hardware key from the table above.
+# Both ops, both purposes (calibration + validation):
+python -m validation.model_v4.cli.capture_ground_truth \
+    --hw <hw> --op matmul --purpose calibration
+python -m validation.model_v4.cli.capture_ground_truth \
+    --hw <hw> --op matmul --purpose validation
+python -m validation.model_v4.cli.capture_ground_truth \
+    --hw <hw> --op linear --purpose calibration
+python -m validation.model_v4.cli.capture_ground_truth \
+    --hw <hw> --op linear --purpose validation
+```
+
+Wall time:
+
+* CPU (i7-12700K, ~78 shapes per CSV, 11 trials each): ~5 minutes per CSV
+* H100 (mostly sub-millisecond kernels): ~30 seconds per CSV
+* Jetson Orin Nano (slower kernels, 8 ms INA3221 averaging adds settle
+  time): ~10 minutes per CSV
+
+Output CSVs land in `validation/model_v4/results/baselines/<hw>_<op>.csv`.
+
+### Smoke test before the full run
+
+To debug the capture flow without burning ~30 minutes, use `--limit`:
+
+```bash
+python -m validation.model_v4.cli.capture_ground_truth \
+    --hw jetson_orin_nano_8gb --op matmul --purpose validation --limit 3
+```
+
+Inspect the CSV. If `latency_ms` is sane and `energy_mJ` is non-empty (or
+the notes column explains why energy is `n/a`), you're good to launch the
+full run.
+
+### Commit the baseline back
+
+From the target box:
+
+```bash
+git add validation/model_v4/results/baselines/<hw>_*.csv
+git commit -m "feat(validation): V4 baseline for <hw>"
+git push
+```
+
+Then the floor tests in `tests/validation_model_v4/test_v4_against_baseline.py`
+should be extended with new `test_<hw>_matmul_pass_*_floor` and
+`test_<hw>_linear_pass_*_floor` cases that pin the post-capture pass rates.
+
+---
+
+## Known limitations
+
+* **NVML on Jetson**: Jetson's NVML reports an aggregate that sometimes
+  excludes the memory-controller draw, which is why the `pytorch_jetson.py`
+  measurer uses INA3221 sysfs instead. NVML on Jetson is *not* a fallback
+  -- if INA3221 is unavailable, energy is reported as None.
+* **Tegra power averaging**: INA3221 has an 8 ms internal averaging window.
+  For sub-8 ms kernels the measurer adds a "below 8ms averaging period"
+  warning to the notes column; treat those energy figures as indicative
+  only. The same pattern as the CPU sub-1ms RAPL skip in `assertions.py`
+  could be applied here as a follow-up.
+* **Whole-machine assumption**: every backend (RAPL, NVML, INA3221)
+  measures *device-level* power. Make the test box otherwise idle when
+  capturing -- background processes inflate the energy figure for every
+  sub-second kernel in the sweep.

--- a/tests/validation_model_v4/test_ground_truth_pytorch_cuda.py
+++ b/tests/validation_model_v4/test_ground_truth_pytorch_cuda.py
@@ -1,0 +1,228 @@
+"""Tests for validation/model_v4/ground_truth/pytorch_cuda.py.
+
+The actual measurement path requires real CUDA hardware and a working
+NVML driver, so these tests focus on what we CAN verify on the i7
+development box:
+
+* The probe detector returns None cleanly when pynvml isn't installed
+  or NVML init fails (so the measurer doesn't crash on CPU-only hosts).
+* The measurer returns a Measurement with energy_j=None and an
+  explanatory note when the probe is unavailable.
+* The measurer returns nan latency + a CUDA note when torch.cuda is
+  unavailable, rather than crashing inside torch.cuda.Event.
+* The probe correctly chooses total-energy vs power-fallback paths
+  based on what NVML reports as supported.
+
+These tests use a mock pynvml to avoid requiring real hardware. The
+end-to-end capture path is exercised separately on the target box (see
+docs/v4-capture-on-target.md).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from validation.model_v4.ground_truth.base import Measurement
+from validation.model_v4.ground_truth.pytorch_cuda import (
+    PyTorchCUDAMeasurer,
+    _detect_nvml,
+    _NVMLProbe,
+)
+
+
+# ---------------------------------------------------------------------------
+# _detect_nvml: graceful degradation
+# ---------------------------------------------------------------------------
+
+
+def test_detect_nvml_returns_none_when_pynvml_missing():
+    """On an i7 dev box without pynvml installed, _detect_nvml must not
+    raise; the measurer interprets None as 'energy unavailable'."""
+    # The real i7-12700K test host typically does not have pynvml; just
+    # call the detector and confirm it returned None or a probe (we don't
+    # assert which -- some dev boxes do have pynvml installed alongside).
+    probe = _detect_nvml(device_index=0)
+    if probe is None:
+        return  # expected on a CPU-only host
+    # If we DID get a probe (developer has pynvml + a GPU), at least one
+    # of the two query types must have succeeded.
+    assert probe.supports_total_energy or probe.read_power_mw() is not None
+
+
+def test_detect_nvml_returns_none_when_init_fails():
+    """If pynvml is importable but nvmlInit raises (driver mismatch,
+    no GPU), the detector returns None instead of letting the exception
+    bubble up."""
+    fake_pynvml = MagicMock()
+    fake_pynvml.nvmlInit.side_effect = RuntimeError("driver mismatch")
+
+    with patch.dict("sys.modules", {"pynvml": fake_pynvml}):
+        # Force re-import inside _detect_nvml
+        probe = _detect_nvml(device_index=0)
+
+    assert probe is None
+
+
+def test_detect_nvml_returns_none_when_no_query_supported():
+    """If neither total-energy nor power queries work (very old GPU),
+    _detect_nvml refuses to return a probe -- there's nothing to read."""
+    fake_pynvml = MagicMock()
+    fake_pynvml.nvmlInit.return_value = None
+    fake_pynvml.nvmlDeviceGetHandleByIndex.return_value = "fake-handle"
+    fake_pynvml.nvmlDeviceGetTotalEnergyConsumption.side_effect = RuntimeError("unsupported")
+    fake_pynvml.nvmlDeviceGetPowerUsage.side_effect = RuntimeError("unsupported")
+
+    with patch.dict("sys.modules", {"pynvml": fake_pynvml}):
+        probe = _detect_nvml(device_index=0)
+
+    assert probe is None
+    # Cleanup must have been attempted
+    fake_pynvml.nvmlShutdown.assert_called()
+
+
+def test_detect_nvml_falls_back_to_power_when_total_energy_missing():
+    """Older Tesla cards expose nvmlDeviceGetPowerUsage but not the
+    cumulative energy counter. The probe must accept this and mark
+    supports_total_energy=False (the measurer then uses the
+    power-fallback path)."""
+    fake_pynvml = MagicMock()
+    fake_pynvml.nvmlInit.return_value = None
+    fake_pynvml.nvmlDeviceGetHandleByIndex.return_value = "fake-handle"
+    fake_pynvml.nvmlDeviceGetTotalEnergyConsumption.side_effect = RuntimeError("unsupported")
+    fake_pynvml.nvmlDeviceGetPowerUsage.return_value = 250_000   # 250W in mW
+    fake_pynvml.nvmlDeviceGetName.return_value = b"Tesla V100"
+
+    with patch.dict("sys.modules", {"pynvml": fake_pynvml}):
+        probe = _detect_nvml(device_index=0)
+
+    assert probe is not None
+    assert probe.supports_total_energy is False
+    assert probe.read_power_mw() == 250_000
+
+
+# ---------------------------------------------------------------------------
+# Measurer: graceful degradation when CUDA / NVML unavailable
+# ---------------------------------------------------------------------------
+
+
+def test_measurer_returns_nan_latency_when_cuda_unavailable():
+    """On a CPU-only host, calling .measure() returns a Measurement
+    with nan latency and a CUDA note rather than crashing inside
+    torch.cuda.Event."""
+    measurer = PyTorchCUDAMeasurer(hardware="h100_sxm5_80gb", _probe=None)
+
+    # Stub torch with cuda.is_available()=False
+    fake_torch = MagicMock()
+    fake_torch.cuda.is_available.return_value = False
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        meas = measurer.measure(model=MagicMock(), inputs=[])
+
+    assert isinstance(meas, Measurement)
+    assert meas.latency_s != meas.latency_s   # nan
+    assert meas.energy_j is None
+    assert "CUDA" in meas.notes
+
+
+def test_measurer_skips_energy_when_no_probe():
+    """No NVML probe but CUDA available: latency still measured via
+    cudaEvent, energy comes back as None with a note."""
+    measurer = PyTorchCUDAMeasurer(
+        hardware="h100_sxm5_80gb",
+        warmup_trials=1, timed_trials=3,
+        _probe=None,
+    )
+
+    fake_torch = _make_fake_cuda_torch(per_trial_ms=2.0)
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        meas = measurer.measure(model=MagicMock(), inputs=[])
+
+    assert meas.energy_j is None
+    assert "NVML: probe not available" in meas.notes
+    # Median of three 2ms readings = 2ms = 2e-3 s
+    assert meas.latency_s == pytest.approx(2e-3, rel=1e-6)
+    assert meas.trial_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Measurer: total-energy path using a mocked probe
+# ---------------------------------------------------------------------------
+
+
+def test_measurer_uses_total_energy_when_supported():
+    """With a probe that reports supports_total_energy=True, the
+    measurer should use the cumulative-counter delta and report the
+    per-trial energy in joules."""
+    fake_pynvml = MagicMock()
+    fake_pynvml.nvmlDeviceGetTotalEnergyConsumption.side_effect = [
+        100_000,     # before: 100000 mJ
+        100_330,     # after:  100330 mJ -> delta 330 mJ across 11 trials
+    ]
+    probe = _NVMLProbe(handle="h", supports_total_energy=True,
+                       pynvml=fake_pynvml, name="H100")
+
+    measurer = PyTorchCUDAMeasurer(
+        hardware="h100_sxm5_80gb",
+        warmup_trials=1, timed_trials=11,
+        _probe=probe,
+    )
+
+    fake_torch = _make_fake_cuda_torch(per_trial_ms=2.0)
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        meas = measurer.measure(model=MagicMock(), inputs=[])
+
+    # 330 mJ / 11 trials = 30 mJ per trial = 30e-3 J
+    assert meas.energy_j == pytest.approx(30e-3, rel=1e-6)
+    # No fallback note expected
+    assert "power-fallback" not in meas.notes
+
+
+def test_measurer_falls_back_to_power_when_no_total_energy():
+    """With a power-only probe, the measurer should compute
+    energy = power * latency."""
+    fake_pynvml = MagicMock()
+    fake_pynvml.nvmlDeviceGetPowerUsage.return_value = 250_000  # 250 W
+    probe = _NVMLProbe(handle="h", supports_total_energy=False,
+                       pynvml=fake_pynvml, name="V100")
+
+    measurer = PyTorchCUDAMeasurer(
+        hardware="h100_sxm5_80gb",
+        warmup_trials=1, timed_trials=5,
+        _probe=probe,
+    )
+
+    fake_torch = _make_fake_cuda_torch(per_trial_ms=4.0)  # 4ms per trial
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        meas = measurer.measure(model=MagicMock(), inputs=[])
+
+    # 250 W * 4ms = 1.0 J per trial
+    assert meas.energy_j == pytest.approx(1.0, rel=1e-6)
+    assert "power-fallback" in meas.notes
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_cuda_torch(per_trial_ms: float):
+    """Build a torch stub whose cuda.Event pair returns ``per_trial_ms``
+    from start.elapsed_time(stop). The stop event's elapsed_time method
+    needs to be set on the start event since cuda.Event.elapsed_time is
+    actually called as start.elapsed_time(stop)."""
+    fake_torch = MagicMock()
+    fake_torch.cuda.is_available.return_value = True
+
+    def _make_event(*args, **kwargs):
+        ev = MagicMock()
+        ev.elapsed_time.return_value = per_trial_ms
+        return ev
+
+    fake_torch.cuda.Event.side_effect = _make_event
+    fake_torch.cuda.synchronize.return_value = None
+    return fake_torch

--- a/tests/validation_model_v4/test_ground_truth_pytorch_cuda.py
+++ b/tests/validation_model_v4/test_ground_truth_pytorch_cuda.py
@@ -15,11 +15,13 @@ development box:
 
 These tests use a mock pynvml to avoid requiring real hardware. The
 end-to-end capture path is exercised separately on the target box (see
-docs/v4-capture-on-target.md).
+docs/plans/v4-capture-on-target.md).
 """
 
 from __future__ import annotations
 
+import math
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -37,18 +39,28 @@ from validation.model_v4.ground_truth.pytorch_cuda import (
 # ---------------------------------------------------------------------------
 
 
-def test_detect_nvml_returns_none_when_pynvml_missing():
-    """On an i7 dev box without pynvml installed, _detect_nvml must not
-    raise; the measurer interprets None as 'energy unavailable'."""
-    # The real i7-12700K test host typically does not have pynvml; just
-    # call the detector and confirm it returned None or a probe (we don't
-    # assert which -- some dev boxes do have pynvml installed alongside).
+def test_detect_nvml_returns_none_when_pynvml_missing(monkeypatch):
+    """Force ``import pynvml`` to fail at the import statement inside
+    ``_detect_nvml`` and confirm the detector returns None instead of
+    raising. This is deterministic regardless of whether pynvml is
+    actually installed on the dev box."""
+    # Hide any previously-imported pynvml so the in-function import path
+    # has to re-resolve; install a meta-finder that raises ImportError.
+    monkeypatch.delitem(sys.modules, "pynvml", raising=False)
+
+    class _BlockPynvml:
+        def find_module(self, name, path=None):    # py<3.4 API, harmless
+            return self if name == "pynvml" else None
+
+        def find_spec(self, name, path=None, target=None):
+            if name == "pynvml":
+                raise ImportError("forced absent for test")
+            return None
+
+    monkeypatch.setattr(sys, "meta_path",
+                        [_BlockPynvml(), *sys.meta_path])
     probe = _detect_nvml(device_index=0)
-    if probe is None:
-        return  # expected on a CPU-only host
-    # If we DID get a probe (developer has pynvml + a GPU), at least one
-    # of the two query types must have succeeded.
-    assert probe.supports_total_energy or probe.read_power_mw() is not None
+    assert probe is None
 
 
 def test_detect_nvml_returns_none_when_init_fails():
@@ -121,7 +133,7 @@ def test_measurer_returns_nan_latency_when_cuda_unavailable():
         meas = measurer.measure(model=MagicMock(), inputs=[])
 
     assert isinstance(meas, Measurement)
-    assert meas.latency_s != meas.latency_s   # nan
+    assert math.isnan(meas.latency_s)
     assert meas.energy_j is None
     assert "CUDA" in meas.notes
 

--- a/tests/validation_model_v4/test_ground_truth_pytorch_jetson.py
+++ b/tests/validation_model_v4/test_ground_truth_pytorch_jetson.py
@@ -1,0 +1,221 @@
+"""Tests for validation/model_v4/ground_truth/pytorch_jetson.py.
+
+Like the CUDA tests, this only verifies the parts we can exercise on
+the i7 dev box (which doesn't have INA3221 sysfs). The end-to-end
+capture path is exercised on the actual Jetson hardware separately.
+
+We test:
+* The probe detector returns None when no INA3221 sysfs is present.
+* The probe detector parses both JetPack-5+ (hwmon) and JetPack-4
+  (iio:device) layouts using a temporary fake sysfs tree.
+* The rail-pattern filter correctly selects/rejects rails by name.
+* The measurer returns nan latency + a CUDA note when torch.cuda is
+  unavailable (CPU-only test host).
+* The measurer integrates rail power x window time correctly when
+  given a fake probe.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from validation.model_v4.ground_truth.base import Measurement
+from validation.model_v4.ground_truth.pytorch_jetson import (
+    DEFAULT_RAIL_PATTERN,
+    PyTorchJetsonMeasurer,
+    _detect_ina3221,
+    _INAProbe,
+    _INARail,
+)
+
+
+# ---------------------------------------------------------------------------
+# _detect_ina3221: graceful degradation
+# ---------------------------------------------------------------------------
+
+
+def test_detect_ina3221_returns_none_on_non_jetson_host():
+    """The i7 dev box has no INA3221 sysfs entries; the detector must
+    return None instead of raising."""
+    probe = _detect_ina3221()
+    assert probe is None
+
+
+def test_detect_ina3221_finds_jp5_hwmon_layout(tmp_path, monkeypatch):
+    """Synthesize a JetPack-5+ hwmon layout under tmp_path and confirm
+    the detector finds the rails."""
+    fake_root = tmp_path / "ina3221" / "1-0040" / "hwmon" / "hwmon3"
+    fake_root.mkdir(parents=True)
+    # Two rails: GPU_SOC (matches default pattern) and a filtered DDR rail.
+    (fake_root / "in1_label").write_text("VDD_GPU_SOC\n")
+    (fake_root / "power1_input").write_text("3500000\n")  # 3500 mW in uW
+    (fake_root / "in2_label").write_text("VDD_DDR\n")
+    (fake_root / "power2_input").write_text("1200000\n")
+
+    monkeypatch.setattr(
+        "validation.model_v4.ground_truth.pytorch_jetson._INA_SEARCH_ROOTS",
+        [tmp_path / "ina3221", tmp_path / "ina3221x_nope"],
+    )
+    probe = _detect_ina3221()
+    assert probe is not None
+    assert probe.backend == "ina3221"
+    assert len(probe.rails) == 1   # DDR filtered out by default pattern
+    assert probe.rails[0].name == "VDD_GPU_SOC"
+    # Rail reads back correctly: 3500000 uW / 1000 = 3500 mW
+    assert probe.rails[0].read_power_mw() == 3500
+
+
+def test_detect_ina3221_finds_jp4_iio_layout(tmp_path, monkeypatch):
+    """JetPack-4 used iio:device with rail_name_<idx> + in_power<idx>_input
+    in milliwatts."""
+    fake_root = tmp_path / "ina3221x" / "1-0040" / "iio:device0"
+    fake_root.mkdir(parents=True)
+    (fake_root / "rail_name_0").write_text("GPU\n")
+    (fake_root / "in_power0_input").write_text("4500\n")    # mW direct
+    (fake_root / "rail_name_1").write_text("VIN_SYS_5V0\n")
+    (fake_root / "in_power1_input").write_text("2000\n")
+
+    monkeypatch.setattr(
+        "validation.model_v4.ground_truth.pytorch_jetson._INA_SEARCH_ROOTS",
+        [tmp_path / "ina3221_nope", tmp_path / "ina3221x"],
+    )
+    probe = _detect_ina3221()
+    assert probe is not None
+    assert probe.backend == "ina3221x"
+    assert len(probe.rails) == 2
+    assert probe.read_total_power_mw() == 6500  # 4500 + 2000
+
+
+def test_rail_pattern_filters_to_caller_choice(tmp_path, monkeypatch):
+    """Caller-supplied pattern selects only matching rails."""
+    fake_root = tmp_path / "ina3221x" / "1-0040" / "iio:device0"
+    fake_root.mkdir(parents=True)
+    for i, (name, mw) in enumerate([
+            ("GPU", 4000),
+            ("CPU", 2000),
+            ("MEM", 1000),
+    ]):
+        (fake_root / f"rail_name_{i}").write_text(f"{name}\n")
+        (fake_root / f"in_power{i}_input").write_text(f"{mw}\n")
+
+    monkeypatch.setattr(
+        "validation.model_v4.ground_truth.pytorch_jetson._INA_SEARCH_ROOTS",
+        [tmp_path / "ina3221_nope", tmp_path / "ina3221x"],
+    )
+    probe = _detect_ina3221(rail_pattern=r"^GPU$")
+    assert probe is not None
+    assert [r.name for r in probe.rails] == ["GPU"]
+    assert probe.read_total_power_mw() == 4000
+
+
+def test_default_rail_pattern_is_a_valid_regex():
+    """Sanity: the DEFAULT_RAIL_PATTERN constant compiles."""
+    import re
+    re.compile(DEFAULT_RAIL_PATTERN)
+
+
+# ---------------------------------------------------------------------------
+# Measurer: graceful degradation when CUDA / INA unavailable
+# ---------------------------------------------------------------------------
+
+
+def test_measurer_returns_nan_latency_when_cuda_unavailable():
+    measurer = PyTorchJetsonMeasurer(hardware="jetson_orin_nano_8gb", _probe=None)
+
+    fake_torch = MagicMock()
+    fake_torch.cuda.is_available.return_value = False
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        meas = measurer.measure(model=MagicMock(), inputs=[])
+
+    assert isinstance(meas, Measurement)
+    assert meas.latency_s != meas.latency_s   # nan
+    assert meas.energy_j is None
+    assert "CUDA" in meas.notes
+
+
+def test_measurer_skips_energy_when_no_probe():
+    """No INA3221 probe but CUDA available: latency measured, energy
+    None with 'probe not available' note."""
+    measurer = PyTorchJetsonMeasurer(
+        hardware="jetson_orin_nano_8gb",
+        warmup_trials=1, timed_trials=3,
+        _probe=None,
+    )
+    fake_torch = _make_fake_cuda_torch(per_trial_ms=2.0)
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        meas = measurer.measure(model=MagicMock(), inputs=[])
+
+    assert meas.energy_j is None
+    assert "INA3221: probe not available" in meas.notes
+
+
+# ---------------------------------------------------------------------------
+# Measurer: power integration with a fake probe
+# ---------------------------------------------------------------------------
+
+
+def test_measurer_integrates_rail_power_into_energy():
+    """A fake probe reports 5000 mW each side; with 3 trials at 4 ms each
+    the per-trial energy should be (5W * 12ms) / 3 = 20 mJ = 0.02 J."""
+    rail = _INARail(name="GPU", read_power_mw=lambda: 5000)
+    probe = _INAProbe(rails=[rail], backend="ina3221x")
+
+    measurer = PyTorchJetsonMeasurer(
+        hardware="jetson_orin_nano_8gb",
+        warmup_trials=1, timed_trials=3,
+        _probe=probe,
+    )
+    fake_torch = _make_fake_cuda_torch(per_trial_ms=4.0)
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        meas = measurer.measure(model=MagicMock(), inputs=[])
+
+    # window = 3 * 4ms = 12 ms; avg_power = 5W; total = 60 mJ
+    # per-trial = 60 / 3 = 20 mJ = 0.02 J
+    assert meas.energy_j == pytest.approx(0.02, rel=1e-6)
+    assert "rails=['GPU']" in meas.notes
+
+
+def test_measurer_warns_on_sub_8ms_window():
+    """INA3221 has 8 ms internal averaging; windows smaller than that
+    get a noise warning in the notes."""
+    rail = _INARail(name="GPU", read_power_mw=lambda: 5000)
+    probe = _INAProbe(rails=[rail], backend="ina3221x")
+
+    measurer = PyTorchJetsonMeasurer(
+        hardware="jetson_orin_nano_8gb",
+        warmup_trials=1, timed_trials=3,
+        _probe=probe,
+    )
+    # 3 trials * 1 ms = 3 ms total, well below 8 ms.
+    fake_torch = _make_fake_cuda_torch(per_trial_ms=1.0)
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        meas = measurer.measure(model=MagicMock(), inputs=[])
+
+    assert meas.energy_j is not None
+    assert "below 8ms averaging period" in meas.notes
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_cuda_torch(per_trial_ms: float):
+    fake_torch = MagicMock()
+    fake_torch.cuda.is_available.return_value = True
+
+    def _make_event(*args, **kwargs):
+        ev = MagicMock()
+        ev.elapsed_time.return_value = per_trial_ms
+        return ev
+
+    fake_torch.cuda.Event.side_effect = _make_event
+    fake_torch.cuda.synchronize.return_value = None
+    return fake_torch

--- a/tests/validation_model_v4/test_ground_truth_pytorch_jetson.py
+++ b/tests/validation_model_v4/test_ground_truth_pytorch_jetson.py
@@ -17,7 +17,7 @@ We test:
 
 from __future__ import annotations
 
-from pathlib import Path
+import math
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -132,7 +132,7 @@ def test_measurer_returns_nan_latency_when_cuda_unavailable():
         meas = measurer.measure(model=MagicMock(), inputs=[])
 
     assert isinstance(meas, Measurement)
-    assert meas.latency_s != meas.latency_s   # nan
+    assert math.isnan(meas.latency_s)
     assert meas.energy_j is None
     assert "CUDA" in meas.notes
 

--- a/tests/validation_model_v4/test_sweep_augment.py
+++ b/tests/validation_model_v4/test_sweep_augment.py
@@ -13,7 +13,6 @@ The augmenter must be:
 
 from __future__ import annotations
 
-import copy
 import json
 from pathlib import Path
 

--- a/tests/validation_model_v4/test_sweep_augment.py
+++ b/tests/validation_model_v4/test_sweep_augment.py
@@ -1,0 +1,128 @@
+"""Tests for validation/model_v4/sweeps/_augment.py.
+
+The augmenter must be:
+* Additive: existing entries (shape, dtype, original target regimes)
+  are never modified.
+* Idempotent: re-running with the same target overwrites the same
+  value, no duplication.
+* Dtype-aware: only entries with matching dtype get classified for a
+  given target.
+* Schema-stable: the augmented JSON still satisfies the sweep schema
+  expected by the runner.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from validation.model_v4.sweeps._augment import (
+    KNOWN_TARGETS,
+    augment_sweep,
+)
+from validation.model_v4.sweeps.classify import Regime
+
+
+@pytest.fixture
+def tmp_sweep(tmp_path: Path) -> Path:
+    """Write a tiny synthetic sweep with 3 fp32 + 2 fp16 entries."""
+    payload = {
+        "op": "matmul",
+        "purpose": "calibration",
+        "generator_seed": 42,
+        "generated_against_hardware": ["i7_12700k"],
+        "shapes": [
+            {"shape": [256, 256, 256], "dtype": "fp32",
+             "regime_per_hw": {"i7_12700k": "l2_bound"}},
+            {"shape": [1024, 1024, 1024], "dtype": "fp32",
+             "regime_per_hw": {"i7_12700k": "l2_bound"}},
+            {"shape": [4096, 4096, 4096], "dtype": "fp32",
+             "regime_per_hw": {"i7_12700k": "dram_bound"}},
+            {"shape": [1024, 1024, 1024], "dtype": "fp16",
+             "regime_per_hw": {"h100_sxm5_80gb": "launch_bound"}},
+            {"shape": [4096, 4096, 4096], "dtype": "fp16",
+             "regime_per_hw": {"h100_sxm5_80gb": "dram_bound"}},
+        ],
+    }
+    sweep_path = tmp_path / "matmul_calibration.json"
+    sweep_path.write_text(json.dumps(payload, indent=2))
+    return sweep_path
+
+
+def test_augmenter_classifies_only_matching_dtype_entries(tmp_sweep):
+    """Augmenting with an fp16 target should only classify the 2 fp16
+    entries; the 3 fp32 entries get untouched."""
+    target = KNOWN_TARGETS["jetson_orin_nano_8gb"]   # dtype=fp16
+    classified, skipped = augment_sweep(tmp_sweep, target)
+    assert classified == 2
+    assert skipped == 3
+
+
+def test_augmenter_preserves_existing_target_regimes(tmp_sweep):
+    """The original i7_12700k regime labels must stay byte-identical
+    after augmentation -- the augmenter never overwrites *other*
+    targets' regimes."""
+    before = json.loads(tmp_sweep.read_text())
+    augment_sweep(tmp_sweep, KNOWN_TARGETS["jetson_orin_nano_8gb"])
+    after = json.loads(tmp_sweep.read_text())
+
+    for b, a in zip(before["shapes"], after["shapes"]):
+        # All original keys preserved with original values
+        for k, v in b["regime_per_hw"].items():
+            assert a["regime_per_hw"][k] == v
+
+
+def test_augmenter_is_idempotent(tmp_sweep):
+    """Running the same augmentation twice must produce identical output."""
+    target = KNOWN_TARGETS["jetson_orin_agx_64gb"]
+    augment_sweep(tmp_sweep, target)
+    snapshot = json.loads(tmp_sweep.read_text())
+    augment_sweep(tmp_sweep, target)
+    after = json.loads(tmp_sweep.read_text())
+    assert snapshot == after
+
+
+def test_augmenter_records_target_in_metadata(tmp_sweep):
+    """``augmented_with_hardware`` should list every target ever applied,
+    sorted, no duplicates."""
+    augment_sweep(tmp_sweep, KNOWN_TARGETS["jetson_orin_nano_8gb"])
+    augment_sweep(tmp_sweep, KNOWN_TARGETS["h100_sxm5_80gb"])
+    augment_sweep(tmp_sweep, KNOWN_TARGETS["jetson_orin_nano_8gb"])  # dup
+
+    payload = json.loads(tmp_sweep.read_text())
+    assert payload["augmented_with_hardware"] == [
+        "h100_sxm5_80gb", "jetson_orin_nano_8gb",
+    ]
+
+
+def test_augmenter_emits_only_valid_regime_values(tmp_sweep):
+    """All regime values written by the augmenter must be valid Regime
+    enum strings (the sweep schema test in test_sweeps.py enforces this
+    on the committed files; here we double-check on synthetic data)."""
+    valid = {r.value for r in Regime}
+    augment_sweep(tmp_sweep, KNOWN_TARGETS["jetson_orin_nano_8gb"])
+    payload = json.loads(tmp_sweep.read_text())
+    for entry in payload["shapes"]:
+        for r in entry["regime_per_hw"].values():
+            assert r in valid
+
+
+def test_known_targets_includes_jetson_keys():
+    """The augmenter registry must list at least the i7 + jetson +
+    h100 entries that the runner's SWEEP_HW_TO_MAPPER expects."""
+    expected = {"i7_12700k", "h100_sxm5_80gb",
+                "jetson_orin_nano_8gb", "jetson_orin_agx_64gb",
+                "jetson_orin_nx_16gb"}
+    assert expected.issubset(set(KNOWN_TARGETS))
+
+
+def test_each_known_target_has_a_mapper_factory():
+    """Every entry must produce a usable HardwareResourceModel without
+    raising. Catches signature drift in the gpu/cpu factories."""
+    for key, target in KNOWN_TARGETS.items():
+        hw = target.hw
+        assert hw.peak_bandwidth > 0, f"{key} has no peak_bandwidth"
+        assert hw.compute_units > 0, f"{key} has no compute_units"

--- a/tests/validation_model_v4/test_sweeps.py
+++ b/tests/validation_model_v4/test_sweeps.py
@@ -21,7 +21,12 @@ from pathlib import Path
 import pytest
 
 from graphs.hardware.mappers.cpu import create_i7_12700k_mapper
-from graphs.hardware.mappers.gpu import create_h100_sxm5_80gb_mapper
+from graphs.hardware.mappers.gpu import (
+    create_h100_sxm5_80gb_mapper,
+    create_jetson_orin_agx_64gb_mapper,
+    create_jetson_orin_nano_8gb_mapper,
+    create_jetson_orin_nx_16gb_mapper,
+)
 from validation.model_v4.sweeps.classify import Regime, classify_regime
 
 
@@ -37,9 +42,15 @@ SWEEP_FILES = [
 
 @pytest.fixture(scope="module")
 def hw():
+    """All hardware keys the augmenter knows about. Must stay in sync with
+    KNOWN_TARGETS in validation/model_v4/sweeps/_augment.py -- if a new
+    target is added there, add the matching mapper here."""
     return {
         "i7_12700k": create_i7_12700k_mapper().resource_model,
         "h100_sxm5_80gb": create_h100_sxm5_80gb_mapper().resource_model,
+        "jetson_orin_nano_8gb": create_jetson_orin_nano_8gb_mapper().resource_model,
+        "jetson_orin_agx_64gb": create_jetson_orin_agx_64gb_mapper().resource_model,
+        "jetson_orin_nx_16gb": create_jetson_orin_nx_16gb_mapper().resource_model,
     }
 
 

--- a/validation/model_v4/cli/capture_ground_truth.py
+++ b/validation/model_v4/cli/capture_ground_truth.py
@@ -42,10 +42,15 @@ SWEEP_DIR = Path(__file__).resolve().parents[1] / "sweeps"
 BASELINE_DIR = Path(__file__).resolve().parents[1] / "results" / "baselines"
 
 
-# Hardware -> measurer factory. Add cuda / simulator here when V4-4 / V4-5 land.
+# Hardware -> measurer-backend tag. Resolved to a concrete class in
+# _make_measurer (lazy import keeps NVML/Jetson backends optional on
+# hosts that don't have torch.cuda or pynvml installed).
 _MEASURER_FACTORY = {
     "i7_12700k": "pytorch_cpu",
-    # "h100_sxm5_80gb": "pytorch_cuda",
+    "h100_sxm5_80gb": "pytorch_cuda",
+    "jetson_orin_nano_8gb": "pytorch_jetson",
+    "jetson_orin_agx_64gb": "pytorch_jetson",
+    "jetson_orin_nx_16gb": "pytorch_jetson",
 }
 
 
@@ -53,6 +58,21 @@ def _make_measurer(hw_key: str, *, warmup_trials: int, timed_trials: int):
     backend = _MEASURER_FACTORY.get(hw_key)
     if backend == "pytorch_cpu":
         return PyTorchCPUMeasurer(
+            hardware=hw_key,
+            warmup_trials=warmup_trials,
+            timed_trials=timed_trials,
+        )
+    if backend == "pytorch_cuda":
+        # Lazy import: this module pulls in pynvml only when called.
+        from validation.model_v4.ground_truth.pytorch_cuda import PyTorchCUDAMeasurer
+        return PyTorchCUDAMeasurer(
+            hardware=hw_key,
+            warmup_trials=warmup_trials,
+            timed_trials=timed_trials,
+        )
+    if backend == "pytorch_jetson":
+        from validation.model_v4.ground_truth.pytorch_jetson import PyTorchJetsonMeasurer
+        return PyTorchJetsonMeasurer(
             hardware=hw_key,
             warmup_trials=warmup_trials,
             timed_trials=timed_trials,

--- a/validation/model_v4/cli/capture_ground_truth.py
+++ b/validation/model_v4/cli/capture_ground_truth.py
@@ -14,9 +14,14 @@ Cache invalidation is **explicit** (per the v4 plan): this CLI is the
 only writer. The validate CLI is read-only -- it never silently moves
 the validation reference.
 
-Currently the only ground-truth backend is ``PyTorchCPUMeasurer``
-(wall-clock + Intel RAPL). GPU (V4-4) and KPU simulator (V4-5)
-backends will dispatch via ``--hw``.
+Backends dispatch via ``--hw`` through ``_MEASURER_FACTORY``:
+
+* ``PyTorchCPUMeasurer`` (wall-clock + Intel RAPL) -- CPU targets
+* ``PyTorchCUDAMeasurer`` (cudaEvent + NVML) -- desktop / server
+  NVIDIA GPUs (H100, A100, ...)
+* ``PyTorchJetsonMeasurer`` (cudaEvent + INA3221) -- Jetson Orin Nano,
+  AGX, NX, Thor
+* KPU simulator backend (V4-5) is still pending.
 """
 
 from __future__ import annotations

--- a/validation/model_v4/ground_truth/pytorch_cuda.py
+++ b/validation/model_v4/ground_truth/pytorch_cuda.py
@@ -1,0 +1,287 @@
+"""PyTorch CUDA ground-truth measurer with optional NVML energy.
+
+Used to capture per-shape latency (and energy when available) on real
+NVIDIA GPU hardware so the v4 harness can validate the analyzer's
+predictions on accelerators (H100, A100, RTX, etc.).
+
+Latency:
+    GPU-accurate via ``torch.cuda.Event(enable_timing=True)``. CUDA event
+    timing brackets only the kernel launch + execution window on the
+    device, NOT host-side dispatch overhead -- which is the right thing
+    to measure when we want to validate the analyzer's *kernel* roofline
+    prediction. (Host overhead shows up in our launch_bound regime via a
+    different mechanism: the analyzer's launch_overhead_s constant.)
+
+    A small warm-up run primes any kernel autotune / cache before the
+    timed window; ``torch.cuda.synchronize`` is called before the start
+    event and after the stop event so the host-side measurement isn't
+    polluted by uncompleted launches.
+
+Energy:
+    NVML's ``nvmlDeviceGetTotalEnergyConsumption`` returns the cumulative
+    energy in millijoules since driver load (monotonic, wraps only at
+    2^64 mJ which is effectively never). We bracket the timed window
+    with two reads and take the delta.
+
+    If ``nvmlDeviceGetTotalEnergyConsumption`` isn't supported on the
+    device (older GPUs, integrated tegra), we fall back to
+    ``nvmlDeviceGetPowerUsage`` (instantaneous milliwatts) sampled
+    once and multiplied by latency -- a coarse approximation, marked
+    as such in the Measurement notes.
+
+    NVML is **device-level** (one reading per GPU). Like RAPL on CPU,
+    a noisy host that's running other CUDA workloads will inflate the
+    energy figure -- the harness assumes the test box is otherwise idle.
+
+If NVML is unavailable (pynvml not installed, driver mismatch, etc.)
+the measurer returns ``Measurement(energy_j=None,
+notes="NVML: <reason>")``. Per the assertions module that lets the
+record still pass overall on regime + latency.
+
+Use this measurer for desktop/server NVIDIA GPUs. For Jetson devices
+(Orin Nano/AGX/NX, Thor) use ``pytorch_jetson.py`` instead -- those
+read INA3221 power rails via sysfs, which gives a more accurate
+package-level number than the SoC-side NVML telemetry.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass, field
+from typing import Any, Optional, Tuple
+
+
+# Default warm-up + trial counts. CUDA kernels are typically less noisy
+# than CPU wall-clock so we can use a smaller trial count if desired,
+# but the defaults match pytorch_cpu.py for cross-target comparability.
+DEFAULT_WARMUP_TRIALS = 3
+DEFAULT_TIMED_TRIALS = 11    # odd so median is well-defined
+
+
+# ---------------------------------------------------------------------------
+# NVML probe
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _NVMLProbe:
+    """Minimal NVML energy reader. None when unavailable.
+
+    Holds a device handle (opaque ``int`` in pynvml) and remembers
+    whether total-energy is supported -- some Tesla cards and most
+    consumer GPUs only expose power, not the cumulative energy counter.
+    """
+    handle: Any                    # pynvml device handle (opaque)
+    supports_total_energy: bool
+    pynvml: Any                    # the imported pynvml module
+    name: str = "gpu-0"
+
+    def read_energy_mj(self) -> Optional[int]:
+        """Return cumulative energy since driver load in millijoules,
+        or None if the device doesn't support the counter."""
+        if not self.supports_total_energy:
+            return None
+        try:
+            return int(self.pynvml.nvmlDeviceGetTotalEnergyConsumption(self.handle))
+        except Exception:
+            return None
+
+    def read_power_mw(self) -> Optional[int]:
+        """Instantaneous power draw in milliwatts, or None on error."""
+        try:
+            return int(self.pynvml.nvmlDeviceGetPowerUsage(self.handle))
+        except Exception:
+            return None
+
+
+def _detect_nvml(device_index: int = 0) -> Optional[_NVMLProbe]:
+    """Initialize NVML on the given device or return None with no surprise.
+
+    Returns None for any of: pynvml not installed, NVML init failed,
+    invalid device index, both energy and power queries unsupported.
+    Callers should treat None as "energy not measured" rather than crash.
+    """
+    try:
+        import pynvml
+    except ImportError:
+        return None
+    try:
+        pynvml.nvmlInit()
+    except Exception:
+        return None
+    try:
+        handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
+    except Exception:
+        try:
+            pynvml.nvmlShutdown()
+        except Exception:
+            pass
+        return None
+
+    # Check support: try one read each; if both fail we can't measure energy.
+    supports_total_energy = True
+    try:
+        pynvml.nvmlDeviceGetTotalEnergyConsumption(handle)
+    except Exception:
+        supports_total_energy = False
+
+    supports_power = True
+    try:
+        pynvml.nvmlDeviceGetPowerUsage(handle)
+    except Exception:
+        supports_power = False
+
+    if not supports_total_energy and not supports_power:
+        try:
+            pynvml.nvmlShutdown()
+        except Exception:
+            pass
+        return None
+
+    try:
+        name_bytes = pynvml.nvmlDeviceGetName(handle)
+        name = (name_bytes.decode() if isinstance(name_bytes, bytes) else str(name_bytes))
+    except Exception:
+        name = f"gpu-{device_index}"
+
+    return _NVMLProbe(handle=handle, supports_total_energy=supports_total_energy,
+                      pynvml=pynvml, name=name)
+
+
+# ---------------------------------------------------------------------------
+# Measurer
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PyTorchCUDAMeasurer:
+    """cudaEvent + NVML measurer for PyTorch on a desktop/server NVIDIA GPU.
+
+    Stateful only insofar as it caches the NVML device handle. Inputs
+    are assumed to already be on the target device; the measurer does
+    not move tensors -- the workload builder owns placement.
+    """
+    hardware: str                 # caller supplies the hardware key
+    device_index: int = 0
+    warmup_trials: int = DEFAULT_WARMUP_TRIALS
+    timed_trials: int = DEFAULT_TIMED_TRIALS
+    name: str = "pytorch_cuda_nvml"
+    _probe: Optional[_NVMLProbe] = field(default=None)
+
+    def __post_init__(self) -> None:
+        if self._probe is None:
+            self._probe = _detect_nvml(self.device_index)
+
+    # -- public API ----------------------------------------------------------
+
+    def measure(self, model, inputs):
+        """Run ``model(*inputs)`` warmup + N times, return Measurement.
+
+        Imports torch lazily so the test harness can import this module
+        on a CPU-only machine without torch.cuda available.
+        """
+        import torch
+        from validation.model_v4.ground_truth.base import Measurement
+
+        if not torch.cuda.is_available():
+            # Without CUDA we can't measure on a GPU; surface as a clean
+            # error rather than crashing inside torch.cuda.Event below.
+            return Measurement(
+                latency_s=float("nan"),
+                energy_j=None,
+                trial_count=0,
+                notes="CUDA: torch.cuda.is_available() returned False",
+            )
+
+        # Warm-up (results discarded; primes kernel autotune + caches)
+        for _ in range(self.warmup_trials):
+            model(*inputs)
+        torch.cuda.synchronize(self.device_index)
+
+        latencies_s, energy_j, notes = self._timed_window(model, inputs, torch)
+        median_latency_s = statistics.median(latencies_s) if latencies_s else float("nan")
+
+        return Measurement(
+            latency_s=median_latency_s,
+            energy_j=energy_j,
+            trial_count=self.timed_trials,
+            notes=notes,
+        )
+
+    # -- internals -----------------------------------------------------------
+
+    def _timed_window(self, model, inputs, torch) -> Tuple[list[float], Optional[float], str]:
+        """Run the timed trials. Returns (latencies, energy, notes)."""
+        notes_parts: list[str] = []
+
+        # Energy bracketing: prefer cumulative-energy delta; fall back to
+        # power * latency if the device doesn't support the counter.
+        energy_before_mj: Optional[int] = None
+        if self._probe is not None and self._probe.supports_total_energy:
+            energy_before_mj = self._probe.read_energy_mj()
+            if energy_before_mj is None:
+                notes_parts.append("NVML: total-energy read failed pre-window")
+
+        # cudaEvent timing per trial. Each event lives on the same device;
+        # we synchronize after the stop event before reading elapsed time.
+        latencies_s: list[float] = []
+        for _ in range(self.timed_trials):
+            start = torch.cuda.Event(enable_timing=True)
+            stop = torch.cuda.Event(enable_timing=True)
+            start.record()
+            model(*inputs)
+            stop.record()
+            torch.cuda.synchronize(self.device_index)
+            # elapsed_time returns milliseconds
+            latencies_s.append(start.elapsed_time(stop) * 1e-3)
+
+        # Total wall-clock window length (sum of medians as approximation).
+        # We use median-trial-latency * trial_count for the energy denominator
+        # so a single tail-latency outlier doesn't inflate the figure.
+        median_latency_s = statistics.median(latencies_s)
+        window_s = median_latency_s * self.timed_trials
+
+        energy_j: Optional[float] = None
+        if self._probe is None:
+            notes_parts.append("NVML: probe not available on this host")
+        elif self._probe.supports_total_energy and energy_before_mj is not None:
+            energy_after_mj = self._probe.read_energy_mj()
+            if energy_after_mj is None:
+                notes_parts.append("NVML: total-energy read failed post-window")
+            else:
+                # NVML monotonic counter -- straightforward subtraction.
+                # Wraparound at 2^64 mJ is ~580 million years of full TDP,
+                # so we don't bother handling it.
+                delta_mj = energy_after_mj - energy_before_mj
+                if delta_mj < 0:
+                    notes_parts.append("NVML: energy counter went backwards "
+                                       "(driver restart?); energy=None")
+                else:
+                    mean_energy_mj = delta_mj / self.timed_trials
+                    energy_j = mean_energy_mj * 1e-3
+        else:
+            # Power-fallback path: one read of instantaneous power, multiply
+            # by per-trial latency. Less accurate but better than nothing for
+            # devices without the cumulative counter.
+            power_mw = self._probe.read_power_mw()
+            if power_mw is None:
+                notes_parts.append("NVML: power read failed (no fallback)")
+            else:
+                energy_j = (power_mw * 1e-3) * median_latency_s
+                notes_parts.append("NVML: power-fallback (no total-energy "
+                                   f"counter); P={power_mw}mW * lat")
+
+        return latencies_s, energy_j, "; ".join(notes_parts)
+
+    # -- cleanup -------------------------------------------------------------
+
+    def close(self) -> None:
+        """Optional: shut down NVML to release the handle. Safe to call
+        multiple times. Not strictly required -- NVML cleans up on
+        process exit."""
+        if self._probe is not None:
+            try:
+                self._probe.pynvml.nvmlShutdown()
+            except Exception:
+                pass
+            self._probe = None

--- a/validation/model_v4/ground_truth/pytorch_cuda.py
+++ b/validation/model_v4/ground_truth/pytorch_cuda.py
@@ -115,6 +115,8 @@ def _detect_nvml(device_index: int = 0) -> Optional[_NVMLProbe]:
         try:
             pynvml.nvmlShutdown()
         except Exception:
+            # Best-effort cleanup -- if shutdown also fails (driver wedge),
+            # there's nothing we can do; the caller still gets None.
             pass
         return None
 
@@ -135,6 +137,7 @@ def _detect_nvml(device_index: int = 0) -> Optional[_NVMLProbe]:
         try:
             pynvml.nvmlShutdown()
         except Exception:
+            # Best-effort cleanup on the unsupported-device path.
             pass
         return None
 
@@ -235,11 +238,9 @@ class PyTorchCUDAMeasurer:
             # elapsed_time returns milliseconds
             latencies_s.append(start.elapsed_time(stop) * 1e-3)
 
-        # Total wall-clock window length (sum of medians as approximation).
-        # We use median-trial-latency * trial_count for the energy denominator
-        # so a single tail-latency outlier doesn't inflate the figure.
+        # Median per-trial latency for the power-fallback energy estimate
+        # (avoids inflating energy from a single tail-latency outlier).
         median_latency_s = statistics.median(latencies_s)
-        window_s = median_latency_s * self.timed_trials
 
         energy_j: Optional[float] = None
         if self._probe is None:
@@ -283,5 +284,7 @@ class PyTorchCUDAMeasurer:
             try:
                 self._probe.pynvml.nvmlShutdown()
             except Exception:
+                # Teardown is best-effort; NVML cleans up on process exit
+                # anyway, so a shutdown failure here is not actionable.
                 pass
             self._probe = None

--- a/validation/model_v4/ground_truth/pytorch_jetson.py
+++ b/validation/model_v4/ground_truth/pytorch_jetson.py
@@ -1,0 +1,304 @@
+"""PyTorch CUDA + INA3221 ground-truth measurer for NVIDIA Jetson devices.
+
+The Jetson family (Orin Nano/NX/AGX, Thor) exposes per-rail power
+telemetry via the INA3221 sysfs interface. This is *more accurate* than
+NVML on Jetson because it reads the dedicated current-sense hardware on
+the SoC, capturing the integrated GPU + CPU + memory + IO power as
+separate rails -- whereas NVML on Tegra reports an aggregate that
+sometimes excludes the memory-controller draw (which is a meaningful
+fraction of inference power).
+
+Latency:
+    Same as ``pytorch_cuda.py``: ``torch.cuda.Event(enable_timing=True)``
+    bracketing each timed iteration.
+
+Energy:
+    Sum of selected INA3221 rail power readings, integrated across the
+    timed window. Sysfs paths vary by JetPack version:
+
+    * JetPack 5+ (Orin, Thor):
+      ``/sys/bus/i2c/drivers/ina3221/<bus>/hwmon/<hwmonN>/in<idx>_input``
+      voltage in mV
+      ``/sys/bus/i2c/drivers/ina3221/<bus>/hwmon/<hwmonN>/curr<idx>_input``
+      current in mA
+      Power_mW = (V_mV * I_mA) / 1000
+
+    * JetPack 4 (Xavier):
+      ``/sys/bus/i2c/drivers/ina3221x/<bus>/iio:device<n>/in_power<idx>_input``
+      power in mW directly
+
+    Both paths are detected at __init__ time. Rail labels (e.g.,
+    ``"VDD_GPU_SOC"``, ``"VDD_CPU_CV"``, ``"VDD_SOC"``) are read from
+    the matching ``rail_name_<idx>`` or ``in_name`` files so the caller
+    can pick which rails to integrate.
+
+    Default rail set: GPU + SOC + CPU. The user can override via the
+    ``rail_pattern`` argument (a regex matched against rail names).
+
+If INA3221 isn't accessible (path missing, permission denied, no rails
+match the pattern), the measurer returns
+``Measurement(energy_j=None, notes="INA3221: <reason>")``. Like the
+CPU/CUDA cases, the assertions module treats this as "not failed".
+"""
+
+from __future__ import annotations
+
+import re
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+
+DEFAULT_WARMUP_TRIALS = 3
+DEFAULT_TIMED_TRIALS = 11
+
+# Default rails to integrate. Conservative pattern that catches the
+# main inference draws on Orin Nano / AGX / NX without picking up DDR
+# (which is power-managed independently and may double-count).
+DEFAULT_RAIL_PATTERN = r"^(VDD_GPU_SOC|VDD_CPU_CV|VDD_SOC|VDD_IN|GPU|CPU|SOC|VIN_SYS_5V0)$"
+
+# Sysfs roots to probe in order of preference.
+_INA_SEARCH_ROOTS = [
+    Path("/sys/bus/i2c/drivers/ina3221"),     # JetPack 5+
+    Path("/sys/bus/i2c/drivers/ina3221x"),    # JetPack 4
+]
+
+
+# ---------------------------------------------------------------------------
+# INA3221 probe
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _INARail:
+    """One INA3221 rail with a power reader (mW)."""
+    name: str
+    read_power_mw: Any   # callable: () -> Optional[int]
+
+
+@dataclass
+class _INAProbe:
+    """Selected set of INA3221 rails to integrate."""
+    rails: list[_INARail] = field(default_factory=list)
+    backend: str = "unknown"   # "ina3221" (jp5+) or "ina3221x" (jp4)
+
+    def read_total_power_mw(self) -> Optional[int]:
+        """Sum the rail power readings. None if any rail fails."""
+        total = 0
+        for r in self.rails:
+            v = r.read_power_mw()
+            if v is None:
+                return None
+            total += v
+        return total
+
+
+def _detect_ina3221(rail_pattern: str = DEFAULT_RAIL_PATTERN) -> Optional[_INAProbe]:
+    """Walk the sysfs roots, find rails whose name matches ``rail_pattern``,
+    and return an _INAProbe ready to read total power. None on any failure."""
+    pat = re.compile(rail_pattern)
+
+    # JetPack 5+ path: hwmon-style power = V*I / 1000
+    for hwmon_root in _INA_SEARCH_ROOTS[:1]:
+        if not hwmon_root.exists():
+            continue
+        rails: list[_INARail] = []
+        for dev in hwmon_root.glob("*/hwmon/hwmon*"):
+            for name_path in sorted(dev.glob("in*_label")):
+                try:
+                    rail_name = name_path.read_text().strip()
+                except OSError:
+                    continue
+                if not pat.match(rail_name):
+                    continue
+                # name_path looks like "in1_label"; the matching power rail
+                # is "in1_input" + "curr1_input" -- but on hwmon the simpler
+                # path is "power1_input" in microwatts.
+                idx_match = re.match(r"in(\d+)_label", name_path.name)
+                if not idx_match:
+                    continue
+                idx = idx_match.group(1)
+                power_path = dev / f"power{idx}_input"
+                if power_path.exists():
+                    rails.append(_INARail(
+                        name=rail_name,
+                        read_power_mw=_make_uw_reader(power_path),
+                    ))
+                else:
+                    # Fall back to V*I (both in milli-units)
+                    volt_path = dev / f"in{idx}_input"
+                    curr_path = dev / f"curr{idx}_input"
+                    if volt_path.exists() and curr_path.exists():
+                        rails.append(_INARail(
+                            name=rail_name,
+                            read_power_mw=_make_vi_reader(volt_path, curr_path),
+                        ))
+        if rails:
+            return _INAProbe(rails=rails, backend="ina3221")
+
+    # JetPack 4 path: iio-style, direct power in mW
+    for iio_root in _INA_SEARCH_ROOTS[1:]:
+        if not iio_root.exists():
+            continue
+        rails = []
+        for dev in iio_root.glob("*/iio:device*"):
+            # rail names live in in_name<N>; power in in_power<N>_input (mW)
+            for name_path in sorted(dev.glob("rail_name_*")):
+                try:
+                    rail_name = name_path.read_text().strip()
+                except OSError:
+                    continue
+                if not pat.match(rail_name):
+                    continue
+                idx_match = re.match(r"rail_name_(\d+)", name_path.name)
+                if not idx_match:
+                    continue
+                idx = idx_match.group(1)
+                power_path = dev / f"in_power{idx}_input"
+                if power_path.exists():
+                    rails.append(_INARail(
+                        name=rail_name,
+                        read_power_mw=_make_mw_reader(power_path),
+                    ))
+        if rails:
+            return _INAProbe(rails=rails, backend="ina3221x")
+
+    return None
+
+
+def _make_mw_reader(path: Path):
+    def _read() -> Optional[int]:
+        try:
+            return int(path.read_text().strip())
+        except (OSError, ValueError):
+            return None
+    return _read
+
+
+def _make_uw_reader(path: Path):
+    def _read() -> Optional[int]:
+        try:
+            return int(path.read_text().strip()) // 1000  # uW -> mW
+        except (OSError, ValueError):
+            return None
+    return _read
+
+
+def _make_vi_reader(volt_path: Path, curr_path: Path):
+    def _read() -> Optional[int]:
+        try:
+            v_mv = int(volt_path.read_text().strip())
+            i_ma = int(curr_path.read_text().strip())
+            return (v_mv * i_ma) // 1000  # mV*mA = uW; uW/1000 = mW
+        except (OSError, ValueError):
+            return None
+    return _read
+
+
+# ---------------------------------------------------------------------------
+# Measurer
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PyTorchJetsonMeasurer:
+    """cudaEvent + INA3221 measurer for PyTorch on a Jetson device.
+
+    Use this for Orin Nano/NX/AGX and Thor. For desktop/server NVIDIA
+    use ``PyTorchCUDAMeasurer`` (NVML) instead.
+
+    Energy integration strategy: sample INA3221 power once at the start
+    and once at the end of the timed window, average, multiply by total
+    window time. INA3221 has ~8ms internal averaging built in (per the
+    datasheet), so for our typical millisecond-scale windows the read-
+    once-per-side approach is roughly equivalent to a tight polling loop
+    while costing far less CPU overhead. The notes field surfaces if the
+    window was below the INA3221 averaging period (results unreliable).
+    """
+    hardware: str
+    device_index: int = 0
+    warmup_trials: int = DEFAULT_WARMUP_TRIALS
+    timed_trials: int = DEFAULT_TIMED_TRIALS
+    rail_pattern: str = DEFAULT_RAIL_PATTERN
+    name: str = "pytorch_jetson_ina3221"
+    _probe: Optional[_INAProbe] = field(default=None)
+
+    def __post_init__(self) -> None:
+        if self._probe is None:
+            self._probe = _detect_ina3221(self.rail_pattern)
+
+    # -- public API ----------------------------------------------------------
+
+    def measure(self, model, inputs):
+        """Run ``model(*inputs)`` warmup + N times, return Measurement."""
+        import torch
+        from validation.model_v4.ground_truth.base import Measurement
+
+        if not torch.cuda.is_available():
+            return Measurement(
+                latency_s=float("nan"),
+                energy_j=None,
+                trial_count=0,
+                notes="CUDA: torch.cuda.is_available() returned False",
+            )
+
+        for _ in range(self.warmup_trials):
+            model(*inputs)
+        torch.cuda.synchronize(self.device_index)
+
+        latencies_s, energy_j, notes = self._timed_window(model, inputs, torch)
+        median_latency_s = statistics.median(latencies_s) if latencies_s else float("nan")
+
+        return Measurement(
+            latency_s=median_latency_s,
+            energy_j=energy_j,
+            trial_count=self.timed_trials,
+            notes=notes,
+        )
+
+    # -- internals -----------------------------------------------------------
+
+    def _timed_window(self, model, inputs, torch) -> Tuple[list[float], Optional[float], str]:
+        notes_parts: list[str] = []
+
+        power_before_mw: Optional[int] = None
+        if self._probe is not None:
+            power_before_mw = self._probe.read_total_power_mw()
+            if power_before_mw is None:
+                notes_parts.append("INA3221: pre-window power read failed")
+
+        latencies_s: list[float] = []
+        for _ in range(self.timed_trials):
+            start = torch.cuda.Event(enable_timing=True)
+            stop = torch.cuda.Event(enable_timing=True)
+            start.record()
+            model(*inputs)
+            stop.record()
+            torch.cuda.synchronize(self.device_index)
+            latencies_s.append(start.elapsed_time(stop) * 1e-3)
+
+        energy_j: Optional[float] = None
+        if self._probe is None:
+            notes_parts.append("INA3221: probe not available on this host")
+        elif power_before_mw is not None:
+            power_after_mw = self._probe.read_total_power_mw()
+            if power_after_mw is None:
+                notes_parts.append("INA3221: post-window power read failed")
+            else:
+                # Average power across the window, multiplied by window time.
+                # This double-counts if the workload is bursty (e.g., short
+                # kernels with idle gaps) but for back-to-back inference
+                # trials this is close enough.
+                median_latency_s = statistics.median(latencies_s)
+                window_s = median_latency_s * self.timed_trials
+                avg_power_w = (power_before_mw + power_after_mw) / 2.0 * 1e-3
+                # Per-trial mean energy
+                energy_j = (avg_power_w * window_s) / self.timed_trials
+                # Warn if the window is below INA3221's 8ms averaging period
+                if window_s < 8e-3:
+                    notes_parts.append(f"INA3221: window {window_s*1e3:.1f}ms "
+                                       "below 8ms averaging period; energy noisy")
+                notes_parts.append(f"rails={[r.name for r in self._probe.rails]}")
+
+        return latencies_s, energy_j, "; ".join(notes_parts)

--- a/validation/model_v4/harness/runner.py
+++ b/validation/model_v4/harness/runner.py
@@ -70,10 +70,14 @@ from validation.model_v4.workloads.matmul import build_matmul
 
 # Sweep-JSON keys -> mapper-registry keys. Sweep JSONs use a normalized
 # form (lowercase, underscores) so they're stable across registry naming
-# changes; the runner translates here.
+# changes; the runner translates here. Must stay in sync with
+# KNOWN_TARGETS in validation/model_v4/sweeps/_augment.py.
 SWEEP_HW_TO_MAPPER: dict[str, str] = {
     "i7_12700k": "Intel-i7-12700K",
     "h100_sxm5_80gb": "H100-SXM5-80GB",
+    "jetson_orin_nano_8gb": "Jetson-Orin-Nano-8GB",
+    "jetson_orin_agx_64gb": "Jetson-Orin-AGX-64GB",
+    "jetson_orin_nx_16gb": "Jetson-Orin-NX-16GB",
 }
 
 

--- a/validation/model_v4/sweeps/_augment.py
+++ b/validation/model_v4/sweeps/_augment.py
@@ -1,0 +1,166 @@
+"""Augment existing sweep JSONs with regimes for additional hardware.
+
+Why this exists, separately from ``_generate.py``:
+
+The original generator (``_generate.py``) picks shapes that exhibit
+specific regimes on a fixed list of TARGETS (currently i7-12700K and
+H100). Adding a new target there would change which shapes get chosen
+because the sampling iterates over (target, regime) buckets -- so
+re-running ``_generate.py`` with extra targets churns the committed
+sweeps and invalidates the i7 baseline that's already in the repo.
+
+This script is the *additive* path: it reads the existing sweep, runs
+the regime classifier against new hardware mappers, and inserts the
+results into ``regime_per_hw`` for each entry. Existing entries (their
+shapes, dtypes, and original target regimes) are left untouched. Run
+this when adding a new hardware target without re-sampling.
+
+Usage:
+
+    python -m validation.model_v4.sweeps._augment \\
+        --hw jetson_orin_nano_8gb \\
+        --dtype fp16 \\
+        --op matmul \\
+        --purpose validation
+
+    # Re-augment everything with all currently-supported targets:
+    python -m validation.model_v4.sweeps._augment --all
+
+The script is idempotent: re-running with the same (hw, dtype) is a
+no-op (existing keys in ``regime_per_hw`` are overwritten with the
+same value).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from graphs.hardware.mappers.cpu import create_i7_12700k_mapper
+from graphs.hardware.mappers.gpu import create_h100_sxm5_80gb_mapper
+from graphs.hardware.mappers.gpu import (
+    create_jetson_orin_nano_8gb_mapper,
+    create_jetson_orin_agx_64gb_mapper,
+    create_jetson_orin_nx_16gb_mapper,
+)
+
+from validation.model_v4.sweeps.classify import Regime, classify_regime
+
+
+SWEEP_DIR = Path(__file__).resolve().parent
+
+
+@dataclass(frozen=True)
+class _Target:
+    hw_key: str           # the key written into regime_per_hw
+    dtype: str            # the precision to classify against
+    factory: Callable     # callable returning a mapper
+
+    @property
+    def hw(self):
+        return self.factory().resource_model
+
+
+# Registry of targets the augmenter knows how to classify against.
+# Adding a new entry here is the single point of change for V4-4 hardware
+# expansion. The CPU / H100 entries are duplicated from _generate.py
+# because the augmenter must be able to *re-augment* existing entries
+# (idempotently) without depending on the generator's specific dtype
+# choices.
+KNOWN_TARGETS: dict[str, _Target] = {
+    "i7_12700k": _Target(
+        hw_key="i7_12700k", dtype="fp32", factory=create_i7_12700k_mapper),
+    "h100_sxm5_80gb": _Target(
+        hw_key="h100_sxm5_80gb", dtype="fp16", factory=create_h100_sxm5_80gb_mapper),
+    "jetson_orin_nano_8gb": _Target(
+        hw_key="jetson_orin_nano_8gb", dtype="fp16",
+        factory=create_jetson_orin_nano_8gb_mapper),
+    "jetson_orin_agx_64gb": _Target(
+        hw_key="jetson_orin_agx_64gb", dtype="fp16",
+        factory=create_jetson_orin_agx_64gb_mapper),
+    "jetson_orin_nx_16gb": _Target(
+        hw_key="jetson_orin_nx_16gb", dtype="fp16",
+        factory=create_jetson_orin_nx_16gb_mapper),
+}
+
+
+def augment_sweep(sweep_path: Path, target: _Target) -> tuple[int, int]:
+    """Insert ``target.hw_key`` regimes into the sweep JSON at ``sweep_path``.
+
+    Only entries whose existing dtype matches ``target.dtype`` are
+    classified; entries with non-matching dtype get a clean skip rather
+    than a forced UNSUPPORTED label (the entry just won't have a
+    regime for this target, which is exactly the runner's expectation
+    -- no regime => skip in run_sweep).
+
+    Returns: (entries_classified, entries_skipped_dtype).
+    """
+    sweep = json.loads(sweep_path.read_text())
+    op = sweep["op"]
+    hw = target.hw
+
+    classified = 0
+    skipped_dtype = 0
+    for entry in sweep["shapes"]:
+        if entry["dtype"] != target.dtype:
+            skipped_dtype += 1
+            continue
+        regime = classify_regime(op, tuple(entry["shape"]),
+                                 entry["dtype"], hw)
+        entry.setdefault("regime_per_hw", {})[target.hw_key] = regime.value
+        classified += 1
+
+    # Surface in the JSON metadata that this hw was augmented in.
+    augmented = sweep.setdefault("augmented_with_hardware", [])
+    if target.hw_key not in augmented:
+        augmented.append(target.hw_key)
+        augmented.sort()
+
+    sweep_path.write_text(json.dumps(sweep, indent=2))
+    return classified, skipped_dtype
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--hw", choices=sorted(KNOWN_TARGETS),
+                   help="Augment one specific hardware key")
+    g.add_argument("--all", action="store_true",
+                   help="Augment with every known target")
+    p.add_argument("--op", choices=["matmul", "linear"], default=None,
+                   help="Restrict to one op (default: both)")
+    p.add_argument("--purpose", choices=["calibration", "validation"], default=None,
+                   help="Restrict to one purpose (default: both)")
+    args = p.parse_args(argv)
+
+    targets = (list(KNOWN_TARGETS.values()) if args.all
+               else [KNOWN_TARGETS[args.hw]])
+
+    ops = [args.op] if args.op else ["matmul", "linear"]
+    purposes = [args.purpose] if args.purpose else ["calibration", "validation"]
+
+    for op in ops:
+        for purpose in purposes:
+            sweep_path = SWEEP_DIR / f"{op}_{purpose}.json"
+            if not sweep_path.exists():
+                print(f"  skip (no file): {sweep_path.name}")
+                continue
+            for target in targets:
+                classified, skipped = augment_sweep(sweep_path, target)
+                print(f"{sweep_path.name} [{target.hw_key}]: "
+                      f"{classified} classified, {skipped} dtype-mismatch")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validation/model_v4/sweeps/_augment.py
+++ b/validation/model_v4/sweeps/_augment.py
@@ -48,7 +48,7 @@ from graphs.hardware.mappers.gpu import (
     create_jetson_orin_nx_16gb_mapper,
 )
 
-from validation.model_v4.sweeps.classify import Regime, classify_regime
+from validation.model_v4.sweeps.classify import classify_regime
 
 
 SWEEP_DIR = Path(__file__).resolve().parent

--- a/validation/model_v4/sweeps/linear_calibration.json
+++ b/validation/model_v4/sweeps/linear_calibration.json
@@ -15,7 +15,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -37,7 +40,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -59,7 +65,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -81,7 +90,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -257,7 +269,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "alu_bound"
+        "h100_sxm5_80gb": "alu_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -268,7 +283,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "alu_bound"
+        "h100_sxm5_80gb": "alu_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -279,7 +297,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "alu_bound"
+        "h100_sxm5_80gb": "alu_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -290,7 +311,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -301,7 +325,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -312,7 +339,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -323,7 +353,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -334,7 +367,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -345,7 +381,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -356,7 +395,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -367,7 +409,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -378,7 +423,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -389,7 +437,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -400,8 +451,18 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     }
+  ],
+  "augmented_with_hardware": [
+    "h100_sxm5_80gb",
+    "i7_12700k",
+    "jetson_orin_agx_64gb",
+    "jetson_orin_nano_8gb",
+    "jetson_orin_nx_16gb"
   ]
 }

--- a/validation/model_v4/sweeps/linear_validation.json
+++ b/validation/model_v4/sweeps/linear_validation.json
@@ -15,7 +15,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -37,7 +40,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -59,7 +65,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -81,7 +90,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -103,7 +115,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -125,7 +140,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -147,7 +165,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -169,7 +190,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -191,7 +215,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -213,7 +240,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -785,7 +815,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "alu_bound"
+        "h100_sxm5_80gb": "alu_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -796,7 +829,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "alu_bound"
+        "h100_sxm5_80gb": "alu_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -807,7 +843,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -818,7 +857,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -829,7 +871,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -840,7 +885,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -851,7 +899,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -862,7 +913,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "alu_bound"
+        "h100_sxm5_80gb": "alu_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -873,7 +927,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -884,7 +941,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -895,7 +955,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -906,7 +969,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -917,7 +983,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -928,7 +997,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -939,7 +1011,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -950,7 +1025,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -961,7 +1039,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -972,7 +1053,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -983,7 +1067,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -994,7 +1081,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1005,7 +1095,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1016,7 +1109,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1027,7 +1123,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1038,7 +1137,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1049,7 +1151,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1060,7 +1165,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1071,7 +1179,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1082,7 +1193,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1093,7 +1207,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1104,7 +1221,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1115,7 +1235,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1126,7 +1249,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1137,7 +1263,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1148,7 +1277,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1159,7 +1291,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1170,8 +1305,18 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     }
+  ],
+  "augmented_with_hardware": [
+    "h100_sxm5_80gb",
+    "i7_12700k",
+    "jetson_orin_agx_64gb",
+    "jetson_orin_nano_8gb",
+    "jetson_orin_nx_16gb"
   ]
 }

--- a/validation/model_v4/sweeps/matmul_calibration.json
+++ b/validation/model_v4/sweeps/matmul_calibration.json
@@ -15,7 +15,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -37,7 +40,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -59,7 +65,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -81,7 +90,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -257,7 +269,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -268,7 +283,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -279,7 +297,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -290,7 +311,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "alu_bound"
+        "h100_sxm5_80gb": "alu_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -301,7 +325,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "alu_bound"
+        "h100_sxm5_80gb": "alu_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -312,7 +339,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -323,7 +353,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -334,7 +367,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -345,7 +381,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -356,7 +395,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -367,7 +409,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -378,7 +423,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -389,7 +437,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -400,7 +451,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -411,7 +465,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -422,8 +479,18 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     }
+  ],
+  "augmented_with_hardware": [
+    "h100_sxm5_80gb",
+    "i7_12700k",
+    "jetson_orin_agx_64gb",
+    "jetson_orin_nano_8gb",
+    "jetson_orin_nx_16gb"
   ]
 }

--- a/validation/model_v4/sweeps/matmul_validation.json
+++ b/validation/model_v4/sweeps/matmul_validation.json
@@ -15,7 +15,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -37,7 +40,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -59,7 +65,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -81,7 +90,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -103,7 +115,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -125,7 +140,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -147,7 +165,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -169,7 +190,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -191,7 +215,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -213,7 +240,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "launch_bound"
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
       }
     },
     {
@@ -785,7 +815,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -796,7 +829,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -807,7 +843,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "alu_bound"
+        "h100_sxm5_80gb": "alu_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -818,7 +857,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -829,7 +871,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -840,7 +885,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -851,7 +899,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -862,7 +913,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -873,7 +927,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -884,7 +941,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -895,7 +955,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -906,7 +969,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -917,7 +983,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -928,7 +997,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -939,7 +1011,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -950,7 +1025,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -961,7 +1039,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -972,7 +1053,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -983,7 +1067,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "alu_bound"
+        "h100_sxm5_80gb": "alu_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -994,7 +1081,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1005,7 +1095,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1016,7 +1109,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1027,7 +1123,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1038,7 +1137,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1049,7 +1151,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1060,7 +1165,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1071,7 +1179,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1082,7 +1193,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1093,7 +1207,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1104,7 +1221,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1115,7 +1235,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1126,7 +1249,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1137,7 +1263,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "dram_bound"
+        "h100_sxm5_80gb": "dram_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1148,7 +1277,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1159,7 +1291,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1170,7 +1305,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1181,7 +1319,10 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     },
     {
@@ -1192,8 +1333,18 @@
       ],
       "dtype": "fp16",
       "regime_per_hw": {
-        "h100_sxm5_80gb": "l2_bound"
+        "h100_sxm5_80gb": "l2_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
       }
     }
+  ],
+  "augmented_with_hardware": [
+    "h100_sxm5_80gb",
+    "i7_12700k",
+    "jetson_orin_agx_64gb",
+    "jetson_orin_nano_8gb",
+    "jetson_orin_nx_16gb"
   ]
 }


### PR DESCRIPTION
## Summary
Phase A of V4-4: ships the measurement-side scaffolding for V4 validation on NVIDIA targets without requiring access to the target hardware. The actual baseline CSVs need to be captured on real silicon (Phase B) -- this PR is reviewable on the i7 dev box because every change is mock-tested or schema-tested.

## What's new

### Ground-truth backends
- **`pytorch_cuda.py`** -- cudaEvent + NVML for desktop/server NVIDIA (H100, A100, RTX). Total-energy counter preferred, instantaneous-power fallback for older Tesla cards. Graceful degradation when pynvml is missing or NVML init fails.
- **`pytorch_jetson.py`** -- cudaEvent + INA3221 sysfs for Jetson Orin Nano/AGX/NX, Thor. Two-layout detector (JetPack 5+ hwmon and JetPack 4 iio). Rail filter with sane defaults (GPU/CPU/SOC/VIN_SYS, skips DDR). Warns when window is below INA3221's 8 ms averaging period.

### Sweep augmentation
- **`sweeps/_augment.py`** -- adds new hardware regimes to existing sweep entries *additively*. Re-running the original generator would churn shape selection and invalidate the committed i7 baseline. Idempotent, dtype-aware, schema-stable.
- All four sweep JSONs re-augmented with H100 + 3 Jetson keys. The pre-existing i7 entries are byte-identical (verified by `test_recorded_regime_labels_still_match_classifier`).

### Plumbing
- `runner.SWEEP_HW_TO_MAPPER` extended with H100 + 3 Jetson keys.
- `capture_ground_truth._MEASURER_FACTORY` dispatches to the new backends via lazy import (so the i7 box without pynvml/torch.cuda can still import the CLI module).

### Docs
- `docs/plans/v4-capture-on-target.md` -- per-target capture procedure (dependencies, rail permissions, smoke test, full run, commit-back step).

## Tests
| Target | Result |
|---|---|
| 29 new tests across 3 new files | PASS |
| Full `tests/validation_model_v4/` (203 tests, was 174) | PASS |

The new tests use `unittest.mock` to fake pynvml + torch.cuda + INA3221 sysfs, so they run on any host. Real-hardware verification is Phase B.

## Phase B (future PR, needs target access)
- Run capture-on-target on Jetson Orin Nano (locally available).
- Commit `jetson_orin_nano_8gb_{matmul,linear}.csv` baselines.
- Add pass-rate floor tests pinning the post-capture pass rates.
- Repeat for H100 once a server is available.

## Test plan
- [ ] CI passes on this PR (CPU-only path)
- [ ] CodeRabbit / github-code-quality review
- [ ] Phase B: capture on Jetson Orin Nano -> baseline CSV PR

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ground-truth measurement support for NVIDIA CUDA GPUs and Jetson devices.
  * Introduced sweep augmentation tool for hardware regime classification.

* **Documentation**
  * Added comprehensive V4 ground-truth capture workflow guide with hardware target procedures.

* **Tests**
  * Added test coverage for CUDA and Jetson measurement modules.
  * Added test coverage for sweep augmentation and validation logic.

* **Chores**
  * Extended hardware target support (H100, Jetson Orin Nano/AGX/NX).
  * Updated calibration and validation sweep data for new hardware targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->