### PR TITLE
feat(hardware): V5-1 -- MemoryTier dataclass + hw.memory_hierarchy property

### DIFF
--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -777,6 +777,35 @@ class MemoryTier:
     access_latency_ns: float          # first-request startup latency for this tier
     achievable_fraction: float = 1.0  # V5-5 calibration knob; default = ideal
 
+    def __post_init__(self) -> None:
+        """Validate physical invariants. Without this, V5-3's tier picker
+        could silently produce garbage memory_time math from physically
+        nonsensical inputs (negative BW, fraction > 1.0, etc.). Fail
+        loudly at construction so calibration mistakes get caught at
+        the source instead of as confusing analyzer drift downstream."""
+        if not self.name:
+            raise ValueError("MemoryTier.name must be non-empty")
+        if self.capacity_bytes < 0:
+            raise ValueError(
+                f"MemoryTier({self.name!r}).capacity_bytes must be >= 0; "
+                f"got {self.capacity_bytes}")
+        if self.num_units < 1:
+            raise ValueError(
+                f"MemoryTier({self.name!r}).num_units must be >= 1; "
+                f"got {self.num_units}")
+        if self.peak_bandwidth_bps < 0:
+            raise ValueError(
+                f"MemoryTier({self.name!r}).peak_bandwidth_bps must be >= 0; "
+                f"got {self.peak_bandwidth_bps}")
+        if self.access_latency_ns < 0:
+            raise ValueError(
+                f"MemoryTier({self.name!r}).access_latency_ns must be >= 0; "
+                f"got {self.access_latency_ns}")
+        if not (0.0 <= self.achievable_fraction <= 1.0):
+            raise ValueError(
+                f"MemoryTier({self.name!r}).achievable_fraction must be in "
+                f"[0.0, 1.0]; got {self.achievable_fraction}")
+
     @property
     def total_capacity_bytes(self) -> int:
         """Aggregate capacity across the whole chip."""

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -727,6 +727,71 @@ class ThermalOperatingPoint:
 
 
 # ============================================================================
+# V5-1: Memory hierarchy as a queueing-theory tier list
+# ============================================================================
+# See docs/plans/v5-memory-hierarchy-rewrite-plan.md.
+#
+# Each tier is a "server" in the operational-analysis sense -- capacity
+# plus a service rate. The analyzer's tier_picker (V5-3) walks the list
+# innermost-out to find the binding bottleneck for a given (op, shape).
+# This dataclass is V5-1 scaffolding; nothing in the analyzer reads it
+# yet.
+
+@dataclass(frozen=True)
+class MemoryTier:
+    """One level of the memory hierarchy, as a queueing-theory server.
+
+    Constructed by ``HardwareResourceModel.memory_hierarchy`` from
+    existing fields (l1_cache_per_unit + l1_bandwidth_per_unit_bps,
+    l2_cache_total + l2_bandwidth_bps, l3_cache_total + l3_bandwidth_bps,
+    main_memory + peak_bandwidth, plus per-tier access_latency_ns
+    overrides).
+
+    Per-unit tiers (``is_per_unit=True``): ``capacity_bytes`` is the
+    per-compute-unit value (e.g., 32 KB per CPU core, 256 KB per SM).
+    The aggregate capacity across the chip is exposed via the
+    ``total_capacity_bytes`` property.
+
+    Aggregate tiers (``is_per_unit=False``, the default): capacity and
+    BW are already the chip-wide totals. ``num_units`` is 1 for these.
+
+    The ``access_latency_ns`` field is the per-request first-stream
+    startup cost. For a kernel issuing N independent requests, the
+    latency-bound floor is roughly ``startup + per_request * N`` --
+    dominant for vector / matvec ops where bandwidth-limited service
+    time is comparable to the startup. The analyzer's tier picker
+    (V5-3) uses this as a memory-side analog of LAUNCH_BOUND.
+
+    The ``achievable_fraction`` field defaults to 1.0; it's the place
+    V5-5 calibration hangs the per-(hardware, tier) measured-vs-peak
+    ratio (currently captured in the scalar bw_efficiency_scale).
+    """
+    name: str                         # "L1", "L2", "L3", "DRAM", "scratchpad"
+    capacity_bytes: int               # per-unit if is_per_unit else aggregate
+    is_per_unit: bool
+    num_units: int                    # compute_units when is_per_unit=True; else 1
+    peak_bandwidth_bps: float         # aggregate, for both per-unit and shared tiers
+                                      # (per-unit BW is multiplied by num_units when
+                                      # the property derives this -- the field is
+                                      # always the aggregate the kernel sees)
+    access_latency_ns: float          # first-request startup latency for this tier
+    achievable_fraction: float = 1.0  # V5-5 calibration knob; default = ideal
+
+    @property
+    def total_capacity_bytes(self) -> int:
+        """Aggregate capacity across the whole chip."""
+        if self.is_per_unit:
+            return self.capacity_bytes * self.num_units
+        return self.capacity_bytes
+
+    @property
+    def effective_bandwidth_bps(self) -> float:
+        """Achievable BW = peak * calibrated fraction. V5-5 will drive
+        the fraction down from 1.0 to per-(hw, tier) measured values."""
+        return self.peak_bandwidth_bps * self.achievable_fraction
+
+
+# ============================================================================
 # OLD: Legacy PrecisionProfile (kept for backward compatibility)
 # ============================================================================
 
