### PR TITLE
feat(ci): V4-6 -- dedicated V4 model-validation gate workflow

### DIFF
--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -1,0 +1,114 @@
+# V4 model-validation gate.
+#
+# Per the v4 plan exit criterion (docs/plans/validation-harness-v4-plan.md):
+#   "First PR blocked by a real drift"
+#
+# This workflow runs the per-shape regime/latency floor tests + KPU
+# consistency invariants on every PR that touches an area where the
+# analytical model (or its supporting infrastructure) might drift.
+#
+# It is intentionally *separate* from the main `CI` workflow so that:
+#   * Doc-only PRs don't pay the cost (path filter below).
+#   * The check appears as a distinct line in the PR status rollup,
+#     so reviewers see "V4 Model Validation" pass/fail without
+#     digging through a multi-hundred-test pytest log.
+#   * Failures point directly at the failing invariant + its
+#     historical floor, via the test docstrings.
+#
+# What it gates today:
+#   * tests/validation_model_v4/                 (78 V4 unit tests)
+#   * tests/analysis/test_energy_cpu_active_power.py  (#71 calibration)
+#   * tests/analysis/test_roofline_cpu_efficiency.py  (#67 floor)
+#   * tests/analysis/test_roofline_cpu_dispatch_floor.py  (#69 floor)
+#   * tests/analysis/test_roofline_cpu_bw_efficiency.py   (#74 floor)
+#
+# To make this a *required* status check, configure branch protection
+# on `main` in repo settings -> Branches -> Branch protection rules:
+# add "V4 Model Validation" to the required-checks list.
+
+name: V4 Model Validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      # Code paths that can shift the analytical model
+      - 'src/graphs/estimation/**'
+      - 'src/graphs/hardware/**'
+      - 'src/graphs/transform/**'
+      - 'src/graphs/core/**'
+      # The validation harness itself
+      - 'validation/model_v4/**'
+      # The tests that encode the V4 contract
+      - 'tests/validation_model_v4/**'
+      - 'tests/analysis/test_energy_cpu_active_power.py'
+      - 'tests/analysis/test_roofline_cpu_efficiency.py'
+      - 'tests/analysis/test_roofline_cpu_dispatch_floor.py'
+      - 'tests/analysis/test_roofline_cpu_bw_efficiency.py'
+      # The committed baselines: a CSV change implies a deliberate
+      # measurement refresh, which the gate must rerun against.
+      - 'validation/model_v4/results/baselines/**'
+      # Self-modification of the gate
+      - '.github/workflows/v4-validation.yml'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  v4-validation:
+    name: V4 Model Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-py3.10-pip-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-py3.10-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          pip install -e .
+          pip install pytest
+
+      - name: Run V4 harness unit tests
+        run: |
+          pytest tests/validation_model_v4/ -v --tb=short
+
+      - name: Run V4-anchored CPU regression tests
+        run: |
+          # These four files lock in the V4 baseline floors that #67,
+          # #69, #71, and #74 established. Any change to the analyzer
+          # that regresses below these floors fails the gate.
+          pytest \
+            tests/analysis/test_roofline_cpu_efficiency.py \
+            tests/analysis/test_roofline_cpu_dispatch_floor.py \
+            tests/analysis/test_roofline_cpu_bw_efficiency.py \
+            tests/analysis/test_energy_cpu_active_power.py \
+            -v --tb=short
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## V4 Model Validation gate" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Gates the analytical-model layer per the v4 plan." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Failure here means one of:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "* A change to \`src/graphs/estimation/\` shifted a per-shape regime/latency band off floor." >> $GITHUB_STEP_SUMMARY
+          echo "* A change to \`src/graphs/hardware/\` shifted a peak FLOPS / BW spec." >> $GITHUB_STEP_SUMMARY
+          echo "* A change to a hardware mapper broke a KPU invariant (achieved <= peak, monotonicity, etc.)." >> $GITHUB_STEP_SUMMARY
+          echo "* A change to \`src/graphs/transform/\` broke partitioner round-tripping." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The failing test's docstring will name the specific issue (e.g., #67 for compute efficiency curve)." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -58,6 +58,15 @@ jobs:
   v4-validation:
     name: V4 Model Validation
     runs-on: ubuntu-latest
