### PR TITLE
feat(validation): V5-2a -- vector_add workload + sweep + harness plumbing

### DIFF
--- a/tests/validation_model_v4/test_classify.py
+++ b/tests/validation_model_v4/test_classify.py
@@ -63,6 +63,25 @@ def test_linear_footprint_math():
     assert fp.flops == 2 * 8 * 512 * 256
 
 
+def test_vector_add_footprint_math():
+    """Vector add c[i] = a[i] + b[i] on N=1024 elements at fp32:
+    WS = 3 * 1024 * 4 = 12288 bytes, FLOPs = 1024 (one add per element).
+    OI = 1024 / 12288 = 1/(3*4) = 0.0833 -- always memory-bound."""
+    fp = op_footprint("vector_add", (1024,), "fp32")
+    assert fp.working_set_bytes == 3 * 1024 * 4
+    assert fp.flops == 1024
+    assert fp.operational_intensity == pytest.approx(1.0 / (3 * 4), rel=1e-9)
+
+
+def test_vector_add_footprint_at_fp16_halves_working_set():
+    """fp16 has bpe=2 vs fp32 bpe=4; same N gives half the WS."""
+    fp32 = op_footprint("vector_add", (4096,), "fp32")
+    fp16 = op_footprint("vector_add", (4096,), "fp16")
+    assert fp16.working_set_bytes == fp32.working_set_bytes // 2
+    # FLOPs unchanged (it's the same op count)
+    assert fp16.flops == fp32.flops == 4096
+
+
 def test_op_footprint_rejects_unknown_op():
     with pytest.raises(ValueError, match="Unsupported op"):
         op_footprint("conv2d", (1, 1, 1), "fp32")

--- a/tests/validation_model_v4/test_sweeps.py
+++ b/tests/validation_model_v4/test_sweeps.py
@@ -37,6 +37,8 @@ SWEEP_FILES = [
     "matmul_validation.json",
     "linear_calibration.json",
     "linear_validation.json",
+    "vector_add_calibration.json",
+    "vector_add_validation.json",
 ]
 
 
@@ -57,7 +59,7 @@ def hw():
 @pytest.mark.parametrize("filename", SWEEP_FILES)
 def test_sweep_file_loads_with_expected_schema(filename):
     payload = json.loads((SWEEP_DIR / filename).read_text())
-    assert payload["op"] in {"matmul", "linear"}
+    assert payload["op"] in {"matmul", "linear", "vector_add"}
     assert payload["purpose"] in {"calibration", "validation"}
     assert isinstance(payload["generator_seed"], int)
     assert isinstance(payload["generated_against_hardware"], list)

--- a/tests/validation_model_v4/test_workloads.py
+++ b/tests/validation_model_v4/test_workloads.py
@@ -118,3 +118,76 @@ def test_linear_bias_can_be_disabled():
 def test_linear_name_is_descriptive():
     w = build_linear(64, 1024, 256, "bf16")
     assert w.name == "linear_B64_IN1024_OUT256_bf16"
+
+
+# ---------------------------------------------------------------------------
+# vector_add (V5-2a)
+# ---------------------------------------------------------------------------
+
+
+from validation.model_v4.workloads.vector_add import build_vector_add
+
+
+def test_vector_add_runs_and_shapes_match():
+    w = build_vector_add(1024, "fp32")
+    assert w.op == "vector_add"
+    assert w.shape == (1024,)
+    assert w.dtype == "fp32"
+    assert len(w.inputs) == 2
+    a, b = w.inputs
+    assert a.shape == (1024,)
+    assert b.shape == (1024,)
+    out = w.model(*w.inputs)
+    assert out.shape == (1024,)
+    # Forward should equal a + b elementwise
+    assert torch.allclose(out, a + b)
+
+
+@pytest.mark.parametrize("dtype,torch_dtype", [
+    ("fp32", torch.float32),
+    ("fp16", torch.float16),
+    ("bf16", torch.bfloat16),
+    ("fp64", torch.float64),
+])
+def test_vector_add_float_dtypes(dtype, torch_dtype):
+    w = build_vector_add(64, dtype)
+    assert w.inputs[0].dtype == torch_dtype
+
+
+@pytest.mark.parametrize("dtype,torch_dtype", [
+    ("int8", torch.int8),
+    ("int16", torch.int16),
+    ("int32", torch.int32),
+])
+def test_vector_add_int_dtypes(dtype, torch_dtype):
+    """Unlike matmul / linear, vector_add over int dtypes is a normal
+    elementwise op -- no quantized path needed."""
+    w = build_vector_add(64, dtype)
+    assert w.inputs[0].dtype == torch_dtype
+    out = w.model(*w.inputs)
+    assert torch.equal(out, w.inputs[0] + w.inputs[1])
+
+
+def test_vector_add_rejects_subbyte_dtypes():
+    for dtype in ["fp4", "int4"]:
+        with pytest.raises(ValueError, match="Unsupported torch dtype"):
+            build_vector_add(64, dtype)
+
+
+def test_vector_add_rejects_zero_or_negative_n():
+    with pytest.raises(ValueError, match="must be positive"):
+        build_vector_add(0)
+    with pytest.raises(ValueError, match="must be positive"):
+        build_vector_add(-1)
+
+
+def test_vector_add_seed_is_reproducible():
+    w1 = build_vector_add(128, "fp32", seed=42)
+    w2 = build_vector_add(128, "fp32", seed=42)
+    assert torch.equal(w1.inputs[0], w2.inputs[0])
+    assert torch.equal(w1.inputs[1], w2.inputs[1])
+
+
+def test_vector_add_name_is_descriptive():
+    w = build_vector_add(65536, "fp16")
+    assert w.name == "vector_add_N65536_fp16"