@@ -918,6 +983,26 @@ class HardwareResourceModel:
     # L3 as a distinct hop. Provenance: ``l3_bandwidth_bps``.
     l3_bandwidth_bps: Optional[float] = None
 
+    # Per-tier access latency (V5-1, plan: docs/plans/v5-memory-hierarchy-rewrite-plan.md).
+    # All values in nanoseconds, Optional so unaugmented mappers fall
+    # through to typical-tier-class defaults in MemoryTier.
+    #
+    # The latency floor matters for memory-bound operators where the
+    # single-stream startup dominates total time -- vector add, matvec,
+    # and small-matrix ops where the per-request latency at the binding
+    # tier is comparable to or larger than the bandwidth-limited service
+    # time. This is the analog of LAUNCH_BOUND for the memory side.
+    #
+    # Typical published values (only as defaults if mapper doesn't set):
+    #   L1:  1-3 ns   (4-12 cycles at 3 GHz)
+    #   L2:  5-15 ns  (Skylake L2 ~12 cycles)
+    #   L3:  20-40 ns (LLC depends on slice / ring topology)
+    #   DRAM: 80-200 ns DDR / LPDDR; 100-300 ns HBM
+    l1_access_latency_ns: Optional[float] = None
+    l2_access_latency_ns: Optional[float] = None
+    l3_access_latency_ns: Optional[float] = None
+    dram_access_latency_ns: Optional[float] = None
+
     # M5 Layer 5: cache-coherence protocol class.
     # ``"snoopy_mesi"`` -- snoopy MESI / MOESI on shared bus or
     # ring (CPU multi-core, single-socket).
@@ -970,6 +1055,121 @@ class HardwareResourceModel:
             f"{self.name} does not support {precision.name.lower()} -- "
             f"supported precisions are: {', '.join(supported) if supported else '(none)'}"
         )
