### PR TITLE
feat(validation): V4-5 -- KPU consistency-only invariants

### DIFF
--- a/tests/validation_model_v4/test_kpu_invariants.py
+++ b/tests/validation_model_v4/test_kpu_invariants.py
@@ -39,6 +39,7 @@ from graphs.hardware.resource_model import Precision
 
 from validation.model_v4.invariants.kpu import (
     DEFAULT_SHAPE_GRID,
+    _bpe,
     check_achieved_bw_below_peak,
     check_achieved_compute_below_peak,
     check_avg_power_below_tdp,
@@ -181,6 +182,32 @@ def test_family_latency_non_increasing(shape_idx):
 # ---------------------------------------------------------------------------
 # Battery: convenience pass-rate check via run_kpu_invariants
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# _bpe contract -- fail fast on packed sub-byte and unrecognized precisions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("precision,expected", [
+    (Precision.FP64, 8),
+    (Precision.FP32, 4),
+    (Precision.TF32, 4),
+    (Precision.FP16, 2),
+    (Precision.BF16, 2),
+    (Precision.INT8, 1),
+    (Precision.FP8, 1),
+])
+def test_bpe_returns_known_byte_widths(precision, expected):
+    assert _bpe(precision) == expected
+
+
+@pytest.mark.parametrize("precision", [Precision.INT4, Precision.FP4])
+def test_bpe_raises_on_packed_sub_byte(precision):
+    """Packed 4-bit precisions need fractional byte accounting; the
+    invariant suite should fail fast rather than silently round to 1."""
+    with pytest.raises(NotImplementedError, match="packed sub-byte"):
+        _bpe(precision)
 
 
 def test_run_kpu_invariants_returns_zero_hard_failures(kpu_mapper):