+    # Put the repo root on sys.path so `from validation.model_v4...` resolves.
+    # `graphs.*` comes from the editable install below; `validation/` is not
+    # a published package, just a sibling directory whose modules the tests
+    # import directly. Without this env var, pytest's default `prepend`
+    # import mode adds tests/ (the first __init__-less dir walking up from
+    # tests/validation_model_v4/test_*.py) -- which doesn't help for the
+    # validation/ tree at the repo root.
+    env:
+      PYTHONPATH: ${{ github.workspace }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -28,6 +28,13 @@
 
 name: V4 Model Validation
 
+# Minimal permissions per the principle of least privilege. The gate
+# only needs to check out the source and read it -- no PR comments, no
+# release writes, no security tokens. Flagged by CodeQL alert #11/#12
+# on the initial PR.
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]

--- a/tests/validation_model_v4/test_v4_ci_gate_workflow.py
+++ b/tests/validation_model_v4/test_v4_ci_gate_workflow.py
@@ -1,0 +1,127 @@
+"""Meta-tests for the V4 model-validation CI gate (V4-6).
+
+The gate is a separate workflow file (`.github/workflows/v4-validation.yml`)
+intentionally disjoint from the catch-all `CI` workflow so that:
+  * doc-only PRs don't trigger it (path filter)
+  * it surfaces as a distinct check in the PR status rollup
+
+These tests pin the contract:
+  1. The workflow file exists and parses as YAML.
+  2. It triggers on pull_request to main with a path filter.
+  3. The path filter covers every code area whose drift the V4 plan
+     says the gate must catch (estimation, hardware, transform, core,
+     plus the validation harness and its tests).
+  4. The job actually runs the V4 test directories the gate is supposed
+     to enforce.
+
+If a future contributor narrows the path filter or removes one of the
+test invocations, these tests fire with a clear message pointing at
+which V4 contract regressed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# tests/validation_model_v4/test_v4_ci_gate_workflow.py -> repo root is parents[2]
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "v4-validation.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow():
+    """Parse the V4 gate workflow once per module."""
+    yaml = pytest.importorskip("yaml")
+    assert WORKFLOW_PATH.exists(), (
+        f"V4 CI gate workflow missing at {WORKFLOW_PATH.relative_to(REPO_ROOT)}; "
+        f"V4-6 requires this file. Re-add it from git history if accidentally deleted."
+    )
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def test_workflow_file_exists():
+    assert WORKFLOW_PATH.exists()
+
+
+def test_workflow_triggers_on_pull_request_to_main(workflow):
+    """The gate must run on every PR to main (with the path filter)."""
+    # PyYAML parses the unquoted YAML key `on:` as the boolean True,
+    # so check both keys for compatibility.
+    on = workflow.get("on") or workflow.get(True)
+    assert on is not None, "workflow has no `on:` block"
+    assert "pull_request" in on
+    pr = on["pull_request"]
+    assert pr.get("branches") == ["main"], (
+        f"V4 gate must target PRs to main; got branches={pr.get('branches')}"
+    )
+
+
+def test_workflow_path_filter_covers_required_areas(workflow):
+    """Per the v4 plan, the gate must trigger on PRs touching
+    estimation/, hardware/, transform/. Plus it must rerun when the
+    harness or its tests change."""
+    on = workflow.get("on") or workflow.get(True)
+    paths = set(on["pull_request"].get("paths", []))
+    must_have = {
+        "src/graphs/estimation/**",
+        "src/graphs/hardware/**",
+        "src/graphs/transform/**",
+        "validation/model_v4/**",
+        "tests/validation_model_v4/**",
+    }
+    missing = must_have - paths
+    assert not missing, (
+        f"V4 gate path filter is missing required areas: {sorted(missing)}. "
+        f"Per docs/plans/validation-harness-v4-plan.md V4-6, the gate must "
+        f"trigger on PRs touching every area where the analytical model "
+        f"or its tests can drift."
+    )
+
+
+def test_workflow_runs_v4_harness_tests(workflow):
+    """The job must actually invoke pytest on tests/validation_model_v4/."""
+    jobs = workflow.get("jobs", {})
+    assert "v4-validation" in jobs, "expected job `v4-validation`"
+    steps = jobs["v4-validation"].get("steps", [])
+    run_blocks = [s.get("run", "") for s in steps if "run" in s]
+    combined = "\n".join(run_blocks)
+    assert "tests/validation_model_v4/" in combined, (
+        "V4 gate must run pytest against tests/validation_model_v4/; "
+        "found run steps did not reference that path"
+    )
+
+
+def test_workflow_runs_v4_anchored_cpu_regression_tests(workflow):
+    """The four CPU regression test files (locked in by #67/#69/#71/#74)
+    must be in the gate. They encode the V4 calibration floors -- a
+    regression there is the canonical 'real drift' the gate must catch."""
+    jobs = workflow.get("jobs", {})
+    steps = jobs["v4-validation"].get("steps", [])
+    combined = "\n".join(s.get("run", "") for s in steps if "run" in s)
+    must_run = [
+        "tests/analysis/test_roofline_cpu_efficiency.py",       # #67
+        "tests/analysis/test_roofline_cpu_dispatch_floor.py",   # #69
+        "tests/analysis/test_roofline_cpu_bw_efficiency.py",    # #74
+        "tests/analysis/test_energy_cpu_active_power.py",       # #71
+    ]
+    missing = [p for p in must_run if p not in combined]
+    assert not missing, (
+        "V4 gate must invoke the V4-anchored CPU regression tests; "
+        f"missing: {missing}"
+    )
+
+
+def test_workflow_job_name_is_distinct_in_pr_status(workflow):
+    """The gate's purpose is visibility -- the job's display name must
+    be 'V4 Model Validation' so it's easily found in the PR check
+    rollup. If a future change renames the job, this fails so the
+    contributor updates branch-protection settings to match."""
+    jobs = workflow.get("jobs", {})
+    job = jobs.get("v4-validation", {})
+    assert job.get("name") == "V4 Model Validation", (
+        f"job display name drifted from 'V4 Model Validation' to "
+        f"{job.get('name')!r}; if intentional, also update the branch "
+        f"protection required-checks list to match."
+    )

--- a/validation/model_v4/README.md
+++ b/validation/model_v4/README.md
@@ -1,0 +1,93 @@
+# V4 Model Validation Harness
+
+The V4 harness is the analytical-model validation layer described in
+[`docs/plans/validation-harness-v4-plan.md`](../../docs/plans/validation-harness-v4-plan.md).
+Five principles drive its design (see plan for the full rationale):
+
+1. **Stratified sweep** — every shape is classified into a bottleneck regime
+   *before* measurement, so per-shape failures attribute to one architectural-
+   model assumption.
+2. **Out-of-band ground truth** — RAPL on CPU, NVML on desktop GPU, INA3221
+   on Jetson, simulator output (eventually) on KPU. No self-validation against
+   the analyzer's own previous output.
+3. **Per-layer assertions** — three independent checks per shape (regime,
+   latency, energy) so a failure points at one specific drift.
+4. **Calibration / validation separation** — disjoint shape sets per op.
+5. **Drift attribution** — heatmap output naming the offending hardware ×
+   regime cell.
+
+## Layout
+
+```
+validation/model_v4/
+├── workloads/           # PyTorch nn.Module factories per op (matmul, linear)
+├── sweeps/              # Frozen JSON shape sets + classifier + augmenter
+│   ├── classify.py      # Pure-function regime classifier
+│   ├── _generate.py     # Sampling generator (run once; output committed)
+│   └── _augment.py      # Additive re-classification when adding hardware
+├── ground_truth/        # Per-target measurer backends (V4-3, V4-4)
+│   ├── pytorch_cpu.py     # wall-clock + Intel RAPL
+│   ├── pytorch_cuda.py    # cudaEvent + NVML (H100, A100, ...)
+│   └── pytorch_jetson.py  # cudaEvent + INA3221 (Orin, Thor)
+├── invariants/          # Consistency-only checks (V4-5; KPU/TPU)
+│   └── kpu.py             # roofline self-consistency, monotonicity, etc.
+├── harness/             # predict + measure + assert orchestration
+│   ├── runner.py
+│   ├── assertions.py
+│   └── report.py
+├── cli/                 # capture_ground_truth.py, validate.py
+└── results/baselines/   # Committed CSVs per (hardware, op)
+```
+
+## The CI gate (V4-6)
+
+`.github/workflows/v4-validation.yml` runs the V4 contract on every PR
+that touches:
+
+- `src/graphs/{estimation,hardware,transform,core}/**`
+- `validation/model_v4/**`
+- `tests/validation_model_v4/**`
+- The four V4-anchored CPU regression test files
+  (`tests/analysis/test_roofline_cpu_*.py`, `test_energy_cpu_active_power.py`)
+- `validation/model_v4/results/baselines/**`
+
+The gate fails the PR check named **"V4 Model Validation"** if:
+
+- any `tests/validation_model_v4/` test fails (regime classification math,
+  V4 floor pass-rate regression, KPU invariant violation, sweep schema
+  drift, ground-truth contract drift);
+- any of the V4-calibrated CPU floor tests regress
+  ([#67](https://github.com/branes-ai/graphs/issues/67),
+  [#69](https://github.com/branes-ai/graphs/issues/69),
+  [#71](https://github.com/branes-ai/graphs/issues/71),
+  [#74](https://github.com/branes-ai/graphs/issues/74)).
+
+To make the check **required for merge**, set it in
+*Repo Settings → Branches → Branch protection rules → main → Required
+status checks*.
+
+The meta-test
+[`tests/validation_model_v4/test_v4_ci_gate_workflow.py`](../../tests/validation_model_v4/test_v4_ci_gate_workflow.py)
+asserts the workflow file is well-formed and continues to gate the
+right paths and tests — so a future contributor narrowing the scope
+trips a unit-test failure with a clear message.
+
+## Adding a new hardware target
+
+See
+[`docs/plans/v4-capture-on-target.md`](../../docs/plans/v4-capture-on-target.md)
+and the runbooks in [`bin/`](../../bin/) (`v4-capture-jetson-orin-nano.sh`,
+`v4-capture-h100.sh`).
+
+In short:
+
+1. Add a `_Target(...)` entry to `KNOWN_TARGETS` in `sweeps/_augment.py`.
+2. Run `python -m validation.model_v4.sweeps._augment --hw <new_key>` to
+   add the new hardware's regimes to the existing sweep entries
+   *additively* (existing baselines stay valid).
+3. Add the same key to `_MEASURER_FACTORY` in `cli/capture_ground_truth.py`.
+4. Add the same key to `SWEEP_HW_TO_MAPPER` in `harness/runner.py`.
+5. Add the key to the `hw` fixture in `tests/validation_model_v4/test_sweeps.py`.
+6. Run `bin/v4-capture-<hw>.sh` on the target box to capture the baseline CSV.
+7. Open a PR with the CSV and add a `test_<hw>_pass_*_floor` case to
+   `tests/validation_model_v4/test_v4_against_baseline.py`.


### PR DESCRIPTION
## Summary
Implements V4-6 from the validation harness plan. Adds a separate GitHub Actions workflow that surfaces V4 contract failures as a distinct **"V4 Model Validation"** check in the PR status rollup, with a path filter so it only runs on PRs that could plausibly shift the analytical model.

## What the gate enforces
- All `tests/validation_model_v4/` pass (regime classification math, V4 floor pass-rate regression, KPU invariants, sweep schema drift, ground-truth contract drift)
- The four V4-anchored CPU regression tests pass:
  - `test_roofline_cpu_efficiency.py` (#67 floor)
  - `test_roofline_cpu_dispatch_floor.py` (#69 floor)
  - `test_roofline_cpu_bw_efficiency.py` (#74 floor)
  - `test_energy_cpu_active_power.py` (#71 calibration)

These already run inside the catch-all `pytest tests/` in the main CI workflow, but the dedicated job adds:
- A **distinct line** in the PR status rollup so reviewers see V4 pass/fail without digging through a multi-hundred-test pytest log
- A **path filter** so doc-only PRs don't pay the install + test cost
- **Failure attribution**: the failing test's docstring names the issue that established the floor

## Path filter
- `src/graphs/{estimation,hardware,transform,core}/**`
- `validation/model_v4/**`
- `tests/validation_model_v4/**`
- The four V4-anchored CPU regression test files
- `validation/model_v4/results/baselines/**` (CSV refresh)
- `.github/workflows/v4-validation.yml` (self-modification)

## Files
- `.github/workflows/v4-validation.yml` -- the gate
- `tests/validation_model_v4/test_v4_ci_gate_workflow.py` -- 6 meta-tests pinning workflow structure
- `validation/model_v4/README.md` -- harness layout + contributor guide

## Making the check required for merge
After merge, enable in *Repo Settings -> Branches -> Branch protection rules -> main -> Required status checks*: add "V4 Model Validation".

## Test plan
- [x] Fast CI passes (the new workflow will fire on this PR since it touches `tests/validation_model_v4/`)
- [x] CodeRabbit review

Generated with [Claude Code](https://claude.com/claude-code)