+
+    @property
+    def memory_hierarchy(self) -> list["MemoryTier"]:
+        """Derived view of the memory hierarchy as an ordered list of
+        ``MemoryTier`` objects, innermost (smallest, fastest) to outermost.
+
+        V5-1 scaffolding (plan: docs/plans/v5-memory-hierarchy-rewrite-plan.md).
+        Builds the tier list from existing fields:
+
+        * L1 if ``l1_cache_per_unit`` and ``l1_bandwidth_per_unit_bps`` are
+          both set (per-unit tier; aggregate = capacity * compute_units).
+        * L2 if ``l2_bandwidth_bps`` is set (the M1 schema convention puts
+          the LLC capacity in ``l2_cache_total``; on x86 that's L3, on
+          GPUs that's L2 -- see ``l2_topology``).
+        * L3 if ``l3_cache_total`` and ``l3_bandwidth_bps`` are both set.
+        * DRAM is always present from ``main_memory`` + ``peak_bandwidth``.
+
+        Mappers that don't populate the on-chip BW peaks (most of the 45+
+        existing mappers as of V5-1) return a hierarchy with only the
+        DRAM tier. Backward compat: nothing in V5-1 reads this property
+        in the analyzer; that lands in V5-3.
+
+        Tier ``access_latency_ns`` falls back to typical published values
+        per tier class when the mapper doesn't override (1.5 ns L1,
+        10 ns L2, 30 ns L3, 100 ns DRAM). These defaults match consumer
+        x86 / Ampere ballparks; specific mappers should override.
+        """
+        tiers: list["MemoryTier"] = []
+
+        # L1 (per-unit capacity, per-unit BW). Only emitted when both
+        # capacity and BW are set. peak_bandwidth_bps stored on the tier
+        # is the AGGREGATE (per-unit BW * compute_units) so callers can
+        # treat all tiers uniformly; the per-unit value is recoverable
+        # via tier.peak_bandwidth_bps / tier.num_units.
+        if (self.l1_cache_per_unit and self.l1_bandwidth_per_unit_bps
+                and self.l1_bandwidth_per_unit_bps > 0):
+            tiers.append(MemoryTier(
+                name="L1",
+                capacity_bytes=self.l1_cache_per_unit,
+                is_per_unit=True,
+                num_units=self.compute_units,
+                peak_bandwidth_bps=(self.l1_bandwidth_per_unit_bps
+                                    * self.compute_units),
+                access_latency_ns=(self.l1_access_latency_ns
+                                   if self.l1_access_latency_ns is not None
+                                   else 1.5),
+            ))
+
+        # L2. The M1 convention: ``l2_cache_total`` may carry either L2 (on
+        # GPUs that have a distinct L2 -- e.g., H100) or LLC (on x86, where
+        # the LLC IS L3 and there's no separate L2 capacity at the schema
+        # level). The hierarchy emits this as "L2" when ``l2_bandwidth_bps``
+        # is set; if the mapper has both ``l2_bandwidth_bps`` and
+        # ``l3_bandwidth_bps``, the L3 tier is emitted as a separate hop
+        # below.
+        if (self.l2_cache_total and self.l2_bandwidth_bps
+                and self.l2_bandwidth_bps > 0):
+            tiers.append(MemoryTier(
+                name="L2",
+                capacity_bytes=self.l2_cache_total,
+                is_per_unit=False,
+                num_units=1,
+                peak_bandwidth_bps=self.l2_bandwidth_bps,
+                access_latency_ns=(self.l2_access_latency_ns
+                                   if self.l2_access_latency_ns is not None
+                                   else 10.0),
+            ))
+
+        # L3 / LLC (CPU only, typically). Distinct from L2 only on x86
+        # where ``l2_cache_total`` carries the LLC value but we want a
+        # separate hop. On i7-12700K post-#94: l3_bandwidth_bps=200e9
+        # but no l2_bandwidth_bps, so the hierarchy is L1 -> L3 -> DRAM
+        # (no distinct L2 hop).
+        if (self.l3_cache_total and self.l3_bandwidth_bps
+                and self.l3_bandwidth_bps > 0):
+            tiers.append(MemoryTier(
+                name="L3",
+                capacity_bytes=self.l3_cache_total,
+                is_per_unit=False,
+                num_units=1,
+                peak_bandwidth_bps=self.l3_bandwidth_bps,
+                access_latency_ns=(self.l3_access_latency_ns
+                                   if self.l3_access_latency_ns is not None
+                                   else 30.0),
+            ))
+        elif (self.l2_cache_total and not self.l2_bandwidth_bps
+              and self.l3_bandwidth_bps and self.l3_bandwidth_bps > 0):
+            # x86 fallback: ``l2_cache_total`` carries the LLC (which IS L3
+            # on x86), and ``l3_bandwidth_bps`` is the matching BW. Emit
+            # this as a single L3 tier using the L2_total capacity.
+            tiers.append(MemoryTier(
+                name="L3",
+                capacity_bytes=self.l2_cache_total,
+                is_per_unit=False,
+                num_units=1,
+                peak_bandwidth_bps=self.l3_bandwidth_bps,
+                access_latency_ns=(self.l3_access_latency_ns
+                                   if self.l3_access_latency_ns is not None
+                                   else 30.0),
+            ))
+
+        # DRAM is always present (every mapper sets peak_bandwidth +
+        # main_memory; these are required fields).
+        tiers.append(MemoryTier(
+            name="DRAM",
+            capacity_bytes=self.main_memory,
+            is_per_unit=False,
+            num_units=1,
+            peak_bandwidth_bps=self.peak_bandwidth,
+            access_latency_ns=(self.dram_access_latency_ns
+                               if self.dram_access_latency_ns is not None
+                               else 100.0),
+        ))
+
+        return tiers
 
     def get_peak_ops(self, precision: Precision) -> float:
         """

--- a/tests/hardware/test_memory_hierarchy.py
+++ b/tests/hardware/test_memory_hierarchy.py
@@ -239,3 +239,91 @@ def test_effective_bandwidth_scales_with_achievable_fraction():
         access_latency_ns=10.0, achievable_fraction=0.6,
     )
     assert t.effective_bandwidth_bps == 6e11
+
+
+# ---------------------------------------------------------------------------
+# __post_init__: physical invariant validation
+# ---------------------------------------------------------------------------
+
+
+def _valid_kwargs(**overrides):
+    """Baseline-valid MemoryTier kwargs; tests override one field at a
+    time to exercise each invariant check."""
+    base = dict(
+        name="L1", capacity_bytes=32 * 1024, is_per_unit=True,
+        num_units=8, peak_bandwidth_bps=500e9, access_latency_ns=1.5,
+        achievable_fraction=0.85,
+    )
+    base.update(overrides)
+    return base
+
+
+def test_post_init_rejects_empty_name():
+    with pytest.raises(ValueError, match="name must be non-empty"):
+        MemoryTier(**_valid_kwargs(name=""))
+
+
+def test_post_init_rejects_negative_capacity():
+    with pytest.raises(ValueError, match="capacity_bytes must be >= 0"):
+        MemoryTier(**_valid_kwargs(capacity_bytes=-1))
+
+
+def test_post_init_rejects_zero_or_negative_num_units():
+    with pytest.raises(ValueError, match="num_units must be >= 1"):
+        MemoryTier(**_valid_kwargs(num_units=0))
+    with pytest.raises(ValueError, match="num_units must be >= 1"):
+        MemoryTier(**_valid_kwargs(num_units=-3))
+
+
+def test_post_init_rejects_negative_bandwidth():
+    with pytest.raises(ValueError, match="peak_bandwidth_bps must be >= 0"):
+        MemoryTier(**_valid_kwargs(peak_bandwidth_bps=-1.0))
+
+
+def test_post_init_rejects_negative_latency():
+    with pytest.raises(ValueError, match="access_latency_ns must be >= 0"):
+        MemoryTier(**_valid_kwargs(access_latency_ns=-0.5))
+
+
+def test_post_init_rejects_achievable_fraction_above_one():
+    """A tier achieving > 100% of its peak BW would be physically
+    impossible -- cache hits reflect a *different* tier's BW, not this
+    one's peak * a >1 factor."""
+    with pytest.raises(ValueError, match=r"achievable_fraction must be in \[0\.0, 1\.0\]"):
+        MemoryTier(**_valid_kwargs(achievable_fraction=1.5))
+
+
+def test_post_init_rejects_negative_achievable_fraction():
+    with pytest.raises(ValueError, match=r"achievable_fraction must be in \[0\.0, 1\.0\]"):
+        MemoryTier(**_valid_kwargs(achievable_fraction=-0.1))
+
+
+def test_post_init_accepts_zero_bandwidth_and_zero_latency():
+    """Zero is a valid sentinel (e.g., a tier in test fixtures); only
+    negatives are rejected."""
+    t = MemoryTier(**_valid_kwargs(peak_bandwidth_bps=0.0, access_latency_ns=0.0,
+                                    achievable_fraction=0.0))
+    assert t.effective_bandwidth_bps == 0.0
+
+
+def test_post_init_error_messages_name_the_field_and_tier():
+    """Error messages include the tier name + offending field so a
+    miscalibrated mapper traces back to the source quickly."""
+    with pytest.raises(ValueError) as exc_info:
+        MemoryTier(**_valid_kwargs(name="DRAM", peak_bandwidth_bps=-100e9))
+    msg = str(exc_info.value)
+    assert "MemoryTier('DRAM')" in msg
+    assert "peak_bandwidth_bps" in msg
+    assert "-100" in msg
+
+
+def test_post_init_does_not_break_real_mapper_construction():
+    """Sanity: the existing reference mappers still construct cleanly
+    after adding the invariant checks. (i7 / H100 / Orin all parse the
+    hierarchy without raising.)"""
+    for factory in (create_i7_12700k_mapper, create_h100_sxm5_80gb_mapper,
+                    create_jetson_orin_nano_8gb_mapper):
+        hw = factory().resource_model
+        # Just access the property; any tier with bad values would raise
+        tiers = hw.memory_hierarchy
+        assert len(tiers) >= 1

