### PR TITLE
fix(ground_truth): move workload to CUDA device before measuring (#88)

### DIFF
--- a/tests/validation_model_v4/test_ground_truth_pytorch_cuda.py
+++ b/tests/validation_model_v4/test_ground_truth_pytorch_cuda.py
@@ -193,6 +193,58 @@ def test_measurer_uses_total_energy_when_supported():
     assert "power-fallback" not in meas.notes
 
 
+def test_measurer_moves_model_and_inputs_to_cuda_before_warmup():
+    """Issue #88 regression: workload factories build on CPU; the
+    measurer must move both ``model`` and any tensor in ``inputs`` to
+    the target CUDA device BEFORE the warmup window. Otherwise the
+    work runs on the host and cudaEvents bracket an idle GPU stream."""
+    measurer = PyTorchCUDAMeasurer(
+        hardware="h100_sxm5_80gb",
+        device_index=0,
+        warmup_trials=1, timed_trials=3,
+        _probe=None,
+    )
+    fake_torch = _make_fake_cuda_torch(per_trial_ms=2.0)
+    # Mock tensors that record their .to() calls.
+    fake_input_a = MagicMock()
+    fake_input_b = MagicMock()
+    fake_torch.is_tensor.return_value = True
+    fake_model = MagicMock()
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        measurer.measure(model=fake_model, inputs=[fake_input_a, fake_input_b])
+
+    # Model was moved to the target device exactly once (before warmup).
+    fake_model.to.assert_called_once_with("cuda:0")
+    # Each tensor input was moved to the target device exactly once.
+    fake_input_a.to.assert_called_once_with("cuda:0")
+    fake_input_b.to.assert_called_once_with("cuda:0")
+
+
+def test_measurer_skips_to_call_on_non_tensor_inputs():
+    """``inputs`` may contain non-tensor entries (e.g., None for an
+    optional bias, or scalar Python objects). The measurer's tensor-
+    move loop must skip them via ``torch.is_tensor`` rather than
+    blindly calling ``.to()`` on everything."""
+    measurer = PyTorchCUDAMeasurer(
+        hardware="h100_sxm5_80gb",
+        warmup_trials=1, timed_trials=3,
+        _probe=None,
+    )
+    fake_torch = _make_fake_cuda_torch(per_trial_ms=2.0)
+    real_tensor = MagicMock()
+    not_a_tensor = MagicMock()
+    # Only the first input is reported as a tensor:
+    fake_torch.is_tensor.side_effect = lambda x: x is real_tensor
+    fake_model = MagicMock()
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        measurer.measure(model=fake_model, inputs=[real_tensor, not_a_tensor, None])
+
+    real_tensor.to.assert_called_once_with("cuda:0")
+    not_a_tensor.to.assert_not_called()
+
+
 def test_measurer_falls_back_to_power_when_no_total_energy():
     """With a power-only probe, the measurer should compute
     energy = power * latency."""

--- a/tests/validation_model_v4/test_ground_truth_pytorch_jetson.py
+++ b/tests/validation_model_v4/test_ground_truth_pytorch_jetson.py
@@ -155,6 +155,59 @@ def test_measurer_skips_energy_when_no_probe():
 
 
 # ---------------------------------------------------------------------------
+# Issue #88 regression: device placement
+# ---------------------------------------------------------------------------
+
+
+def test_measurer_moves_model_and_inputs_to_cuda_before_warmup():
+    """Issue #88 regression: workload factories build on CPU; the
+    measurer must move both ``model`` and any tensor in ``inputs`` to
+    the integrated GPU BEFORE the warmup window. Otherwise the work
+    runs on the Cortex-A78 cores and INA3221 measures CPU draw, not
+    iGPU draw -- which surfaced as a 3-hour 15/48-shapes Phase B run
+    on Orin Nano."""
+    measurer = PyTorchJetsonMeasurer(
+        hardware="jetson_orin_nano_8gb",
+        device_index=0,
+        warmup_trials=1, timed_trials=3,
+        _probe=None,
+    )
+    fake_torch = _make_fake_cuda_torch(per_trial_ms=2.0)
+    fake_input_a = MagicMock()
+    fake_input_b = MagicMock()
+    fake_torch.is_tensor.return_value = True
+    fake_model = MagicMock()
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        measurer.measure(model=fake_model, inputs=[fake_input_a, fake_input_b])
+
+    fake_model.to.assert_called_once_with("cuda:0")
+    fake_input_a.to.assert_called_once_with("cuda:0")
+    fake_input_b.to.assert_called_once_with("cuda:0")
+
+
+def test_measurer_skips_to_call_on_non_tensor_inputs():
+    """Non-tensor entries in ``inputs`` (e.g., None bias) must not get
+    .to() called on them."""
+    measurer = PyTorchJetsonMeasurer(
+        hardware="jetson_orin_nano_8gb",
+        warmup_trials=1, timed_trials=3,
+        _probe=None,
+    )
+    fake_torch = _make_fake_cuda_torch(per_trial_ms=2.0)
+    real_tensor = MagicMock()
+    not_a_tensor = MagicMock()
+    fake_torch.is_tensor.side_effect = lambda x: x is real_tensor
+    fake_model = MagicMock()
+
+    with patch.dict("sys.modules", {"torch": fake_torch}):
+        measurer.measure(model=fake_model, inputs=[real_tensor, not_a_tensor, None])
+
+    real_tensor.to.assert_called_once_with("cuda:0")
+    not_a_tensor.to.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Measurer: power integration with a fake probe
 # ---------------------------------------------------------------------------
 

--- a/validation/model_v4/ground_truth/pytorch_cuda.py
+++ b/validation/model_v4/ground_truth/pytorch_cuda.py
@@ -160,9 +160,12 @@ def _detect_nvml(device_index: int = 0) -> Optional[_NVMLProbe]:
 class PyTorchCUDAMeasurer:
     """cudaEvent + NVML measurer for PyTorch on a desktop/server NVIDIA GPU.
 
-    Stateful only insofar as it caches the NVML device handle. Inputs
-    are assumed to already be on the target device; the measurer does
-    not move tensors -- the workload builder owns placement.
+    Stateful only insofar as it caches the NVML device handle. The
+    measurer moves ``model`` and any tensor in ``inputs`` to the target
+    CUDA device before warmup -- the workload factories build on CPU
+    and are hardware-agnostic, so device placement is the measurer's
+    responsibility (issue #88). The move is a no-op if the model /
+    inputs are already on the target device.
     """
     hardware: str                 # caller supplies the hardware key
     device_index: int = 0
@@ -195,6 +198,22 @@ class PyTorchCUDAMeasurer:
                 trial_count=0,
                 notes="CUDA: torch.cuda.is_available() returned False",
             )