--- a/validation/model_v4/cli/capture_ground_truth.py
+++ b/validation/model_v4/cli/capture_ground_truth.py
@@ -41,6 +41,7 @@ from validation.model_v4.ground_truth.pytorch_cpu import (
 from validation.model_v4.sweeps.classify import Regime
 from validation.model_v4.workloads.linear import build_linear
 from validation.model_v4.workloads.matmul import build_matmul
+from validation.model_v4.workloads.vector_add import build_vector_add
 
 
 SWEEP_DIR = Path(__file__).resolve().parents[1] / "sweeps"
@@ -95,6 +96,9 @@ def _build_workload(op: str, shape: tuple, dtype: str):
     if op == "linear":
         B, IN, OUT = shape
         return build_linear(B, IN, OUT, dtype)
+    if op == "vector_add":
+        (N,) = shape
+        return build_vector_add(N, dtype)
     raise ValueError(f"Unsupported op {op!r}")
 
 
@@ -108,7 +112,7 @@ def main(argv: list[str] | None = None) -> int:
     # (e.g., GPU lands in V4-4, KPU in V4-5).
     p.add_argument("--hw", required=True,
                    choices=sorted(k for k, v in _MEASURER_FACTORY.items() if v))
-    p.add_argument("--op", required=True, choices=["matmul", "linear"])
+    p.add_argument("--op", required=True, choices=["matmul", "linear", "vector_add"])
     p.add_argument("--purpose", default="calibration",
                    choices=["calibration", "validation"])
     p.add_argument("--warmup", type=int, default=DEFAULT_WARMUP_TRIALS)

--- a/validation/model_v4/harness/runner.py
+++ b/validation/model_v4/harness/runner.py
@@ -66,6 +66,7 @@ from validation.model_v4.sweeps.classify import (
 )
 from validation.model_v4.workloads.linear import build_linear
 from validation.model_v4.workloads.matmul import build_matmul
+from validation.model_v4.workloads.vector_add import build_vector_add
 
 
 # Sweep-JSON keys -> mapper-registry keys. Sweep JSONs use a normalized
@@ -228,6 +229,15 @@ def _build_subgraph(op: str, shape: tuple, dtype: str) -> SubgraphDescriptor:
         # Weight matrix + bias (mirrors what build_linear() actually allocates)
         weight_bytes = int(round((IN * OUT + OUT) * bpe))
         op_type = OperationType.LINEAR
+    elif op == "vector_add":
+        # c[i] = a[i] + b[i]. Two N-element inputs, one N-element output,
+        # no weights. The zero-reuse op the V5 plan uses for tier-BW
+        # microbenchmarks.
+        (N_elems,) = shape
+        input_bytes = int(round(2 * N_elems * bpe))
+        output_bytes = int(round(N_elems * bpe))
+        weight_bytes = 0
+        op_type = OperationType.ELEMENTWISE
     else:
         raise ValueError(f"Unsupported op {op!r} for v4 runner")
 
@@ -282,4 +292,7 @@ def _build_workload(op: str, shape: tuple, dtype: str):
     if op == "linear":
         B, IN, OUT = shape
         return build_linear(B, IN, OUT, dtype)
+    if op == "vector_add":
+        (N,) = shape
+        return build_vector_add(N, dtype)
     raise ValueError(f"Unsupported op {op!r}")

--- a/validation/model_v4/sweeps/_augment.py
+++ b/validation/model_v4/sweeps/_augment.py
@@ -137,8 +137,8 @@ def main(argv: list[str] | None = None) -> int:
                    help="Augment one specific hardware key")
     g.add_argument("--all", action="store_true",
                    help="Augment with every known target")