--- a/tests/hardware/test_memory_hierarchy.py
+++ b/tests/hardware/test_memory_hierarchy.py
@@ -1,0 +1,241 @@
+"""Regression tests for the V5-1 memory-hierarchy scaffolding.
+
+The MemoryTier dataclass + ``hw.memory_hierarchy`` derived property are
+pure scaffolding -- nothing in the analyzer reads them yet. These tests
+pin the contract:
+
+1. The hierarchy is built from existing fields (l1_cache_per_unit +
+   l1_bandwidth_per_unit_bps, l2_bandwidth_bps, l3_cache_total +
+   l3_bandwidth_bps, main_memory + peak_bandwidth) plus per-tier
+   access_latency_ns overrides.
+
+2. Tiers are ordered innermost (smallest, fastest) to outermost.
+
+3. Mappers without on-chip BW peaks (most of the 45+ existing mappers)
+   return a hierarchy with only the DRAM tier -- backward compat.
+
+4. Per-unit tiers store aggregate peak_bandwidth_bps (per-unit value
+   * compute_units), so callers don't have to special-case per-unit
+   vs shared tiers when reading the BW field.
+
+5. access_latency_ns falls back to typical published values per tier
+   class when the mapper doesn't override.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graphs.hardware.mappers.cpu import create_i7_12700k_mapper
+from graphs.hardware.mappers.gpu import (
+    create_h100_sxm5_80gb_mapper,
+    create_jetson_orin_nano_8gb_mapper,
+)
+from graphs.hardware.resource_model import MemoryTier
+
+
+# ---------------------------------------------------------------------------
+# i7-12700K: L1 (per-core) + L3 (LLC) + DRAM
+# ---------------------------------------------------------------------------
+
+
+def test_i7_12700k_hierarchy_is_l1_l3_dram():
+    """i7-12700K has populated L1 BW (#61) and L3 BW (the LLC on x86,
+    stored in l3_bandwidth_bps + l2_cache_total per the M1 schema). No
+    distinct L2 hop."""
+    hw = create_i7_12700k_mapper().resource_model
+    tiers = hw.memory_hierarchy
+    names = [t.name for t in tiers]
+    assert names == ["L1", "L3", "DRAM"], (
+        f"i7 hierarchy {names} != ['L1', 'L3', 'DRAM'] -- the LLC should "
+        f"emit as L3 even though it's stored in l2_cache_total per the "
+        f"x86 M1 schema convention."
+    )
+
+
+def test_i7_12700k_l1_aggregates_per_unit_bw():
+    """L1 BW field stores the AGGREGATE (per-unit value * compute_units),
+    so callers don't have to know whether a tier is per-unit when reading
+    the BW field. Per-unit value is recoverable via
+    peak_bandwidth_bps / num_units."""
+    hw = create_i7_12700k_mapper().resource_model
+    l1 = next(t for t in hw.memory_hierarchy if t.name == "L1")
+    assert l1.is_per_unit is True
+    assert l1.num_units == hw.compute_units
+    expected_aggregate = hw.l1_bandwidth_per_unit_bps * hw.compute_units
+    assert l1.peak_bandwidth_bps == expected_aggregate
+    # Per-unit recovery
+    assert l1.peak_bandwidth_bps / l1.num_units == hw.l1_bandwidth_per_unit_bps
+
+
+def test_i7_12700k_total_capacity_per_unit_tier():
+    """L1 total_capacity_bytes = per-core capacity * compute_units."""
+    hw = create_i7_12700k_mapper().resource_model
+    l1 = next(t for t in hw.memory_hierarchy if t.name == "L1")
+    assert l1.total_capacity_bytes == hw.l1_cache_per_unit * hw.compute_units
+
+
+def test_i7_12700k_l3_uses_l2_cache_total_capacity():
+    """On x86 the LLC IS L3 and the M1 convention puts its capacity in
+    ``l2_cache_total`` -- that 25 MB number must surface as the L3
+    tier's capacity."""
+    hw = create_i7_12700k_mapper().resource_model
+    l3 = next(t for t in hw.memory_hierarchy if t.name == "L3")
+    assert l3.capacity_bytes == hw.l2_cache_total
+    assert l3.peak_bandwidth_bps == hw.l3_bandwidth_bps
+
+
+# ---------------------------------------------------------------------------
+# H100 SXM5: L1 (per-SM) + L2 (shared) + DRAM
+# ---------------------------------------------------------------------------
+
+
+def test_h100_sxm5_hierarchy_is_l1_l2_dram():
+    """H100 has both per-SM L1 (`l1_bandwidth_per_unit_bps`) and shared
+    L2 (`l2_bandwidth_bps`) populated per #61. Distinct L2 -- no L3."""
+    hw = create_h100_sxm5_80gb_mapper().resource_model
+    names = [t.name for t in hw.memory_hierarchy]
+    assert names == ["L1", "L2", "DRAM"]
+
+
+def test_h100_l2_is_shared_not_per_unit():
+    """H100's 50 MB L2 is a single shared structure across all SMs."""
+    hw = create_h100_sxm5_80gb_mapper().resource_model
+    l2 = next(t for t in hw.memory_hierarchy if t.name == "L2")
+    assert l2.is_per_unit is False
+    assert l2.num_units == 1
+    assert l2.total_capacity_bytes == l2.capacity_bytes
+
+
+# ---------------------------------------------------------------------------
+# Jetson Orin Nano: L1 (per-SM) + L2 (shared) + DRAM (Super, 102 GB/s)
+# ---------------------------------------------------------------------------
+
+
+def test_jetson_orin_nano_hierarchy_dram_only_until_61_extended():
+    """The Orin Nano mapper hasn't populated ``l1_bandwidth_per_unit_bps``
+    or ``l2_bandwidth_bps`` (#61 only covered i7, H100, KPU-T64). Until
+    that gets extended, Orin's hierarchy is DRAM-only -- which is the
+    correct backward-compat behavior, not a bug. This test pins the
+    current state so a future PR adding on-chip BW peaks for Orin will
+    flip this test (and need to update the assertion to ``L1 -> L2 -> DRAM``)."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    names = [t.name for t in hw.memory_hierarchy]
+    assert names == ["DRAM"], (
+        f"Orin Nano hierarchy {names} != ['DRAM']. If you populated "
+        f"l1_bandwidth_per_unit_bps and/or l2_bandwidth_bps on the Orin "
+        f"Nano mapper, update this test to assert ['L1', 'L2', 'DRAM']."
+    )
+
+
+def test_jetson_orin_nano_dram_is_super_102gbps():
+    """Verify post-#94 Super calibration is reflected in the DRAM tier."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    dram = next(t for t in hw.memory_hierarchy if t.name == "DRAM")
+    assert dram.peak_bandwidth_bps == 102e9
+
+
+# ---------------------------------------------------------------------------
+# Backward compat: mapper without on-chip BW peaks returns DRAM-only
+# ---------------------------------------------------------------------------
+
+
+def test_mapper_without_onchip_bw_peaks_returns_dram_only():
+    """The vast majority of 45+ existing mappers don't populate the
+    on-chip BW peaks (#61's fields are Optional). Their hierarchy must
+    still be valid -- just DRAM-only."""
+    hw = create_i7_12700k_mapper().resource_model
+    # Mutate a copy to clear the on-chip BW peaks, simulating an
+    # un-augmented mapper:
+    import copy
+    hw2 = copy.copy(hw)
+    hw2.l1_bandwidth_per_unit_bps = None
+    hw2.l2_bandwidth_bps = None
+    hw2.l3_bandwidth_bps = None
+
+    tiers = hw2.memory_hierarchy
+    assert len(tiers) == 1
+    assert tiers[0].name == "DRAM"
+    assert tiers[0].peak_bandwidth_bps == hw2.peak_bandwidth
+
+
+# ---------------------------------------------------------------------------
+# Ordering: innermost (smallest) to outermost
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mapper_factory", [
+    create_i7_12700k_mapper,
+    create_h100_sxm5_80gb_mapper,
+    create_jetson_orin_nano_8gb_mapper,
+])
+def test_hierarchy_ordered_innermost_first(mapper_factory):
+    """The contract: tiers[0] is innermost (smallest total capacity);
+    tiers[-1] is DRAM. The tier_picker (V5-3) walks innermost-out."""
+    hw = mapper_factory().resource_model
+    tiers = hw.memory_hierarchy
+    assert tiers[-1].name == "DRAM"
+    # Total capacity strictly increases (innermost is smallest)
+    capacities = [t.total_capacity_bytes for t in tiers]
+    assert capacities == sorted(capacities), (
+        f"hierarchy {[t.name for t in tiers]} not ordered by capacity: "
+        f"{capacities}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# access_latency_ns: defaults + mapper override
+# ---------------------------------------------------------------------------
+
+
+def test_access_latency_falls_back_to_typical_defaults():
+    """When a mapper doesn't set ``l1_access_latency_ns`` etc., the
+    property falls back to typical-tier-class defaults (1.5 / 10 / 30 /
+    100 ns for L1 / L2 / L3 / DRAM)."""
+    hw = create_h100_sxm5_80gb_mapper().resource_model
+    # H100 mapper doesn't override latencies as of V5-1
+    assert hw.l1_access_latency_ns is None
+    tiers = {t.name: t for t in hw.memory_hierarchy}
+    assert tiers["L1"].access_latency_ns == 1.5
+    assert tiers["L2"].access_latency_ns == 10.0
+    assert tiers["DRAM"].access_latency_ns == 100.0
+
+
+def test_access_latency_respects_mapper_override():
+    """A mapper that sets ``l1_access_latency_ns`` etc. wins over the
+    typical defaults."""
+    hw = create_i7_12700k_mapper().resource_model
+    import copy
+    hw2 = copy.copy(hw)
+    hw2.l1_access_latency_ns = 0.8   # custom override
+    hw2.dram_access_latency_ns = 75.0
+
+    tiers = {t.name: t for t in hw2.memory_hierarchy}
+    assert tiers["L1"].access_latency_ns == 0.8
+    assert tiers["DRAM"].access_latency_ns == 75.0
+    # L3 wasn't overridden -> falls back to default
+    assert tiers["L3"].access_latency_ns == 30.0
+
+
+# ---------------------------------------------------------------------------
+# Effective BW = peak * achievable_fraction
+# ---------------------------------------------------------------------------
+
+
+def test_effective_bandwidth_defaults_to_peak():
+    """V5-1 ships with achievable_fraction=1.0 (V5-5 will calibrate
+    these per (hw, tier)). effective_bandwidth_bps = peak * 1.0 = peak."""
+    hw = create_h100_sxm5_80gb_mapper().resource_model
+    for tier in hw.memory_hierarchy:
+        assert tier.achievable_fraction == 1.0
+        assert tier.effective_bandwidth_bps == tier.peak_bandwidth_bps
+
+
+def test_effective_bandwidth_scales_with_achievable_fraction():
+    """Property contract: effective = peak * fraction."""
+    t = MemoryTier(
+        name="L2", capacity_bytes=1 << 22, is_per_unit=False,
+        num_units=1, peak_bandwidth_bps=1e12,
+        access_latency_ns=10.0, achievable_fraction=0.6,
+    )
+    assert t.effective_bandwidth_bps == 6e11


### PR DESCRIPTION
## Summary
First step of the V5 memory-hierarchy rewrite (plan in [#95](https://github.com/branes-ai/graphs/pull/95)). Pure scaffolding — no analyzer behavior change. The tier_picker that consumes this lands in V5-3.

## What ships

### New dataclass: `MemoryTier`
Frozen dataclass representing one level of the hierarchy as a queueing-theory server:
- `name`, `capacity_bytes`, `is_per_unit`, `num_units`
- `peak_bandwidth_bps` — always aggregate (L1 per-unit value gets multiplied by `num_units` when constructed)
- `access_latency_ns` — first-request startup, the memory-side analog of LAUNCH_BOUND
- `achievable_fraction` (default 1.0) — V5-5 will calibrate this from microbenchmarks

### Schema additions to `HardwareResourceModel`
4 new `Optional[float]` fields: `l1_access_latency_ns`, `l2_access_latency_ns`, `l3_access_latency_ns`, `dram_access_latency_ns`. All default to None; typical-tier-class defaults (1.5 / 10 / 30 / 100 ns) apply when unset.

### Derived view: `hw.memory_hierarchy`
Returns an ordered list of `MemoryTier` objects, innermost to outermost. Built from existing fields:
- L1 from `l1_cache_per_unit` + `l1_bandwidth_per_unit_bps`
- L2 from `l2_cache_total` + `l2_bandwidth_bps`
- L3 from `l3_cache_total` + `l3_bandwidth_bps` (with x86 schema fallback when LLC capacity lives in `l2_cache_total`)
- DRAM always present from `main_memory` + `peak_bandwidth`

## Per-mapper hierarchy as of V5-1
| Mapper | Hierarchy |
|---|---|
| i7-12700K | `L1 → L3 → DRAM` (L1 per-core BW + L3 LLC BW from #61) |
| H100-SXM5 | `L1 → L2 → DRAM` (per-SM L1 + shared L2 from #61) |
| KPU-T64 | `L1 → L2 → DRAM` (per-tile + shared from #61) |
| Orin Nano | `DRAM` (#61 didn't populate; pinned in test to flag for next PR) |
| Other 42+ mappers | `DRAM` (backward compat) |

## Tests (16, all pass)
| Test | What it pins |
|---|---|
| 3× hierarchy composition | i7/H100/Orin tier name lists |
| L1 BW aggregation | per-unit × `compute_units` math |
| `total_capacity_bytes` | per-unit aggregation |
| Backward compat | DRAM-only when peaks missing |
| Ordered innermost-first | across all 3 reference mappers |
| Latency defaults | typical-tier-class fallback |
| Latency override | mapper-set values win |
| Effective BW | `peak × achievable_fraction` |

Full hardware + V4 suite: **416 passed, 4 documented xfails** — no regressions.

## What's next
- **V5-2a**: vector_add workload + sweep
- **V5-2b**: vector_add baseline capture (i7 + Jetson)
- **V5-3**: per-op reuse models + `tier_picker` + new `_get_effective_memory_time` (analyzer behavior change)
- **V5-4**: `LatencyDescriptor.memory_explanation`
- **V5-5**: per-mapper `achievable_fraction` calibration
- **V5-6**: retire `bw_efficiency_scale`

## Test plan
- [x] Fast CI passes (V4 Model Validation gate triggers since this touches `src/graphs/hardware/`)
- [x] CodeRabbit review

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced memory hierarchy modeling with configurable per-tier access latencies and bandwidth settings for L1, L2, L3, and DRAM levels, enabling more precise hardware resource characterization and improved performance prediction accuracy across diverse platforms.

* **Tests**
  * Added comprehensive test coverage validating memory hierarchy construction, tier ordering, backward compatibility, and latency fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->