--- a/tests/validation_model_v4/test_kpu_invariants.py
+++ b/tests/validation_model_v4/test_kpu_invariants.py
@@ -1,0 +1,197 @@
+"""V4-5 KPU consistency-only invariant tests.
+
+The KPU is a research/in-development spatial-dataflow accelerator with
+no commercially-available silicon to measure against. Per the v4 plan
+(Principle 2), KPU validation is consistency-only -- we don't assert
+per-shape predicted-vs-measured bands, but we DO assert the analyzer's
+KPU predictions satisfy basic math/physical invariants.
+
+Test coverage matrix:
+
+  Invariant                              T64  T128  T256  T768
+  -------------------------------------  ---  ----  ----  ----
+  roofline_self_consistency              PASS PASS  PASS  PASS
+  latency_non_decreasing_in_size         PASS PASS  PASS  PASS
+  memory_time_scales_with_bytes          PASS PASS  PASS  PASS
+  achieved_compute_below_peak            PASS PASS  PASS  PASS
+  achieved_bw_below_peak                 PASS PASS  PASS  PASS
+  avg_power_below_tdp                    XFAIL XFAIL XFAIL XFAIL  (#81)
+  family_latency_non_increasing                 (cross-mapper test)
+
+The avg_power_below_tdp invariant is marked xfail because the KPU
+energy model uses the GPU IDLE_POWER_FRACTION (0.3) and uncalibrated
+dynamic energy_per_flop coefficients -- the same pre-#71 problem that
+afflicted CPU. Issue #81 tracks the KPU energy calibration; once that
+lands the xfail comes off and this becomes a regular pass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graphs.hardware.mappers.accelerators.kpu import (
+    create_kpu_t64_mapper,
+    create_kpu_t128_mapper,
+    create_kpu_t256_mapper,
+    create_kpu_t768_mapper,
+)
+from graphs.hardware.resource_model import Precision
+
+from validation.model_v4.invariants.kpu import (
+    DEFAULT_SHAPE_GRID,
+    check_achieved_bw_below_peak,
+    check_achieved_compute_below_peak,
+    check_avg_power_below_tdp,
+    check_family_latency_non_increasing,
+    check_latency_non_decreasing_in_size,
+    check_memory_time_scales_with_bytes,
+    check_roofline_self_consistency,
+    run_kpu_invariants,
+)
+
+
+# Order matters here -- many tests rely on this being increasing in
+# capability (T64 -> T768).
+_KPU_FAMILY = [
+    ("T64",  create_kpu_t64_mapper),
+    ("T128", create_kpu_t128_mapper),
+    ("T256", create_kpu_t256_mapper),
+    ("T768", create_kpu_t768_mapper),
+]
+
+
+# BF16 is the only precision supported by every KPU in the family
+# (T128 and T768 don't list FP16/FP32 in their precision_profiles).
+# Using BF16 universally lets all 4 mappers run the same test set.
+PRECISION = Precision.BF16
+
+
+# ---------------------------------------------------------------------------
+# Per-mapper hard invariants (must always hold)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=_KPU_FAMILY, ids=[name for name, _ in _KPU_FAMILY])
+def kpu_mapper(request):
+    name, factory = request.param
+    return name, factory().resource_model
+
+
+def test_roofline_self_consistency(kpu_mapper):
+    """``actual_latency = max(compute_time, memory_time) + overhead`` --
+    if this fails the analyzer's own definition has drifted."""
+    name, hw = kpu_mapper
+    failures = check_roofline_self_consistency(hw, PRECISION)
+    assert not failures, (
+        f"KPU-{name} roofline self-consistency violations:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+def test_latency_non_decreasing_in_size(kpu_mapper):
+    """Sweeping square matmul size: bigger workload cannot run faster."""
+    name, hw = kpu_mapper
+    failures = check_latency_non_decreasing_in_size(hw, PRECISION)
+    assert not failures, (
+        f"KPU-{name} latency non-monotonic in shape size:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+def test_memory_time_scales_with_bytes(kpu_mapper):
+    """Memory time non-decreasing in working_set_bytes (cache effects
+    mean it doesn't have to be linear, but it must be monotonic)."""
+    name, hw = kpu_mapper
+    failures = check_memory_time_scales_with_bytes(hw, PRECISION)
+    assert not failures, (
+        f"KPU-{name} memory_time non-monotonic in bytes:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+def test_achieved_compute_below_peak(kpu_mapper):
+    """Hard physical bound: flops / compute_time <= peak FLOPS * slack."""
+    name, hw = kpu_mapper
+    failures = check_achieved_compute_below_peak(hw, PRECISION)
+    assert not failures, (
+        f"KPU-{name} achieved compute exceeds theoretical peak:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+def test_achieved_bw_below_peak(kpu_mapper):
+    """Hard physical bound: bytes / memory_time <= peak BW * slack."""
+    name, hw = kpu_mapper
+    failures = check_achieved_bw_below_peak(hw, PRECISION)
+    assert not failures, (
+        f"KPU-{name} achieved memory BW exceeds theoretical peak:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic: power-below-TDP is currently violated (xfail with reason)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(strict=True, reason=(
+    "KPU energy model uses the GPU IDLE_POWER_FRACTION (0.3) and "
+    "uncalibrated dynamic energy_per_flop coefficients. Predicted "
+    "average power exceeds TDP by ~1.5x-3x for typical matmul shapes. "
+    "Tracked in #81; mirrors the pre-#71 CPU situation. xfail "
+    "strict=True so if the energy model gets fixed, the test flips "
+    "to a regular pass and CI flags the xfail for removal."
+))
+def test_avg_power_below_tdp_known_violated(kpu_mapper):
+    """Diagnostic: predicted avg power (energy/latency) <= TDP * 1.10.
+
+    Currently KNOWN VIOLATED on every KPU mapper -- see xfail reason.
+    The check itself is implemented and ready to flip to a hard test
+    once the energy model is calibrated."""
+    name, hw = kpu_mapper
+    failures = check_avg_power_below_tdp(hw, PRECISION)
+    assert not failures, (
+        f"KPU-{name} predicted avg power exceeds TDP:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-mapper invariant (single test, not parametrized per-mapper)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape_idx", range(len(DEFAULT_SHAPE_GRID)),
+                         ids=[f"({s.M},{s.K},{s.N})" for s in DEFAULT_SHAPE_GRID])
+def test_family_latency_non_increasing(shape_idx):
+    """Across the KPU family ordered by capability (T64 -> T128 -> T256
+    -> T768), predicted latency for a fixed shape must be non-increasing.
+    More tiles + more BW cannot make a fixed workload slower."""
+    family = [(f"KPU-{name}", factory().resource_model)
+              for name, factory in _KPU_FAMILY]
+    shape = DEFAULT_SHAPE_GRID[shape_idx]
+    failures = check_family_latency_non_increasing(family, PRECISION, shape)
+    assert not failures, (
+        f"family latency monotonicity violated at shape "
+        f"({shape.M},{shape.K},{shape.N}):\n  "
+        + "\n  ".join(failures)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Battery: convenience pass-rate check via run_kpu_invariants
+# ---------------------------------------------------------------------------
+
+
+def test_run_kpu_invariants_returns_zero_hard_failures(kpu_mapper):
+    """Sanity: ``run_kpu_invariants`` produces 0 *hard* failures for every
+    KPU mapper. (Soft failures = avg_power_below_tdp; excluded via
+    ``hard_failures()``.) This guards against a future invariant being
+    added that the existing mappers can't satisfy."""
+    name, hw = kpu_mapper
+    report = run_kpu_invariants(hw, PRECISION, hardware_name=f"KPU-{name}")
+    hard = report.hard_failures()
+    assert not hard, (
+        f"KPU-{name} battery has hard failures:\n  "
+        + "\n  ".join(f"[{k}] {v}" for k, vs in hard.items() for v in vs)
+    )

--- a/validation/model_v4/invariants/__init__.py
+++ b/validation/model_v4/invariants/__init__.py
@@ -1,0 +1,14 @@
+"""Consistency-only invariant checks for accelerators without per-shape
+ground truth (V4-5).
+
+Per Principle 2 of the v4 plan, KPU/TPU-class accelerators that lack
+out-of-band measurement get a different validation contract than
+CPU/GPU: instead of asserting per-shape predicted-vs-measured bands,
+we assert that the analyzer's predictions are *internally consistent*
+and physically plausible.
+
+Each invariant is a pure function returning a list of failure messages
+(empty list = pass). The pytest wrapper at
+``tests/validation_model_v4/test_kpu_invariants.py`` parametrizes
+the invariants over the KPU mapper family (T64/T128/T256/T768).
+"""

--- a/validation/model_v4/invariants/kpu.py
+++ b/validation/model_v4/invariants/kpu.py
@@ -71,7 +71,18 @@ class _MatmulShape:
 
 
 def _bpe(precision: Precision) -> int:
-    """Bytes per element for the precision argument."""
+    """Bytes per element for the precision argument.
+
+    Raises on packed sub-byte precisions (INT4, FP4) -- this helper
+    returns an integer count of bytes, so honest accounting for 0.5 B
+    per element would require a bytes-per-N-elements API instead. The
+    invariant suite uses BF16, INT8, and larger; if a future invariant
+    needs INT4, this helper should be promoted to return float (or
+    pairs).
+
+    Raises on any unrecognized Precision rather than silently defaulting,
+    so a typo or new precision enum value fails fast at the invariant
+    layer rather than producing nonsense byte counts."""
     if precision in (Precision.FP64,):
         return 8
     if precision in (Precision.FP32, Precision.TF32):
@@ -81,8 +92,15 @@ def _bpe(precision: Precision) -> int:
     if precision in (Precision.INT8, Precision.FP8, Precision.FP8_E4M3, Precision.FP8_E5M2):
         return 1
     if precision in (Precision.INT4, Precision.FP4):
-        return 1   # round up; 0.5 doesn't fit in int. Tests use larger precisions.
-    return 4
+        raise NotImplementedError(
+            f"_bpe(): packed sub-byte precision {precision.name} requires "
+            "fractional byte accounting (0.5 B/elem). Promote _bpe to "
+            "return float (or bytes-per-N-elements) before using it here."
+        )
+    raise ValueError(
+        f"_bpe(): unrecognized Precision {precision!r}. Add an explicit "
+        "branch above rather than relying on a default."
+    )
 
 
 # Default shape grid for monotonicity / scaling sweeps. Square shapes
@@ -119,12 +137,20 @@ def check_roofline_self_consistency(
     for s in shapes:
         sg = s.to_subgraph(bpe)
         lat = analyzer._analyze_subgraph(sg)
+        # All four time components must be non-negative -- a negative
+        # value means the analyzer's math has a sign error somewhere.
         if lat.compute_time < 0:
             failures.append(
                 f"shape=({s.M},{s.K},{s.N}): compute_time={lat.compute_time:.3e} < 0")
         if lat.memory_time < 0:
             failures.append(
                 f"shape=({s.M},{s.K},{s.N}): memory_time={lat.memory_time:.3e} < 0")
+        if lat.overhead < 0:
+            failures.append(
+                f"shape=({s.M},{s.K},{s.N}): overhead={lat.overhead:.3e} < 0")
+        if lat.actual_latency < 0:
+            failures.append(
+                f"shape=({s.M},{s.K},{s.N}): actual_latency={lat.actual_latency:.3e} < 0")
         expected = max(lat.compute_time, lat.memory_time) + lat.overhead
         # Tiny floating-point slack is fine; anything > 1ns is suspicious.
         if abs(lat.actual_latency - expected) > 1e-9:

--- a/validation/model_v4/invariants/kpu.py
+++ b/validation/model_v4/invariants/kpu.py
@@ -1,0 +1,372 @@
+"""KPU consistency-only invariant checks (V4-5).
+
+The KPU is a research/in-development spatial-dataflow accelerator with
+no commercially-available silicon to measure against. Per the v4 plan
+(Principle 2 + the "Phasing" recommendation), KPU validation is
+**consistency-only**: the analyzer's predictions must satisfy
+internal-math and physical-plausibility invariants, but we do NOT
+assert any per-shape latency or energy band against ground truth.
+
+Invariant categories:
+
+1. Roofline self-consistency
+   - actual_latency = max(compute_time, memory_time) + overhead
+   - compute_time and memory_time are non-negative
+2. Monotonicity
+   - latency non-decreasing in working-set size at fixed dim ratios
+   - latency non-increasing across the KPU family at fixed shape
+   - memory_time scales monotonically with bytes_transferred
+3. Physical bounds
+   - achieved compute throughput <= theoretical peak FLOPS
+   - achieved memory bandwidth <= theoretical peak DRAM bandwidth
+4. Power below TDP (currently *known* to be violated; surfaced as a
+   diagnostic-only check pending a calibrated KPU energy model).
+
+Each function returns a list of human-readable violation messages
+(empty list = pass). The thin pytest wrapper aggregates them into
+assertion failures with a clear pointer at the violating shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Tuple
+
+from graphs.core.structures import OperationType, SubgraphDescriptor
+from graphs.estimation.energy import EnergyAnalyzer
+from graphs.estimation.roofline import RooflineAnalyzer
+from graphs.hardware.resource_model import HardwareResourceModel, Precision
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _MatmulShape:
+    M: int
+    K: int
+    N: int
+
+    @property
+    def flops(self) -> int:
+        return 2 * self.M * self.K * self.N
+
+    def working_set_bytes(self, bytes_per_element: int) -> int:
+        return (self.M * self.K + self.K * self.N + self.M * self.N) * bytes_per_element
+
+    def to_subgraph(self, bytes_per_element: int) -> SubgraphDescriptor:
+        return SubgraphDescriptor(
+            subgraph_id=0,
+            node_ids=["mm"], node_names=["mm"],
+            operation_types=[OperationType.MATMUL],
+            fusion_pattern="matmul",
+            total_flops=self.flops,
+            total_macs=self.M * self.K * self.N,
+            total_input_bytes=(self.M * self.K + self.K * self.N) * bytes_per_element,
+            total_output_bytes=self.M * self.N * bytes_per_element,
+            total_weight_bytes=0,
+        )
+
+
+def _bpe(precision: Precision) -> int:
+    """Bytes per element for the precision argument."""
+    if precision in (Precision.FP64,):
+        return 8
+    if precision in (Precision.FP32, Precision.TF32):
+        return 4
+    if precision in (Precision.FP16, Precision.BF16):
+        return 2
+    if precision in (Precision.INT8, Precision.FP8, Precision.FP8_E4M3, Precision.FP8_E5M2):
+        return 1
+    if precision in (Precision.INT4, Precision.FP4):
+        return 1   # round up; 0.5 doesn't fit in int. Tests use larger precisions.
+    return 4
+
+
+# Default shape grid for monotonicity / scaling sweeps. Square shapes
+# at fixed dim ratios so working_set ~= 3 * N^2 * bpe.
+DEFAULT_SHAPE_GRID: Tuple[_MatmulShape, ...] = (
+    _MatmulShape(64, 64, 64),
+    _MatmulShape(128, 128, 128),
+    _MatmulShape(256, 256, 256),
+    _MatmulShape(512, 512, 512),
+    _MatmulShape(1024, 1024, 1024),
+    _MatmulShape(2048, 2048, 2048),
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Roofline self-consistency
+# ---------------------------------------------------------------------------
+
+
+def check_roofline_self_consistency(
+    hw: HardwareResourceModel,
+    precision: Precision,
+    shapes: Tuple[_MatmulShape, ...] = DEFAULT_SHAPE_GRID,
+) -> List[str]:
+    """For every shape, ``actual_latency`` must equal ``max(compute_time,
+    memory_time) + overhead`` exactly. Also: both component times must
+    be non-negative.
+
+    This is the bedrock invariant -- if it ever fails, the
+    ``_analyze_subgraph`` math has drifted from its own definition."""
+    failures: List[str] = []
+    analyzer = RooflineAnalyzer(hw, precision=precision)
+    bpe = _bpe(precision)
+    for s in shapes:
+        sg = s.to_subgraph(bpe)
+        lat = analyzer._analyze_subgraph(sg)
+        if lat.compute_time < 0:
+            failures.append(
+                f"shape=({s.M},{s.K},{s.N}): compute_time={lat.compute_time:.3e} < 0")
+        if lat.memory_time < 0:
+            failures.append(
+                f"shape=({s.M},{s.K},{s.N}): memory_time={lat.memory_time:.3e} < 0")
+        expected = max(lat.compute_time, lat.memory_time) + lat.overhead
+        # Tiny floating-point slack is fine; anything > 1ns is suspicious.
+        if abs(lat.actual_latency - expected) > 1e-9:
+            failures.append(
+                f"shape=({s.M},{s.K},{s.N}): actual_latency={lat.actual_latency:.3e} "
+                f"!= max(compute={lat.compute_time:.3e}, memory={lat.memory_time:.3e}) "
+                f"+ overhead={lat.overhead:.3e} (expected {expected:.3e})")
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# 2. Monotonicity
+# ---------------------------------------------------------------------------
+
+
+def check_latency_non_decreasing_in_size(
+    hw: HardwareResourceModel,
+    precision: Precision,
+    shapes: Tuple[_MatmulShape, ...] = DEFAULT_SHAPE_GRID,
+) -> List[str]:
+    """Sweeping square matmul size N in ascending order, predicted
+    actual_latency must be non-decreasing. A monotonically larger
+    workload cannot run faster on the same hardware."""
+    failures: List[str] = []
+    analyzer = RooflineAnalyzer(hw, precision=precision)
+    bpe = _bpe(precision)
+    sorted_shapes = sorted(shapes, key=lambda s: s.flops)
+    prev_lat: float = 0.0
+    prev_label = "<none>"
+    for s in sorted_shapes:
+        lat = analyzer._analyze_subgraph(s.to_subgraph(bpe))
+        if lat.actual_latency < prev_lat - 1e-9:
+            failures.append(
+                f"non-monotonic: shape=({s.M},{s.K},{s.N}) "
+                f"latency={lat.actual_latency:.3e}s < prior {prev_label} "
+                f"latency={prev_lat:.3e}s (work grew but latency dropped)")
+        prev_lat = lat.actual_latency
+        prev_label = f"({s.M},{s.K},{s.N})"
+    return failures
+
+
+def check_memory_time_scales_with_bytes(
+    hw: HardwareResourceModel,
+    precision: Precision,
+    shapes: Tuple[_MatmulShape, ...] = DEFAULT_SHAPE_GRID,
+) -> List[str]:
+    """Memory time must be non-decreasing in working_set_bytes at fixed
+    bandwidth efficiency. (Linear scaling is too strict because
+    bw_efficiency_scale itself depends on working-set size; we only
+    require monotonicity.)"""
+    failures: List[str] = []
+    analyzer = RooflineAnalyzer(hw, precision=precision)
+    bpe = _bpe(precision)
+    rows = []
+    for s in shapes:
+        lat = analyzer._analyze_subgraph(s.to_subgraph(bpe))
+        rows.append((s.working_set_bytes(bpe), lat.memory_time, s))
+    rows.sort(key=lambda r: r[0])
+    for (b1, m1, s1), (b2, m2, s2) in zip(rows, rows[1:]):
+        if m2 < m1 - 1e-9:
+            failures.append(
+                f"memory_time non-monotonic: ws={b1} -> mem_t={m1:.3e}s vs "
+                f"ws={b2} -> mem_t={m2:.3e}s (later shape has more bytes "
+                f"but lower memory_time)")
+    return failures
+
+
+def check_family_latency_non_increasing(
+    family: List[Tuple[str, HardwareResourceModel]],
+    precision: Precision,
+    shape: _MatmulShape,
+) -> List[str]:
+    """Across a family of accelerators ordered by *increasing* compute
+    capability (e.g., T64 -> T128 -> T256 -> T768), predicted latency
+    for the same shape must be *non-increasing*. More tiles + more BW
+    cannot make a fixed workload slower."""
+    failures: List[str] = []
+    bpe = _bpe(precision)
+    sg = shape.to_subgraph(bpe)
+    measured: List[Tuple[str, float]] = []
+    for name, hw in family:
+        analyzer = RooflineAnalyzer(hw, precision=precision)
+        lat = analyzer._analyze_subgraph(sg)
+        measured.append((name, lat.actual_latency))
+    for (n1, l1), (n2, l2) in zip(measured, measured[1:]):
+        if l2 > l1 + 1e-9:
+            failures.append(
+                f"family-monotonicity: {n1}->{l1:.3e}s, {n2}->{l2:.3e}s "
+                f"(more capable {n2} predicts SLOWER than {n1} for "
+                f"shape ({shape.M},{shape.K},{shape.N}))")
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# 3. Physical bounds (achieved <= peak)
+# ---------------------------------------------------------------------------
+
+
+# 5% slack absorbs floating-point and overhead-amortization noise; any
+# real violation will exceed this comfortably.
+_PEAK_SLACK = 1.05
+
+
+def check_achieved_compute_below_peak(
+    hw: HardwareResourceModel,
+    precision: Precision,
+    shapes: Tuple[_MatmulShape, ...] = DEFAULT_SHAPE_GRID,
+) -> List[str]:
+    """Achieved FLOPS = flops / compute_time must not exceed the
+    theoretical peak * PEAK_SLACK."""
+    failures: List[str] = []
+    analyzer = RooflineAnalyzer(hw, precision=precision)
+    bpe = _bpe(precision)
+    peak = hw.get_peak_ops(precision)
+    for s in shapes:
+        lat = analyzer._analyze_subgraph(s.to_subgraph(bpe))
+        if lat.compute_time <= 0:
+            continue
+        achieved = s.flops / lat.compute_time
+        if achieved > peak * _PEAK_SLACK:
+            failures.append(
+                f"shape=({s.M},{s.K},{s.N}): achieved compute "
+                f"{achieved/1e9:.1f} GFLOPS exceeds peak "
+                f"{peak/1e9:.1f} GFLOPS (slack {_PEAK_SLACK:.0%})")
+    return failures
+
+
+def check_achieved_bw_below_peak(
+    hw: HardwareResourceModel,
+    precision: Precision,
+    shapes: Tuple[_MatmulShape, ...] = DEFAULT_SHAPE_GRID,
+) -> List[str]:
+    """Achieved BW = bytes / memory_time must not exceed peak
+    bandwidth * PEAK_SLACK."""
+    failures: List[str] = []
+    analyzer = RooflineAnalyzer(hw, precision=precision)
+    bpe = _bpe(precision)
+    peak = hw.peak_bandwidth
+    for s in shapes:
+        lat = analyzer._analyze_subgraph(s.to_subgraph(bpe))
+        if lat.memory_time <= 0:
+            continue
+        bytes_total = s.working_set_bytes(bpe)
+        achieved = bytes_total / lat.memory_time
+        if achieved > peak * _PEAK_SLACK:
+            failures.append(
+                f"shape=({s.M},{s.K},{s.N}): achieved BW "
+                f"{achieved/1e9:.1f} GB/s exceeds peak "
+                f"{peak/1e9:.1f} GB/s (slack {_PEAK_SLACK:.0%})")
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# 4. Power-below-TDP (diagnostic; currently violated, see comment)
+# ---------------------------------------------------------------------------
+
+
+def check_avg_power_below_tdp(
+    hw: HardwareResourceModel,
+    precision: Precision,
+    shapes: Tuple[_MatmulShape, ...] = DEFAULT_SHAPE_GRID,
+    tdp_slack: float = 1.10,
+) -> List[str]:
+    """Predicted total energy / latency must not exceed TDP * slack.
+
+    NOTE: this invariant is currently *known to fail* on every KPU
+    mapper because the energy model uses the GPU IDLE_POWER_FRACTION
+    (0.3) plus dynamic energy_per_flop coefficients that were not
+    calibrated against KPU silicon. Tracked in #81; the pytest wrapper
+    marks this test as xfail. Once #81 lands the xfail can be removed
+    and this becomes a hard test (same pattern as the #71 CPU fix).
+
+    Returning the violation list (rather than just a bool) lets the
+    diagnostic surface which shapes are most over-prediction-prone."""
+    failures: List[str] = []
+    roof = RooflineAnalyzer(hw, precision=precision)
+    energy = EnergyAnalyzer(hw, precision=precision)
+    bpe = _bpe(precision)
+    tdp = energy.tdp_watts
+    for s in shapes:
+        sg = s.to_subgraph(bpe)
+        lat = roof._analyze_subgraph(sg)
+        if lat.actual_latency <= 0:
+            continue
+        report = energy.analyze(subgraphs=[sg], latencies=[lat.actual_latency])
+        avg_power = report.total_energy_j / lat.actual_latency
+        if avg_power > tdp * tdp_slack:
+            failures.append(
+                f"shape=({s.M},{s.K},{s.N}): avg power {avg_power:.1f}W "
+                f"exceeds TDP {tdp:.1f}W (slack {tdp_slack:.0%}); "
+                f"energy={report.total_energy_j*1e3:.2f}mJ over "
+                f"latency={lat.actual_latency*1e6:.1f}us")
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Convenience: run the full battery on one mapper
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InvariantReport:
+    hardware_name: str
+    precision: Precision
+    failures_per_check: dict[str, List[str]]
+
+    @property
+    def total_failures(self) -> int:
+        return sum(len(v) for v in self.failures_per_check.values())
+
+    def hard_failures(self) -> dict[str, List[str]]:
+        """Return only the failures for *hard* invariants (excluding the
+        known-violated power-below-TDP diagnostic)."""
+        return {k: v for k, v in self.failures_per_check.items()
+                if k != "avg_power_below_tdp" and v}
+
+
+def run_kpu_invariants(
+    hw: HardwareResourceModel,
+    precision: Precision,
+    hardware_name: str = "kpu",
+    shapes: Tuple[_MatmulShape, ...] = DEFAULT_SHAPE_GRID,
+) -> InvariantReport:
+    """Run every single-mapper invariant on ``hw``. Family-monotonicity
+    is excluded because it spans multiple mappers (run separately by
+    the pytest wrapper)."""
+    checks: List[Tuple[str, Callable[[], List[str]]]] = [
+        ("roofline_self_consistency",
+         lambda: check_roofline_self_consistency(hw, precision, shapes)),
+        ("latency_non_decreasing_in_size",
+         lambda: check_latency_non_decreasing_in_size(hw, precision, shapes)),
+        ("memory_time_scales_with_bytes",
+         lambda: check_memory_time_scales_with_bytes(hw, precision, shapes)),
+        ("achieved_compute_below_peak",
+         lambda: check_achieved_compute_below_peak(hw, precision, shapes)),
+        ("achieved_bw_below_peak",
+         lambda: check_achieved_bw_below_peak(hw, precision, shapes)),
+        ("avg_power_below_tdp",
+         lambda: check_avg_power_below_tdp(hw, precision, shapes)),
+    ]
+    return InvariantReport(
+        hardware_name=hardware_name,
+        precision=precision,
+        failures_per_check={name: fn() for name, fn in checks},
+    )


### PR DESCRIPTION
## Summary
Implements V4-5 from the validation harness plan: consistency-only invariant checks for KPU mappers, since there's no commercially-available silicon to measure against.

Six **hard** invariants (must always hold) per mapper:
1. `roofline_self_consistency` -- `actual_latency == max(compute_time, memory_time) + overhead`
2. `latency_non_decreasing_in_size` -- bigger workloads can't run faster
3. `memory_time_scales_with_bytes` -- monotonic in working_set_bytes
4. `achieved_compute_below_peak` -- `flops / compute_time <= peak_FLOPS * 1.05`
5. `achieved_bw_below_peak` -- `bytes / memory_time <= peak_BW * 1.05`
6. `family_latency_non_increasing` -- T64 -> T128 -> T256 -> T768 cross-mapper

One **diagnostic** invariant (currently violated, xfail with #81):
7. `avg_power_below_tdp` -- predicted avg power must not exceed TDP

## Test results
| | T64 | T128 | T256 | T768 |
|---|---|---|---|---|
| roofline_self_consistency | PASS | PASS | PASS | PASS |
| latency_non_decreasing_in_size | PASS | PASS | PASS | PASS |
| memory_time_scales_with_bytes | PASS | PASS | PASS | PASS |
| achieved_compute_below_peak | PASS | PASS | PASS | PASS |
| achieved_bw_below_peak | PASS | PASS | PASS | PASS |
| avg_power_below_tdp | XFAIL | XFAIL | XFAIL | XFAIL |

Plus family monotonicity passing across all 6 sample shapes.

**228 V4 tests pass, 4 documented xfails.**

## Files
- `validation/model_v4/invariants/__init__.py` -- new package
- `validation/model_v4/invariants/kpu.py` -- pure-function invariant checks (reusable)
- `tests/validation_model_v4/test_kpu_invariants.py` -- pytest wrapper, parametrized over the 4 KPU mappers

## Filed alongside
- #81 -- KPU energy model uncalibrated; predicted avg power exceeds TDP. Same shape of bug as #71 was for CPU. The xfail will flip to a hard pass when #81 lands.

## Test plan
- [x] Fast CI passes
- [x] CodeRabbit review

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation test suite for KPU accelerator consistency checks, including roofline self-consistency, latency monotonicity, and memory/power bounds verification
  * Introduced validation framework for hardware configurations across multiple KPU mapper families

<!-- end of auto-generated comment: release notes by coderabbit.ai -->