+
+        # Issue #88: workload factories build on CPU and are hardware-
+        # agnostic. Move model + tensor inputs to the CUDA device before
+        # we start timing; otherwise model(*inputs) runs on the host and
+        # the cudaEvents bracket an idle GPU stream (latency reports
+        # near-zero, wall-clock eats hours, energy attributed to whatever
+        # the package was doing during host compute -- all wrong).
+        # Both calls are no-ops if already on device.
+        device = f"cuda:{self.device_index}"
+        model = model.to(device)
+        inputs = tuple(
+            x.to(device) if torch.is_tensor(x) else x
+            for x in inputs
+        )
+        # Sync so the H2D copies don't bleed into the warmup window.
+        torch.cuda.synchronize(self.device_index)
 
         # Warm-up (results discarded; primes kernel autotune + caches)
         for _ in range(self.warmup_trials):

--- a/validation/model_v4/ground_truth/pytorch_jetson.py
+++ b/validation/model_v4/ground_truth/pytorch_jetson.py
@@ -243,6 +243,19 @@ class PyTorchJetsonMeasurer:
                 notes="CUDA: torch.cuda.is_available() returned False",
             )
 
+        # Issue #88: workload factories build on CPU; move model + tensor
+        # inputs to the integrated GPU before warmup. Without this the
+        # cudaEvents bracket an idle GPU stream and INA3221 measures the
+        # Cortex-A78 cores instead of the iGPU. Both calls are no-ops if
+        # already on device.
+        device = f"cuda:{self.device_index}"
+        model = model.to(device)
+        inputs = tuple(
+            x.to(device) if torch.is_tensor(x) else x
+            for x in inputs
+        )
+        torch.cuda.synchronize(self.device_index)
+
         for _ in range(self.warmup_trials):
             model(*inputs)
         torch.cuda.synchronize(self.device_index)


