### PR TITLE
feat(estimation): V5-3a -- per-op reuse models for matmul, linear, vector_add

### DIFF
--- a/src/graphs/estimation/reuse_models.py
+++ b/src/graphs/estimation/reuse_models.py
@@ -1,0 +1,261 @@
+"""Per-operator reuse models for tier-aware roofline analysis.
+
+V5-3a: pure additions, no analyzer behavior change. The V5-3b
+``tier_picker`` will call the two methods on each model:
+
+  1. ``residency_window(shape, dtype, tier_capacity_bytes) -> TileChoice``
+       Given a hypothetical residency tier with capacity C bytes, what
+       tile size would the op pick and what working set does that imply?
+
+  2. ``bytes_loaded_from_binding(shape, dtype, tile) -> int``
+       Given the chosen tile, how many bytes stream from the *binding*
+       tier (the tier just outside the residency tier) across the kernel?
+
+The two questions together let the analyzer walk the memory hierarchy
+innermost-out, find the smallest tier whose capacity holds the residency
+window, and price the kernel's memory time at the next-larger tier's
+achievable bandwidth.
+
+Reuse model derivations live in ``docs/plans/v5-memory-hierarchy-rewrite-plan.md``
+sections "Per-operator reuse models" and "Tier-picking algorithm".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import floor, sqrt
+from typing import Dict, Protocol, Sequence, Tuple, runtime_checkable
+
+
+_BYTES_PER_ELEMENT: Dict[str, float] = {
+    "fp64": 8, "fp32": 4, "tf32": 4,
+    "fp16": 2, "bf16": 2,
+    "int8": 1, "fp8": 1, "fp8_e4m3": 1, "fp8_e5m2": 1,
+    "int4": 0.5, "fp4": 0.5,
+}
+
+
+def bytes_per_element(dtype: str) -> float:
+    if dtype not in _BYTES_PER_ELEMENT:
+        raise ValueError(
+            f"Unknown dtype {dtype!r}; known: {sorted(_BYTES_PER_ELEMENT)}"
+        )
+    return _BYTES_PER_ELEMENT[dtype]
+
+
+@dataclass(frozen=True)
+class TileChoice:
+    """The tile dimensions an op would pick to fit a given tier capacity,
+    plus the bytes that tile occupies in the residency tier.
+
+    ``tile_dims`` is op-specific:
+      vector_add: ``(N,)`` -- the full length (no useful tiling exists)
+      matmul:     ``(Mt, Nt)`` -- the C-tile dimensions
+      linear:     ``(Mt, Nt)`` -- delegated to matmul (M=batch, N=out)
+    """
+
+    tile_dims: Tuple[int, ...]
+    residency_bytes: int
+
+    def __post_init__(self) -> None:
+        if not self.tile_dims:
+            raise ValueError("tile_dims must be non-empty")
+        if any(d < 1 for d in self.tile_dims):
+            raise ValueError(f"tile_dims must be positive: {self.tile_dims}")
+        if self.residency_bytes < 0:
+            raise ValueError(
+                f"residency_bytes must be non-negative: {self.residency_bytes}"
+            )
+
+
+@runtime_checkable
+class ReuseModel(Protocol):
+    """Per-op interface the V5-3b tier picker calls."""
+
+    op_kind: str
+
+    def residency_window(
+        self,
+        shape: Sequence[int],
+        dtype: str,
+        tier_capacity_bytes: int,
+    ) -> TileChoice: ...
+
+    def bytes_loaded_from_binding(
+        self,
+        shape: Sequence[int],
+        dtype: str,
+        tile: TileChoice,
+    ) -> int: ...
+
+
+class VectorAddReuseModel:
+    """``c[i] = a[i] + b[i]`` on N elements -- the zero-reuse op.
+
+    No tile choice helps: each input byte is read exactly once, each
+    output byte is written exactly once. The residency window is the
+    full working set ``3 * N * bpe``; ``tier_capacity_bytes`` is
+    ignored because no smaller tile reduces traffic.
+    """
+
+    op_kind = "vector_add"
+
+    def residency_window(
+        self,
+        shape: Sequence[int],
+        dtype: str,
+        tier_capacity_bytes: int,  # noqa: ARG002 -- intentionally ignored
+    ) -> TileChoice:
+        if len(shape) != 1:
+            raise ValueError(
+                f"vector_add expects 1-D shape, got {tuple(shape)}"
+            )
+        (N,) = shape
+        if N < 1:
+            raise ValueError(f"vector_add requires N >= 1, got {N}")
+        bpe = bytes_per_element(dtype)
+        return TileChoice(
+            tile_dims=(int(N),),
+            residency_bytes=int(round(3 * N * bpe)),
+        )
+
+    def bytes_loaded_from_binding(
+        self,
+        shape: Sequence[int],
+        dtype: str,
+        tile: TileChoice,  # noqa: ARG002 -- not parameterized by tile choice
+    ) -> int:
+        (N,) = shape
+        bpe = bytes_per_element(dtype)
+        return int(round(3 * N * bpe))
+
+
+class MatmulReuseModel:
+    """``C = A @ B`` with shape ``(M, K, N)``.
+
+    Tile heuristic: optimal-square C-tile of side
+    ``t = floor(sqrt(tier_capacity / (3 * bpe)))``, clamped to
+    ``[1, min(M, N)]``. Residency = ``3 * t * t * bpe`` (the C
+    accumulator plus same-area A and B slice scratch).
+
+    Bytes loaded from the binding tier across the kernel
+    (per the plan, section "Per-operator reuse models / Matmul"):
+      * A is reloaded ``ceil(N / Nt)`` times: ``M*K*bpe * (N/Nt)``
+      * B is reloaded ``ceil(M / Mt)`` times: ``K*N*bpe * (M/Mt)``
+      * C is read + written once: ``2 * M * N * bpe``
+    """
+
+    op_kind = "matmul"
+
+    def residency_window(
+        self,
+        shape: Sequence[int],
+        dtype: str,
+        tier_capacity_bytes: int,
+    ) -> TileChoice:
+        if len(shape) != 3:
+            raise ValueError(
+                f"matmul expects 3-D shape (M, K, N), got {tuple(shape)}"
+            )
+        M, K, N = shape  # noqa: F841 -- K unused here, used in bytes_loaded
+        if M < 1 or K < 1 or N < 1:
+            raise ValueError(f"matmul requires positive dims, got {(M, K, N)}")
+        if tier_capacity_bytes < 1:
+            raise ValueError(
+                f"tier_capacity_bytes must be positive: {tier_capacity_bytes}"
+            )
+        bpe = bytes_per_element(dtype)
+        t_max = min(M, N)
+        t_raw = int(floor(sqrt(tier_capacity_bytes / (3 * bpe))))
+        t = max(1, min(t_max, t_raw))
+        return TileChoice(
+            tile_dims=(t, t),
+            residency_bytes=int(round(3 * t * t * bpe)),
+        )
+
+    def bytes_loaded_from_binding(
+        self,
+        shape: Sequence[int],
+        dtype: str,
+        tile: TileChoice,
+    ) -> int:
+        M, K, N = shape
+        bpe = bytes_per_element(dtype)
+        if len(tile.tile_dims) != 2:
+            raise ValueError(
+                f"matmul tile must be 2-D (Mt, Nt), got {tile.tile_dims}"
+            )
+        Mt, Nt = tile.tile_dims
+        a_bytes = M * K * bpe * (N / Nt)
+        b_bytes = K * N * bpe * (M / Mt)
+        c_bytes = 2 * M * N * bpe
+        return int(round(a_bytes + b_bytes + c_bytes))
+
+
+class LinearReuseModel:
+    """``y = x @ W^T + b`` with shape ``(B, IN, OUT)``.
+
+    Algebraically a matmul with ``M=B``, ``K=IN``, ``N=OUT``; the bias
+    add is a separate vector_add and not modeled here. Delegates to
+    :class:`MatmulReuseModel`.
+    """
+
+    op_kind = "linear"
+
+    def __init__(self) -> None:
+        self._delegate = MatmulReuseModel()
+
+    def residency_window(
+        self,
+        shape: Sequence[int],
+        dtype: str,
+        tier_capacity_bytes: int,
+    ) -> TileChoice:
+        if len(shape) != 3:
+            raise ValueError(
+                f"linear expects 3-D shape (B, IN, OUT), got {tuple(shape)}"
+            )
+        B, IN, OUT = shape
+        return self._delegate.residency_window(
+            (B, IN, OUT), dtype, tier_capacity_bytes
+        )
+
+    def bytes_loaded_from_binding(
+        self,
+        shape: Sequence[int],
+        dtype: str,
+        tile: TileChoice,
+    ) -> int:
+        B, IN, OUT = shape
+        return self._delegate.bytes_loaded_from_binding(
+            (B, IN, OUT), dtype, tile
+        )
+
+
+REUSE_MODELS: Dict[str, ReuseModel] = {
+    "vector_add": VectorAddReuseModel(),
+    "matmul": MatmulReuseModel(),
+    "linear": LinearReuseModel(),
+}
+
+
+def get_reuse_model(op_kind: str) -> ReuseModel:
+    """Look up the reuse model for an op kind. Raises if unknown."""
+    if op_kind not in REUSE_MODELS:
+        raise ValueError(
+            f"No reuse model for op_kind={op_kind!r}; "
+            f"known: {sorted(REUSE_MODELS)}"
+        )
+    return REUSE_MODELS[op_kind]
+
+
+__all__ = [
+    "TileChoice",
+    "ReuseModel",
+    "VectorAddReuseModel",
+    "MatmulReuseModel",
+    "LinearReuseModel",
+    "REUSE_MODELS",
+    "bytes_per_element",
+    "get_reuse_model",
+]

--- a/src/graphs/estimation/reuse_models.py
+++ b/src/graphs/estimation/reuse_models.py
@@ -28,10 +28,17 @@ from typing import Dict, Protocol, Sequence, Tuple, runtime_checkable
 
 
 _BYTES_PER_ELEMENT: Dict[str, float] = {
-    "fp64": 8, "fp32": 4, "tf32": 4,
-    "fp16": 2, "bf16": 2,
-    "int8": 1, "fp8": 1, "fp8_e4m3": 1, "fp8_e5m2": 1,
-    "int4": 0.5, "fp4": 0.5,
+    "fp64": 8,
+    "fp32": 4,
+    "tf32": 4,
+    "fp16": 2,
+    "bf16": 2,
+    "int8": 1,
+    "fp8": 1,
+    "fp8_e4m3": 1,
+    "fp8_e5m2": 1,
+    "int4": 0.5,
+    "fp4": 0.5,
 }
 
 
@@ -107,9 +114,7 @@ class VectorAddReuseModel:
         tier_capacity_bytes: int,  # noqa: ARG002 -- intentionally ignored
     ) -> TileChoice:
         if len(shape) != 1:
-            raise ValueError(
-                f"vector_add expects 1-D shape, got {tuple(shape)}"
-            )
+            raise ValueError(f"vector_add expects 1-D shape, got {tuple(shape)}")
         (N,) = shape
         if N < 1:
             raise ValueError(f"vector_add requires N >= 1, got {N}")
@@ -154,9 +159,7 @@ class MatmulReuseModel:
         tier_capacity_bytes: int,
     ) -> TileChoice:
         if len(shape) != 3:
-            raise ValueError(
-                f"matmul expects 3-D shape (M, K, N), got {tuple(shape)}"
-            )
+            raise ValueError(f"matmul expects 3-D shape (M, K, N), got {tuple(shape)}")
         M, K, N = shape  # noqa: F841 -- K unused here, used in bytes_loaded
         if M < 1 or K < 1 or N < 1:
             raise ValueError(f"matmul requires positive dims, got {(M, K, N)}")
@@ -182,9 +185,7 @@ class MatmulReuseModel:
         M, K, N = shape
         bpe = bytes_per_element(dtype)
         if len(tile.tile_dims) != 2:
-            raise ValueError(
-                f"matmul tile must be 2-D (Mt, Nt), got {tile.tile_dims}"
-            )
+            raise ValueError(f"matmul tile must be 2-D (Mt, Nt), got {tile.tile_dims}")
         Mt, Nt = tile.tile_dims
         a_bytes = M * K * bpe * (N / Nt)
         b_bytes = K * N * bpe * (M / Mt)
@@ -216,9 +217,7 @@ class LinearReuseModel:
                 f"linear expects 3-D shape (B, IN, OUT), got {tuple(shape)}"
             )
         B, IN, OUT = shape
-        return self._delegate.residency_window(
-            (B, IN, OUT), dtype, tier_capacity_bytes
-        )
+        return self._delegate.residency_window((B, IN, OUT), dtype, tier_capacity_bytes)
 
     def bytes_loaded_from_binding(
         self,
@@ -227,9 +226,7 @@ class LinearReuseModel:
         tile: TileChoice,
     ) -> int:
         B, IN, OUT = shape
-        return self._delegate.bytes_loaded_from_binding(
-            (B, IN, OUT), dtype, tile
-        )
+        return self._delegate.bytes_loaded_from_binding((B, IN, OUT), dtype, tile)
 
 
 REUSE_MODELS: Dict[str, ReuseModel] = {
@@ -243,8 +240,7 @@ def get_reuse_model(op_kind: str) -> ReuseModel:
     """Look up the reuse model for an op kind. Raises if unknown."""
     if op_kind not in REUSE_MODELS:
         raise ValueError(
-            f"No reuse model for op_kind={op_kind!r}; "
-            f"known: {sorted(REUSE_MODELS)}"
+            f"No reuse model for op_kind={op_kind!r}; " f"known: {sorted(REUSE_MODELS)}"
         )
     return REUSE_MODELS[op_kind]
 

--- a/tests/analysis/test_reuse_models.py
+++ b/tests/analysis/test_reuse_models.py
@@ -1,0 +1,285 @@
+"""Unit tests for the V5-3a per-op reuse models.
+
+Locks in:
+- bytes_per_element rejects unknowns and matches the V4 classifier table
+- VectorAddReuseModel: residency = full WS (no useful tile choice)
+- MatmulReuseModel: optimal-square C-tile, clamped to [1, min(M,N)],
+  bytes_loaded matches the per-plan formula and is monotone non-increasing
+  in tile size.
+- LinearReuseModel delegates to MatmulReuseModel cleanly.
+- get_reuse_model raises on unknown op kinds.
+"""
+
+from math import floor, sqrt
+
+import pytest
+
+from graphs.estimation.reuse_models import (
+    LinearReuseModel,
+    MatmulReuseModel,
+    REUSE_MODELS,
+    ReuseModel,
+    TileChoice,
+    VectorAddReuseModel,
+    bytes_per_element,
+    get_reuse_model,
+)
+
+
+# ---------------------------------------------------------------------------
+# bytes_per_element
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype,expected", [
+    ("fp64", 8), ("fp32", 4), ("tf32", 4),
+    ("fp16", 2), ("bf16", 2),
+    ("int8", 1), ("fp8", 1), ("fp8_e4m3", 1), ("fp8_e5m2", 1),
+    ("int4", 0.5), ("fp4", 0.5),
+])
+def test_bytes_per_element(dtype, expected):
+    assert bytes_per_element(dtype) == expected
+
+
+def test_bytes_per_element_rejects_unknown():
+    with pytest.raises(ValueError, match="Unknown dtype"):
+        bytes_per_element("complex64")
+
+
+# ---------------------------------------------------------------------------
+# TileChoice invariants
+# ---------------------------------------------------------------------------
+
+
+def test_tile_choice_rejects_empty_dims():
+    with pytest.raises(ValueError, match="non-empty"):
+        TileChoice(tile_dims=(), residency_bytes=0)
+
+
+def test_tile_choice_rejects_zero_or_negative_dims():
+    with pytest.raises(ValueError, match="positive"):
+        TileChoice(tile_dims=(0,), residency_bytes=0)
+    with pytest.raises(ValueError, match="positive"):
+        TileChoice(tile_dims=(64, -1), residency_bytes=0)
+
+
+def test_tile_choice_rejects_negative_residency():
+    with pytest.raises(ValueError, match="non-negative"):
+        TileChoice(tile_dims=(64,), residency_bytes=-1)
+
+
+# ---------------------------------------------------------------------------
+# VectorAddReuseModel
+# ---------------------------------------------------------------------------
+
+
+def test_vector_add_residency_is_full_working_set():
+    """Vector add cannot benefit from tiling: residency must be the
+    full working set 3*N*bpe regardless of the tier capacity hint."""
+    model = VectorAddReuseModel()
+    # N=1024 fp32 -> WS = 3 * 1024 * 4 = 12288 bytes
+    tile = model.residency_window((1024,), "fp32", tier_capacity_bytes=512)
+    assert tile.tile_dims == (1024,)
+    assert tile.residency_bytes == 12288
+
+
+def test_vector_add_residency_ignores_tier_capacity_hint():
+    model = VectorAddReuseModel()
+    tile_small = model.residency_window((4096,), "fp32", tier_capacity_bytes=64)
+    tile_huge = model.residency_window((4096,), "fp32", tier_capacity_bytes=10**12)
+    assert tile_small == tile_huge
+
+
+@pytest.mark.parametrize("N,dtype,expected_bytes", [
+    (1024, "fp32", 3 * 1024 * 4),
+    (1024, "fp16", 3 * 1024 * 2),
+    (1, "fp64", 3 * 1 * 8),
+    (256, "int8", 3 * 256 * 1),
+])
+def test_vector_add_bytes_loaded_equals_working_set(N, dtype, expected_bytes):
+    model = VectorAddReuseModel()
+    tile = model.residency_window((N,), dtype, tier_capacity_bytes=10**12)
+    assert model.bytes_loaded_from_binding((N,), dtype, tile) == expected_bytes
+
+
+def test_vector_add_rejects_non_1d_shape():
+    model = VectorAddReuseModel()
+    with pytest.raises(ValueError, match="1-D shape"):
+        model.residency_window((1024, 1024), "fp32", tier_capacity_bytes=10**6)
+
+
+def test_vector_add_rejects_zero_n():
+    model = VectorAddReuseModel()
+    with pytest.raises(ValueError, match="N >= 1"):
+        model.residency_window((0,), "fp32", tier_capacity_bytes=10**6)
+
+
+# ---------------------------------------------------------------------------
+# MatmulReuseModel: tile sizing
+# ---------------------------------------------------------------------------
+
+
+def test_matmul_optimal_square_tile_size_for_small_capacity():
+    """For C=12 KB and fp32, t = floor(sqrt(12288 / 12)) = floor(sqrt(1024)) = 32.
+    Residency = 3 * 32^2 * 4 = 12288 bytes (fully fills the budget)."""
+    model = MatmulReuseModel()
+    tile = model.residency_window(
+        (1024, 1024, 1024), "fp32", tier_capacity_bytes=12288
+    )
+    assert tile.tile_dims == (32, 32)
+    assert tile.residency_bytes == 12288
+
+
+def test_matmul_optimal_square_for_l2_sized_capacity():
+    """L2 = 256 KB on a per-core slice; fp16 -> t = floor(sqrt(256K/6)) = 209.
+    Residency = 3 * 209^2 * 2 = 262_086 bytes."""
+    model = MatmulReuseModel()
+    tier = 256 * 1024
+    tile = model.residency_window((4096, 4096, 4096), "fp16", tier_capacity_bytes=tier)
+    expected_t = int(floor(sqrt(tier / (3 * 2))))
+    assert tile.tile_dims == (expected_t, expected_t)
+    assert tile.residency_bytes <= tier
+
+
+def test_matmul_tile_clamped_to_min_dim():
+    """If sqrt-formula gives a tile > min(M, N), clamp to min(M, N).
+    Shape (4, 65536, 4) fp32, capacity huge: t_raw is enormous, clamped to 4."""
+    model = MatmulReuseModel()
+    tile = model.residency_window((4, 65536, 4), "fp32", tier_capacity_bytes=10**10)
+    assert tile.tile_dims == (4, 4)
+    assert tile.residency_bytes == 3 * 4 * 4 * 4
+
+
+def test_matmul_tile_clamped_to_at_least_one():
+    """If capacity is absurdly small (< one element), clamp t to 1."""
+    model = MatmulReuseModel()
+    tile = model.residency_window((1024, 1024, 1024), "fp32", tier_capacity_bytes=1)
+    assert tile.tile_dims == (1, 1)
+    assert tile.residency_bytes == 3 * 1 * 1 * 4
+
+
+def test_matmul_rejects_non_3d_shape():
+    model = MatmulReuseModel()
+    with pytest.raises(ValueError, match="3-D shape"):
+        model.residency_window((1024, 1024), "fp32", tier_capacity_bytes=10**6)
+
+
+def test_matmul_rejects_non_positive_dims():
+    model = MatmulReuseModel()
+    with pytest.raises(ValueError, match="positive"):
+        model.residency_window((0, 1024, 1024), "fp32", tier_capacity_bytes=10**6)
+
+
+def test_matmul_rejects_non_positive_capacity():
+    model = MatmulReuseModel()
+    with pytest.raises(ValueError, match="tier_capacity_bytes"):
+        model.residency_window((1024, 1024, 1024), "fp32", tier_capacity_bytes=0)
+
+
+# ---------------------------------------------------------------------------
+# MatmulReuseModel: bytes loaded from binding tier
+# ---------------------------------------------------------------------------
+
+
+def test_matmul_bytes_loaded_full_tile_equals_one_pass():
+    """If the tile equals the full output (Mt=M, Nt=N), each input loaded
+    exactly once: A_bytes = M*K*bpe, B_bytes = K*N*bpe, C_bytes = 2*M*N*bpe."""
+    model = MatmulReuseModel()
+    M, K, N = 1024, 1024, 1024
+    bpe = 4
+    tile = TileChoice(tile_dims=(M, N), residency_bytes=3 * M * N * bpe)
+    actual = model.bytes_loaded_from_binding((M, K, N), "fp32", tile)
+    expected = M * K * bpe + K * N * bpe + 2 * M * N * bpe
+    assert actual == expected
+
+
+def test_matmul_bytes_loaded_singleton_tile_equals_no_reuse():
+    """With Mt=Nt=1, each output element forces a full A-row + B-col load
+    once per output, with C read+written once per element. This is the
+    pessimistic no-reuse bound."""
+    model = MatmulReuseModel()
+    M, K, N = 64, 64, 64  # small enough to keep arithmetic tractable
+    bpe = 4
+    tile = TileChoice(tile_dims=(1, 1), residency_bytes=3 * bpe)
+    actual = model.bytes_loaded_from_binding((M, K, N), "fp32", tile)
+    # A: M*K * (N/1) = M*K*N reloads, B: K*N * (M/1) = K*N*M, C: 2*M*N
+    expected = M * K * N * bpe + K * N * M * bpe + 2 * M * N * bpe
+    assert actual == expected
+
+
+def test_matmul_bytes_loaded_monotone_decreasing_in_tile_size():
+    """Larger C-tile -> more reuse -> fewer bytes streamed from the
+    binding tier. Sweep tile sizes for a fixed problem and assert
+    bytes_loaded is monotone non-increasing."""
+    model = MatmulReuseModel()
+    M, K, N = 512, 512, 512
+    last = float("inf")
+    for t in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]:
+        tile = TileChoice(tile_dims=(t, t), residency_bytes=3 * t * t * 4)
+        b = model.bytes_loaded_from_binding((M, K, N), "fp32", tile)
+        assert b <= last, f"non-monotone at t={t}: {b} > {last}"
+        last = b
+
+
+def test_matmul_bytes_loaded_rejects_non_2d_tile():
+    model = MatmulReuseModel()
+    bad_tile = TileChoice(tile_dims=(64,), residency_bytes=64 * 4)
+    with pytest.raises(ValueError, match="2-D"):
+        model.bytes_loaded_from_binding((512, 512, 512), "fp32", bad_tile)
+
+
+# ---------------------------------------------------------------------------
+# LinearReuseModel: delegates to MatmulReuseModel
+# ---------------------------------------------------------------------------
+
+
+def test_linear_residency_matches_matmul():
+    """Linear (B, IN, OUT) must produce the same TileChoice as matmul
+    (B, IN, OUT) for the same dtype and capacity."""
+    lin = LinearReuseModel()
+    mm = MatmulReuseModel()
+    B, IN, OUT = 32, 512, 256
+    cap = 64 * 1024
+    assert (
+        lin.residency_window((B, IN, OUT), "fp32", cap)
+        == mm.residency_window((B, IN, OUT), "fp32", cap)
+    )
+
+
+def test_linear_bytes_loaded_matches_matmul():
+    lin = LinearReuseModel()
+    mm = MatmulReuseModel()
+    B, IN, OUT = 32, 512, 256
+    cap = 64 * 1024
+    tile = lin.residency_window((B, IN, OUT), "fp32", cap)
+    assert (
+        lin.bytes_loaded_from_binding((B, IN, OUT), "fp32", tile)
+        == mm.bytes_loaded_from_binding((B, IN, OUT), "fp32", tile)
+    )
+
+
+def test_linear_rejects_non_3d_shape():
+    lin = LinearReuseModel()
+    with pytest.raises(ValueError, match="3-D shape"):
+        lin.residency_window((512, 256), "fp32", tier_capacity_bytes=10**6)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op_kind", ["vector_add", "matmul", "linear"])
+def test_get_reuse_model_returns_correct_op(op_kind):
+    model = get_reuse_model(op_kind)
+    assert model.op_kind == op_kind
+
+
+def test_get_reuse_model_unknown_raises():
+    with pytest.raises(ValueError, match="No reuse model"):
+        get_reuse_model("conv2d")
+
+
+def test_registry_models_satisfy_protocol():
+    for model in REUSE_MODELS.values():
+        assert isinstance(model, ReuseModel)

--- a/tests/analysis/test_reuse_models.py
+++ b/tests/analysis/test_reuse_models.py
@@ -31,12 +31,22 @@ from graphs.estimation.reuse_models import (
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("dtype,expected", [
-    ("fp64", 8), ("fp32", 4), ("tf32", 4),
-    ("fp16", 2), ("bf16", 2),
-    ("int8", 1), ("fp8", 1), ("fp8_e4m3", 1), ("fp8_e5m2", 1),
-    ("int4", 0.5), ("fp4", 0.5),
-])
+@pytest.mark.parametrize(
+    "dtype,expected",
+    [
+        ("fp64", 8),
+        ("fp32", 4),
+        ("tf32", 4),
+        ("fp16", 2),
+        ("bf16", 2),
+        ("int8", 1),
+        ("fp8", 1),
+        ("fp8_e4m3", 1),
+        ("fp8_e5m2", 1),
+        ("int4", 0.5),
+        ("fp4", 0.5),
+    ],
+)
 def test_bytes_per_element(dtype, expected):
     assert bytes_per_element(dtype) == expected
 
@@ -90,12 +100,15 @@ def test_vector_add_residency_ignores_tier_capacity_hint():
     assert tile_small == tile_huge
 
 
-@pytest.mark.parametrize("N,dtype,expected_bytes", [
-    (1024, "fp32", 3 * 1024 * 4),
-    (1024, "fp16", 3 * 1024 * 2),
-    (1, "fp64", 3 * 1 * 8),
-    (256, "int8", 3 * 256 * 1),
-])
+@pytest.mark.parametrize(
+    "N,dtype,expected_bytes",
+    [
+        (1024, "fp32", 3 * 1024 * 4),
+        (1024, "fp16", 3 * 1024 * 2),
+        (1, "fp64", 3 * 1 * 8),
+        (256, "int8", 3 * 256 * 1),
+    ],
+)
 def test_vector_add_bytes_loaded_equals_working_set(N, dtype, expected_bytes):
     model = VectorAddReuseModel()
     tile = model.residency_window((N,), dtype, tier_capacity_bytes=10**12)
@@ -123,9 +136,7 @@ def test_matmul_optimal_square_tile_size_for_small_capacity():
     """For C=12 KB and fp32, t = floor(sqrt(12288 / 12)) = floor(sqrt(1024)) = 32.
     Residency = 3 * 32^2 * 4 = 12288 bytes (fully fills the budget)."""
     model = MatmulReuseModel()
-    tile = model.residency_window(
-        (1024, 1024, 1024), "fp32", tier_capacity_bytes=12288
-    )
+    tile = model.residency_window((1024, 1024, 1024), "fp32", tier_capacity_bytes=12288)
     assert tile.tile_dims == (32, 32)
     assert tile.residency_bytes == 12288
 
@@ -240,9 +251,8 @@ def test_linear_residency_matches_matmul():
     mm = MatmulReuseModel()
     B, IN, OUT = 32, 512, 256
     cap = 64 * 1024
-    assert (
-        lin.residency_window((B, IN, OUT), "fp32", cap)
-        == mm.residency_window((B, IN, OUT), "fp32", cap)
+    assert lin.residency_window((B, IN, OUT), "fp32", cap) == mm.residency_window(
+        (B, IN, OUT), "fp32", cap
     )
 
 
@@ -252,10 +262,9 @@ def test_linear_bytes_loaded_matches_matmul():
     B, IN, OUT = 32, 512, 256
     cap = 64 * 1024
     tile = lin.residency_window((B, IN, OUT), "fp32", cap)
-    assert (
-        lin.bytes_loaded_from_binding((B, IN, OUT), "fp32", tile)
-        == mm.bytes_loaded_from_binding((B, IN, OUT), "fp32", tile)
-    )
+    assert lin.bytes_loaded_from_binding(
+        (B, IN, OUT), "fp32", tile
+    ) == mm.bytes_loaded_from_binding((B, IN, OUT), "fp32", tile)
 
 
 def test_linear_rejects_non_3d_shape():


### PR DESCRIPTION
## Summary

V5-3a from `docs/plans/v5-memory-hierarchy-rewrite-plan.md`: ships the
per-op reuse models that the V5-3b tier picker will call. **No analyzer
behavior change** -- pure additions, `bw_efficiency_scale` untouched,
all existing V4 floors hold.

## Interface

```python
class ReuseModel(Protocol):
    op_kind: str

    def residency_window(self, shape, dtype, tier_capacity_bytes) -> TileChoice:
        \"\"\"Given a hypothetical residency tier with capacity C bytes, what
        tile would the op pick and what working set does that imply?\"\"\"

    def bytes_loaded_from_binding(self, shape, dtype, tile) -> int:
        \"\"\"Given the chosen tile, how many bytes stream from the *binding*
        tier (the tier just outside the residency tier) per kernel exec?\"\"\"
```

`TileChoice` is `(tile_dims, residency_bytes)` with op-specific dim
semantics: `(N,)` for vector_add, `(Mt, Nt)` for matmul / linear.

## Three implementations

### `VectorAddReuseModel` -- the zero-reuse op
- Residency = full working set 3*N*bpe; tile-size hint ignored
- bytes_loaded equals residency (each byte streamed once, never reused)

### `MatmulReuseModel` -- optimal-square C-tile
- `t = floor(sqrt(C / (3 * bpe)))` clamped to `[1, min(M, N)]`
- Residency = `3 * t^2 * bpe` (C accumulator + same-area A/B scratch)
- Bytes loaded follows the plan's reuse formula:
  - A reloaded `N/Nt` times: `M*K*bpe * (N/Nt)`
  - B reloaded `M/Mt` times: `K*N*bpe * (M/Mt)`
  - C read + written once: `2*M*N*bpe`

### `LinearReuseModel` -- delegates to matmul
- `y = x @ W^T + b` is matmul (M=B, K=IN, N=OUT) algebraically
- Bias add is a separate vector_add, not modeled here

## What this PR is NOT

- Not an analyzer behavior change. ` _get_bandwidth_efficiency_scale`
  and the existing roofline path are untouched.
- Not a calibration. Tier-specific `achievable_fraction` values land
  in V5-5 (per-mapper, anchored on the V5-2b vector_add baselines).
- Not the tier_picker. That's V5-3b -- it consumes this PR's interface.

## Test plan

- [x] 42 new tests in `tests/analysis/test_reuse_models.py`:
  - bytes_per_element coverage + unknown-dtype rejection
  - TileChoice invariants (empty / negative / zero rejected)
  - vector_add: residency = WS, ignores capacity hint, rejects non-1D
  - matmul: tile sizing at small + L2-sized capacities; clamping to
    `min(M, N)` and to `>= 1`; closed-form bytes_loaded for full-tile
    (one-pass) and singleton-tile (no-reuse); monotone non-increasing
    in tile size
  - linear: matches matmul delegate; rejects non-3D
  - Registry: lookup + unknown-op rejection; all registered models
    satisfy the runtime-checkable Protocol
- [x] Existing `tests/analysis/` + `tests/validation_model_v4/`: 410 still green
- [x] CI: full test matrix passes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reuse model framework for enhanced operator performance optimization.

* **Tests**
  * Added comprehensive test suite for new infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->