### PR TITLE
feat(validation): V5-2b -- Jetson Orin Nano vector_add baseline

### DIFF
--- a/validation/model_v4/results/baselines/jetson_orin_nano_8gb_vector_add.csv
+++ b/validation/model_v4/results/baselines/jetson_orin_nano_8gb_vector_add.csv
@@ -1,0 +1,12 @@
+hardware,op,shape,dtype,latency_s,energy_j,trial_count,notes
+jetson_orin_nano_8gb,vector_add,256,fp16,0.00011398400366306306,0.0009831120315939188,11,"INA3221: window 1.3ms below 8ms averaging period; energy noisy; rails=['VDD_IN', 'VDD_SOC']"
+jetson_orin_nano_8gb,vector_add,1024,fp16,0.00011568000167608262,0.0009973929744511842,11,"INA3221: window 1.3ms below 8ms averaging period; energy noisy; rails=['VDD_IN', 'VDD_SOC']"
+jetson_orin_nano_8gb,vector_add,4096,fp16,0.00011184000223875046,0.0009623832192644477,11,"INA3221: window 1.2ms below 8ms averaging period; energy noisy; rails=['VDD_IN', 'VDD_SOC']"
+jetson_orin_nano_8gb,vector_add,16384,fp16,0.00011542399972677231,0.000995185725644231,11,"INA3221: window 1.3ms below 8ms averaging period; energy noisy; rails=['VDD_IN', 'VDD_SOC']"
+jetson_orin_nano_8gb,vector_add,65536,fp16,0.00010175999999046326,0.0008736095999181271,11,"INA3221: window 1.1ms below 8ms averaging period; energy noisy; rails=['VDD_IN', 'VDD_SOC']"
+jetson_orin_nano_8gb,vector_add,262144,fp16,0.00011219199746847153,0.0009676559781655671,11,"INA3221: window 1.2ms below 8ms averaging period; energy noisy; rails=['VDD_IN', 'VDD_SOC']"
+jetson_orin_nano_8gb,vector_add,1048576,fp16,0.00015692800283432007,0.001356171800494194,11,"INA3221: window 1.7ms below 8ms averaging period; energy noisy; rails=['VDD_IN', 'VDD_SOC']"
+jetson_orin_nano_8gb,vector_add,4194304,fp16,0.00045737600326538087,0.003952643420219421,11,"INA3221: window 5.0ms below 8ms averaging period; energy noisy; rails=['VDD_IN', 'VDD_SOC']"
+jetson_orin_nano_8gb,vector_add,16777216,fp16,0.0016343040466308594,0.014352458137512208,11,"rails=['VDD_IN', 'VDD_SOC']"
+jetson_orin_nano_8gb,vector_add,67108864,fp16,0.007134687900543213,0.06973443953990938,11,"rails=['VDD_IN', 'VDD_SOC']"
+jetson_orin_nano_8gb,vector_add,268435456,fp16,0.028459968566894533,0.35313128997802734,11,"rails=['VDD_IN', 'VDD_SOC']"


### PR DESCRIPTION
Captured via PyTorchJetsonMeasurer (cudaEvent + INA3221) at the 15W thermal profile (matches the Phase B baseline conditions per #94).