-    p.add_argument("--op", choices=["matmul", "linear"], default=None,
-                   help="Restrict to one op (default: both)")
+    p.add_argument("--op", choices=["matmul", "linear", "vector_add"], default=None,
+                   help="Restrict to one op (default: all)")
     p.add_argument("--purpose", choices=["calibration", "validation"], default=None,
                    help="Restrict to one purpose (default: both)")
     args = p.parse_args(argv)
@@ -146,7 +146,7 @@ def main(argv: list[str] | None = None) -> int:
     targets = (list(KNOWN_TARGETS.values()) if args.all
                else [KNOWN_TARGETS[args.hw]])
 
-    ops = [args.op] if args.op else ["matmul", "linear"]
+    ops = [args.op] if args.op else ["matmul", "linear", "vector_add"]
     purposes = [args.purpose] if args.purpose else ["calibration", "validation"]
 
     for op in ops:

--- a/validation/model_v4/sweeps/_generate.py
+++ b/validation/model_v4/sweeps/_generate.py
@@ -99,6 +99,30 @@ def _matmul_candidates() -> Iterable[Tuple[int, int, int]]:
                 yield (m, k, n)
 
 
+def _vector_add_candidates() -> Iterable[Tuple[int]]:
+    """Vector-add candidate pool spanning the cache hierarchy.
+
+    Vector add is the V5 plan's zero-reuse ground truth: bytes-per-second
+    measured at each tier. The classifier will collapse most of these to
+    LAUNCH_BOUND (small N) or DRAM_BOUND (large N) because vector_add's
+    OI = 1/(3*bpe) is well below any hardware's AI breakpoint. The
+    *tier* information comes from the working-set bucket each N falls
+    into (visualized in the lat-vs-WS panel), not from the V4 regime
+    classification. V5-3's tier_picker will reinterpret these same N
+    values via tier-hit decomposition and emit L1_BOUND / L2_BOUND /
+    DRAM_BOUND directly.
+
+    N values log-spaced from 1 KB (256 fp32 elements) to 1 GB
+    (256 M fp32 elements). Covers L1 / L2 / L3 / DRAM on every V4 target.
+    """
+    # Powers of 4 from 256 to 268M. Eleven values; one log decade between
+    # neighbors gives clean WS-bucket separation in the visualizer.
+    sizes = [256, 1024, 4096, 16384, 65536, 262144, 1048576,
+             4194304, 16777216, 67108864, 268435456]
+    for n in sizes:
+        yield (n,)
+
+
 def _linear_candidates() -> Iterable[Tuple[int, int, int]]:
     """Exhaustive Linear shapes from realistic batch + feature dim pools.
 
@@ -242,8 +266,9 @@ def main() -> None:
     # matmul: i7-12700k expects fp32, H100 expects fp16. Generate both
     # halves and write a single combined file (the harness filters by hw).
     for op_name, gen, dtypes in [
-        ("matmul", _matmul_candidates, ["fp32", "fp16"]),
-        ("linear", _linear_candidates, ["fp32", "fp16"]),
+        ("matmul",     _matmul_candidates,     ["fp32", "fp16"]),
+        ("linear",     _linear_candidates,     ["fp32", "fp16"]),
+        ("vector_add", _vector_add_candidates, ["fp32", "fp16"]),
     ]:
         print(f"=== {op_name} ===")
         candidates = list(gen())

--- a/validation/model_v4/sweeps/classify.py
+++ b/validation/model_v4/sweeps/classify.py
@@ -132,9 +132,23 @@ def _linear_footprint(shape: Tuple[int, int, int], dtype: str) -> OpFootprint:
                        operational_intensity=oi)
 
 
+def _vector_add_footprint(shape: Tuple[int, ...], dtype: str) -> OpFootprint:
+    # Vector add: c[i] = a[i] + b[i]. Two N-element inputs + one
+    # N-element output, no operand reuse. The zero-reuse ground truth
+    # for tier-bandwidth measurement (V5 plan).
+    (N,) = shape
+    bpe = bytes_per_element(dtype)
+    working_set = int(round(3 * N * bpe))  # a + b + c
+    flops = N                              # one add per element
+    oi = flops / working_set if working_set > 0 else 0.0
+    return OpFootprint(working_set_bytes=working_set, flops=flops,
+                       operational_intensity=oi)
+
+
 _OP_FOOTPRINT = {
     "matmul": _matmul_footprint,
     "linear": _linear_footprint,
+    "vector_add": _vector_add_footprint,
 }
 
 

--- a/validation/model_v4/sweeps/vector_add_calibration.json
+++ b/validation/model_v4/sweeps/vector_add_calibration.json
@@ -1,0 +1,120 @@
+{
+  "op": "vector_add",
+  "purpose": "calibration",
+  "generator_seed": 20260505,
+  "generated_against_hardware": [
+    "i7_12700k",
+    "h100_sxm5_80gb"
+  ],
+  "shapes": [
+    {
+      "shape": [
+        256
+      ],
+      "dtype": "fp16",
+      "regime_per_hw": {
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        256
+      ],
+      "dtype": "fp32",
+      "regime_per_hw": {
+        "i7_12700k": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        4096
+      ],
+      "dtype": "fp16",
+      "regime_per_hw": {
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        4096
+      ],
+      "dtype": "fp32",
+      "regime_per_hw": {
+        "i7_12700k": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        65536
+      ],
+      "dtype": "fp16",
+      "regime_per_hw": {
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        65536
+      ],
+      "dtype": "fp32",
+      "regime_per_hw": {
+        "i7_12700k": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        1048576
+      ],
+      "dtype": "fp16",
+      "regime_per_hw": {
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        1048576
+      ],
+      "dtype": "fp32",
+      "regime_per_hw": {
+        "i7_12700k": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        16777216
+      ],
+      "dtype": "fp32",
+      "regime_per_hw": {
+        "i7_12700k": "dram_bound"
+      }
+    },
+    {
+      "shape": [
+        268435456
+      ],
+      "dtype": "fp32",
+      "regime_per_hw": {
+        "i7_12700k": "dram_bound"
+      }
+    }
+  ],
+  "augmented_with_hardware": [
+    "h100_sxm5_80gb",
+    "i7_12700k",
+    "jetson_orin_agx_64gb",
+    "jetson_orin_nano_8gb",
+    "jetson_orin_nx_16gb"
+  ]
+}

--- a/validation/model_v4/sweeps/vector_add_validation.json
+++ b/validation/model_v4/sweeps/vector_add_validation.json
@@ -1,0 +1,147 @@
+{
+  "op": "vector_add",
+  "purpose": "validation",
+  "generator_seed": 20260505,
+  "generated_against_hardware": [
+    "i7_12700k",
+    "h100_sxm5_80gb"
+  ],
+  "shapes": [
+    {
+      "shape": [
+        1024
+      ],
+      "dtype": "fp16",
+      "regime_per_hw": {
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        1024
+      ],
+      "dtype": "fp32",
+      "regime_per_hw": {
+        "i7_12700k": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        16384
+      ],
+      "dtype": "fp16",
+      "regime_per_hw": {
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        16384
+      ],
+      "dtype": "fp32",
+      "regime_per_hw": {
+        "i7_12700k": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        262144
+      ],
+      "dtype": "fp16",
+      "regime_per_hw": {
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        262144
+      ],
+      "dtype": "fp32",
+      "regime_per_hw": {
+        "i7_12700k": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        4194304
+      ],
+      "dtype": "fp16",
+      "regime_per_hw": {
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        4194304
+      ],
+      "dtype": "fp32",
+      "regime_per_hw": {
+        "i7_12700k": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        16777216
+      ],
+      "dtype": "fp16",
+      "regime_per_hw": {
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "launch_bound",
+        "jetson_orin_nx_16gb": "launch_bound"
+      }
+    },
+    {
+      "shape": [
+        67108864
+      ],
+      "dtype": "fp16",
+      "regime_per_hw": {
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "launch_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
+      }
+    },
+    {
+      "shape": [
+        67108864
+      ],
+      "dtype": "fp32",
+      "regime_per_hw": {
+        "i7_12700k": "dram_bound"
+      }
+    },
+    {
+      "shape": [
+        268435456
+      ],
+      "dtype": "fp16",
+      "regime_per_hw": {
+        "h100_sxm5_80gb": "launch_bound",
+        "jetson_orin_nano_8gb": "dram_bound",
+        "jetson_orin_agx_64gb": "dram_bound",
+        "jetson_orin_nx_16gb": "dram_bound"
+      }
+    }
+  ],
+  "augmented_with_hardware": [
+    "h100_sxm5_80gb",
+    "i7_12700k",
+    "jetson_orin_agx_64gb",
+    "jetson_orin_nano_8gb",
+    "jetson_orin_nx_16gb"
+  ]
+}

--- a/validation/model_v4/workloads/vector_add.py
+++ b/validation/model_v4/workloads/vector_add.py
@@ -1,0 +1,119 @@
+"""Vector add workload factory for the v4 validation harness (V5-2a).
+
+The zero-reuse ground truth: ``c[i] = a[i] + b[i]`` for N elements.
+Each input byte is read once, each output byte is written once,
+no operand reuse. This makes vector add the cleanest tier-bandwidth
+microbenchmark there is -- no tile-size choices, no kernel-tuning
+variance, just bytes-per-second.
+
+Working set: ``3 * N * bytes_per_element`` (a, b, c).
+FLOPs: ``N`` (one add per element).
+Operational intensity: ``1 / (3 * bpe)`` -- always memory-bound.
+
+Why this exists (V5 plan):
+    The V4 sweep is matmul + linear -- both have rich operand reuse
+    that confounds bandwidth measurement (the achieved BW depends on
+    the kernel's tile size and how well cuBLAS / oneDNN tunes it).
+    Vector add has *no* reuse, so the measured latency / N directly
+    yields the binding tier's effective bandwidth. Sweeping N across
+    the cache hierarchy isolates each tier's BW one at a time.
+
+Same artifact contract as matmul.py / linear.py: a WorkloadArtifact
+flows through the ground-truth measurer, the analyzer, and the
+classifier.
+
+Shape convention: ``(N,)`` -- a 1-D length tuple. The factory accepts
+N as a Python int for ergonomics; the artifact stores it as ``(N,)``
+so the rest of the harness can treat it uniformly with matmul's
+``(M, K, N)`` and linear's ``(B, IN, OUT)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+
+
+_TORCH_DTYPE: dict[str, torch.dtype] = {
+    "fp64": torch.float64,
+    "fp32": torch.float32,
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "int32": torch.int32,
+    "int16": torch.int16,
+    "int8": torch.int8,
+}
+
+
+@dataclass(frozen=True)
+class WorkloadArtifact:
+    """A self-describing workload bundle (parallels matmul / linear)."""
+    name: str
+    op: str                # "vector_add"
+    shape: Tuple[int, ...]  # (N,)
+    dtype: str
+    model: nn.Module
+    inputs: Tuple[torch.Tensor, ...]
+
+
+class _VectorAdd(nn.Module):
+    """Single-op nn.Module that performs ``a + b`` elementwise.
+
+    Wrapping ``torch.add`` in an nn.Module rather than calling it
+    directly means it traces through ``frontend.trace_and_partition``
+    the same way a real layer would, exercising the same partitioner /
+    mapper code path the production analyzer uses."""
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        return a + b
+
+
+def _resolve_dtype(dtype: str) -> torch.dtype:
+    key = dtype.lower()
+    if key not in _TORCH_DTYPE:
+        raise ValueError(
+            f"Unsupported torch dtype {dtype!r}; supported: {sorted(_TORCH_DTYPE)}"
+        )
+    return _TORCH_DTYPE[key]
+
+
+def build_vector_add(
+    N: int, dtype: str = "fp32", *, seed: int = 0,
+) -> WorkloadArtifact:
+    """Build a single-op vector-add workload.
+
+    Args:
+        N: Number of elements per vector. The two input vectors and
+            the output vector each have shape ``(N,)``.
+        dtype: One of fp32, fp16, bf16, fp64, int8, int16, int32.
+        seed: PyTorch RNG seed for reproducible inputs.
+
+    Returns:
+        A WorkloadArtifact bundling the nn.Module and the two inputs.
+    """
+    if N <= 0:
+        raise ValueError(f"vector_add shape must be positive, got N={N}")
+
+    torch_dtype = _resolve_dtype(dtype)
+    g = torch.Generator().manual_seed(seed)
+
+    if torch_dtype.is_floating_point:
+        a = torch.randn(N, generator=g, dtype=torch_dtype)
+        b = torch.randn(N, generator=g, dtype=torch_dtype)
+    else:
+        # Integer dtypes: bounded random values so a + b doesn't overflow.
+        a = torch.randint(-8, 8, (N,), generator=g, dtype=torch_dtype)
+        b = torch.randint(-8, 8, (N,), generator=g, dtype=torch_dtype)
+
+    name = f"vector_add_N{N}_{dtype}"
+    return WorkloadArtifact(
+        name=name,
+        op="vector_add",
+        shape=(N,),
+        dtype=dtype,
+        model=_VectorAdd().eval(),
+        inputs=(a, b),
+    )


### PR DESCRIPTION
## Summary
The zero-reuse ground-truth op the V5 plan calls for. Vector add has no operand reuse, so measured latency / N at each working-set bucket directly yields the binding tier's effective bandwidth — the cleanest possible tier-BW microbenchmark.

V5-2a is **pure code**: workload factory, sweep entries, classifier footprint, harness extensions, tests. The actual baseline capture (V5-2b) runs on i7 + Jetson hardware via the existing `capture_ground_truth.py` CLI.

## What ships
| File | Purpose |
|---|---|
| `validation/model_v4/workloads/vector_add.py` (new) | `build_vector_add(N, dtype) -> WorkloadArtifact` |
| `validation/model_v4/sweeps/vector_add_{calibration,validation}.json` (new) | 11 N values from 256 to 256M elements, log-spaced; covers L1 → L2 → L3 → DRAM on every V4 target |
| `validation/model_v4/sweeps/classify.py` | `_vector_add_footprint` registered in `_OP_FOOTPRINT` |
| `validation/model_v4/sweeps/_generate.py` | `_vector_add_candidates()` + main-loop entry |
| `validation/model_v4/sweeps/_augment.py` | `vector_add` added to `--op` choices |
| `validation/model_v4/harness/runner.py` | `_build_subgraph` + `_build_workload` handle `vector_add` |
| `validation/model_v4/cli/capture_ground_truth.py` | `--op` accepts `vector_add` |

## Tests (11 new)
- 9 vector_add workload cases (forward correctness across 4 float + 3 int dtypes, sub-byte rejection, zero-N rejection, seed reproducibility, descriptive name)
- 2 classifier footprint cases (math correctness + bpe scaling)
- `SWEEP_FILES` extended; schema check now accepts `vector_add`

| Suite | Result |
|---|---|
| Full hardware + V4 | **446 passed**, 4 documented xfails (was 416, +30 new tier/V5-1 tests + V5-2a tests) |
| Smoke test (runner against vector_add sweep) | 5 i7 records correctly skipped as "no baseline" (V5-2b will capture) |

## Note on V4 regime classification of vector_add
On most targets, V4's regime classifier collapses vector_add into either `LAUNCH_BOUND` (small N) or `DRAM_BOUND` (large N) — H100 even classifies all 11 sizes as `LAUNCH_BOUND` because its peak FLOPS are so high that vector_add at any N fails the 25 µs threshold. **This is a fundamental limit of one-bottleneck-fits-all regime classification on memory-bound ops; V5-3's tier_picker is what fixes it.**

The "tier" information for V5 visualization comes from the **working-set bucket** each N falls into, not from the V4 regime classification. The visualizer's lat-vs-WS panel will show per-tier BW directly even when every shape says `LAUNCH_BOUND`.

## Note on generator determinism
Re-running `_generate.py` with vector_add added in the loop produces slightly different matmul/linear outputs (shape-selection ordering shifts subtly). The committed matmul/linear JSONs are **not** regenerated in this PR — only vector_add files added. Worth investigating if the generator becomes routine to re-run; currently a known quirk.

## Next: V5-2b
Run `cli/capture_ground_truth.py --hw <key> --op vector_add --purpose validation` on i7 + Jetson hardware. Commit the resulting CSVs. The visualizer will then render per-tier BW from the lat-vs-WS panel directly.

## Test plan
- [x] Fast CI passes (V4 Model Validation gate triggers since this touches `validation/model_v4/**`)
- [x] CodeRabbit review

Generated with [Claude Code](https://claude.com/claude-code)