### PR DESCRIPTION
## Summary
P0 correctness fix. Surfaced when a Phase B Jetson Orin Nano capture hit **15/48 shapes after 3 hours of wall time** -- the measurer was running matmul/linear on the Cortex-A78 CPU cores, not the integrated GPU.

## Root cause
The workload factories (`validation/model_v4/workloads/{matmul,linear}.py`) build models + tensors on CPU. `linear.py:98` only calls `.to(torch_dtype)`, never `.to(device)`. `PyTorchCUDAMeasurer` and `PyTorchJetsonMeasurer` then call `model(*inputs)` directly without moving anything. The cudaEvents bracket an idle GPU stream while the actual compute runs on the host -- recording near-zero latency from the events and CPU-attributed energy from NVML/INA3221.

## Fix
At the top of `measure()` after the `torch.cuda.is_available()` check, move both:

```python
device = f"cuda:{self.device_index}"
model = model.to(device)
inputs = tuple(
    x.to(device) if torch.is_tensor(x) else x
    for x in inputs
)
torch.cuda.synchronize(self.device_index)
```

- Both `.to(device)` calls are no-ops if already on device.
- `synchronize()` before warmup ensures H2D copies don't bleed into the timed window.
- `torch.is_tensor` guard preserves non-tensor entries (None bias, scalar Python objects).

`PyTorchCPUMeasurer` is unchanged -- model + inputs already start on CPU.

## Tests
4 new regression tests (2 per measurer):
- `test_measurer_moves_model_and_inputs_to_cuda_before_warmup` -- asserts `model.to('cuda:0')` and each tensor input's `.to('cuda:0')` are called exactly once before warmup.
- `test_measurer_skips_to_call_on_non_tensor_inputs` -- non-tensor entries don't get `.to()` invoked.

| Suite | Result |
|---|---|
| `tests/validation_model_v4/test_ground_truth_pytorch_cuda.py` | PASS (10/10, +2 new) |
| `tests/validation_model_v4/test_ground_truth_pytorch_jetson.py` | PASS (11/11, +2 new) |
| Full `tests/validation_model_v4/` | PASS (259/259, was 255) |

## Why Phase A tests didn't catch this
All Phase A tests are mock-based (`MagicMock` for torch + `cuda.Event` + INA3221 sysfs). Since `inputs=[]` in those tests, the iteration that would have called `.to()` never ran -- and `MagicMock` returns truthy on `model.to()` regardless. Only an end-to-end run on real hardware would have surfaced it. The Phase B Orin Nano run did, after 3 hours.

## Phase B impact
The user must:
1. Stop the running capture.
2. `rm validation/model_v4/results/baselines/jetson_orin_nano_8gb_*.csv` (partial CSVs are bogus).
3. After this PR merges, rerun the capture per `bin/v4-capture-jetson-orin-nano.sh`. Expected wall time post-fix: ~30-60 min total instead of "doesn't finish".

## Test plan
- [x] Fast CI passes (V4 Model Validation gate triggers since this touches `validation/model_v4/`)
- [x] CodeRabbit review

Resolves #88

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU measurement accuracy by ensuring models and tensor inputs are properly moved to the target CUDA device before the measurement warmup phase, preventing host-to-device transfers from affecting timing measurements.

* **Tests**
  * Added validation tests to verify correct CUDA device placement behavior for models and tensor inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->