### PR TITLE
feat(estimation,validation): V5-4 -- memory_explanation + binding tier in V4 reports

### DIFF
--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -35,6 +35,44 @@ if TYPE_CHECKING:
     from ..hardware.calibration.registry_sync import HardwareEntry
 
 
+@dataclass(frozen=True)
+class MemoryExplanation:
+    """V5-4 explainability: structured breakdown of where memory_time
+    came from when the V5-3b tier-aware path fired.
+
+    Populated on ``LatencyDescriptor.memory_explanation`` whenever
+    ``RooflineAnalyzer(use_tier_aware_memory=True)`` successfully routed
+    a subgraph through ``pick_binding_tier``. ``None`` on the scalar
+    ``bw_efficiency_scale`` path -- callers that need to render a
+    binding-tier column should treat ``None`` as "not applicable" and
+    fall back to displaying nothing rather than a placeholder.
+
+    Field semantics:
+      * ``binding_tier_name`` -- the tier whose bandwidth gates kernel
+        throughput (the streaming source one outward from the residency
+        tier). Typical values: 'L1', 'L2', 'L3', 'DRAM'.
+      * ``residency_tier_name`` -- the tier whose capacity holds the
+        per-op residency window. Equal to ``binding_tier_name`` when
+        the kernel is already at the outermost tier (DRAM).
+      * ``tile_dims`` -- op-specific (vector_add: ``(N,)``; matmul /
+        linear: ``(Mt, Nt)`` C-tile dims).
+      * ``residency_bytes`` -- the working set the chosen tile occupies
+        in the residency tier (always <= residency tier's aggregate
+        capacity, except for the DRAM-overflow fallthrough).
+      * ``bytes_loaded`` -- bytes streamed from the binding tier per
+        kernel exec; the numerator of ``memory_time`` in the new path.
+      * ``effective_bandwidth_bps`` -- the binding tier's calibrated
+        BW (peak * achievable_fraction); the denominator of memory_time.
+    """
+
+    binding_tier_name: str
+    residency_tier_name: str
+    tile_dims: Tuple[int, ...]
+    residency_bytes: int
+    bytes_loaded: int
+    effective_bandwidth_bps: float
+
+
 @dataclass
 class LatencyDescriptor:
     """
@@ -79,6 +117,12 @@ class LatencyDescriptor:
     # Explanation
     explanation: str = ""
 
+    # V5-4: structured breakdown of the tier-aware memory_time path.
+    # Populated by RooflineAnalyzer when use_tier_aware_memory=True
+    # and the subgraph passed the V5-3b eligibility predicate. Stays
+    # None on the scalar bw_efficiency_scale path.
+    memory_explanation: Optional[MemoryExplanation] = None
+
     def __str__(self) -> str:
         """Short summary"""
         return (
@@ -107,6 +151,16 @@ class LatencyDescriptor:
         )
         if self.confidence.level != ConfidenceLevel.UNKNOWN:
             lines.append(f"  Confidence: {self.confidence}")
+        if self.memory_explanation is not None:
+            me = self.memory_explanation
+            lines.append(
+                f"  Memory binding: tier={me.binding_tier_name} "
+                f"(residency={me.residency_tier_name}, "
+                f"tile={me.tile_dims}, "
+                f"residency_bytes={me.residency_bytes}, "
+                f"bytes_loaded={me.bytes_loaded}, "
+                f"eff_bw={me.effective_bandwidth_bps / 1e9:.1f} GB/s)"
+            )
         return "\n".join(lines)
 
 
@@ -326,13 +380,15 @@ class RooflineAnalyzer:
         self.efficiency_factor = efficiency_factor
         self.thermal_profile = thermal_profile
         self.use_tier_aware_memory = use_tier_aware_memory
-        # Stash for the V5-3b tier-aware path: when
-        # _try_tier_aware_memory_time succeeds, it writes the
-        # binding-tier bytes_loaded here so _analyze_subgraph can use
-        # the tier-aware byte count for downstream attained_bandwidth
-        # math. Reset per-subgraph by the helper itself; never read
-        # without a successful tier-aware call ahead of it.
+        # Stashes for the V5-3b/V5-4 tier-aware path: when
+        # _try_tier_aware_memory_time succeeds, it writes the binding
+        # tier bytes_loaded + structured MemoryExplanation here so
+        # _analyze_subgraph can use the tier-aware byte count for
+        # downstream attained_bandwidth math AND attach the
+        # explanation to the LatencyDescriptor it returns. Reset by
+        # the helper itself; only read after a successful call.
         self._last_tier_bytes_loaded: int = 0
+        self._last_memory_explanation: Optional["MemoryExplanation"] = None
         self.is_calibrated = (
             efficiency_factor is not None
             or calibrated_peak_flops is not None
@@ -574,6 +630,10 @@ class RooflineAnalyzer:
         # behavior change vs pre-V5-3b. See _try_tier_aware_memory_time
         # for the eligibility predicate.
         if self.use_tier_aware_memory:
+            # Reset the explanation stash before the attempt so that a
+            # decline (returning None) doesn't leave a stale explanation
+            # from a prior subgraph attached to this descriptor.
+            self._last_memory_explanation = None
             tier_memory_time = self._try_tier_aware_memory_time(sg)
             if tier_memory_time is not None:
                 memory_time = tier_memory_time
@@ -651,6 +711,7 @@ class RooflineAnalyzer:
             peak_bandwidth=self.peak_bandwidth,
             bandwidth_utilization=bw_util,
             explanation=explanation,
+            memory_explanation=self._last_memory_explanation,
         )
 
     def _get_compute_efficiency_scale(self, sg: SubgraphDescriptor) -> float:
@@ -1059,6 +1120,14 @@ class RooflineAnalyzer:
 
         memory_time = result.bytes_loaded / bw
         self._last_tier_bytes_loaded = result.bytes_loaded
+        self._last_memory_explanation = MemoryExplanation(
+            binding_tier_name=result.binding_tier.name,
+            residency_tier_name=result.residency_tier.name,
+            tile_dims=tuple(result.tile.tile_dims),
+            residency_bytes=int(result.tile.residency_bytes),
+            bytes_loaded=int(result.bytes_loaded),
+            effective_bandwidth_bps=float(bw),
+        )
         return memory_time
 
     @staticmethod

--- a/tests/analysis/test_roofline_tier_aware.py
+++ b/tests/analysis/test_roofline_tier_aware.py
@@ -247,3 +247,84 @@ def test_opt_in_falls_back_for_unknown_dtype():
         hw, precision=Precision.FP32, use_tier_aware_memory=True
     )._analyze_subgraph(sg)
     assert desc.memory_time > 0
+
+
+# ---------------------------------------------------------------------------
+# V5-4: memory_explanation field is populated when the path fires
+# ---------------------------------------------------------------------------
+
+
+def test_memory_explanation_populated_when_tier_path_fires():
+    """When the V5-3b tier-aware path fires, LatencyDescriptor must
+    carry a fully-populated MemoryExplanation: binding tier, residency
+    tier, tile dims, residency bytes, bytes loaded, effective BW."""
+    sg = _matmul_subgraph(1024, 1024, 1024)
+    hw = create_i7_12700k_mapper().resource_model
+    desc = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )._analyze_subgraph(sg)
+
+    me = desc.memory_explanation
+    assert me is not None
+    # i7-12700K: hierarchy is L1, L3, DRAM (post-V5-1 / #94 build).
+    # 1024^3 fp32 matmul tiles to fit in L1 -> binds at L3.
+    assert me.binding_tier_name in {"L1", "L3", "DRAM"}
+    assert me.residency_tier_name in {"L1", "L3", "DRAM"}
+    assert len(me.tile_dims) == 2  # matmul -> (Mt, Nt)
+    assert me.residency_bytes > 0
+    assert me.bytes_loaded > 0
+    assert me.effective_bandwidth_bps > 0
+
+
+def test_memory_explanation_none_when_path_declines():
+    """Default (off) and decline cases (fused, CONV2D, 3D matmul,
+    unknown dtype) must leave memory_explanation == None so callers
+    can render 'no tier info' without surprise."""
+    hw = create_i7_12700k_mapper().resource_model
+
+    # Default (flag off)
+    desc1 = RooflineAnalyzer(hw, precision=Precision.FP32)._analyze_subgraph(
+        _matmul_subgraph(1024, 1024, 1024)
+    )
+    assert desc1.memory_explanation is None
+
+    # Opt-in but ineligible (fused subgraph)
+    desc2 = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )._analyze_subgraph(_fused_matmul_relu())
+    assert desc2.memory_explanation is None
+
+
+def test_memory_explanation_does_not_leak_across_subgraphs():
+    """The analyzer's per-subgraph stash must reset between calls so
+    a decline (e.g., fused subgraph) doesn't inherit the previous
+    successful subgraph's MemoryExplanation."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )
+
+    # First: a successful tier-path subgraph
+    desc_ok = analyzer._analyze_subgraph(_matmul_subgraph(1024, 1024, 1024))
+    assert desc_ok.memory_explanation is not None
+
+    # Second: a fused subgraph that the predicate rejects -- must come
+    # back with memory_explanation=None, NOT the prior subgraph's value
+    desc_decline = analyzer._analyze_subgraph(_fused_matmul_relu())
+    assert desc_decline.memory_explanation is None
+
+
+def test_memory_explanation_format_summary_renders_breakdown():
+    """LatencyDescriptor.format_summary should include a 'Memory binding'
+    line when memory_explanation is set, so the breakdown surfaces in
+    the human-readable string output without callers having to dig into
+    the structured field."""
+    sg = _matmul_subgraph(1024, 1024, 1024)
+    hw = create_i7_12700k_mapper().resource_model
+    desc = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )._analyze_subgraph(sg)
+
+    summary = desc.format_summary()
+    assert "Memory binding" in summary
+    assert desc.memory_explanation.binding_tier_name in summary

--- a/tests/validation_model_v4/test_report.py
+++ b/tests/validation_model_v4/test_report.py
@@ -18,14 +18,28 @@ from validation.model_v4.harness.report import (
 from validation.model_v4.harness.runner import RunnerResult
 
 
-def _record(*, hardware="i7_12700k", op="matmul", shape=(1024, 1024, 1024),
-            dtype="fp32", regime_predicted="l2_bound",
-            regime_measured="l2_bound",
-            pass_regime=True, pass_latency=True, pass_energy=True,
-            latency_predicted_ms=10.0, latency_measured_ms=10.0,
-            energy_predicted_j=1.0, energy_measured_j=1.0) -> ValidationRecord:
+def _record(
+    *,
+    hardware="i7_12700k",
+    op="matmul",
+    shape=(1024, 1024, 1024),
+    dtype="fp32",
+    regime_predicted="l2_bound",
+    regime_measured="l2_bound",
+    pass_regime=True,
+    pass_latency=True,
+    pass_energy=True,
+    latency_predicted_ms=10.0,
+    latency_measured_ms=10.0,
+    energy_predicted_j=1.0,
+    energy_measured_j=1.0,
+    binding_tier=None,
+) -> ValidationRecord:
     return ValidationRecord(
-        hardware=hardware, op=op, shape=shape, dtype=dtype,
+        hardware=hardware,
+        op=op,
+        shape=shape,
+        dtype=dtype,
         regime_predicted=regime_predicted,
         latency_predicted_ms=latency_predicted_ms,
         energy_predicted_j=energy_predicted_j,
@@ -38,6 +52,7 @@ def _record(*, hardware="i7_12700k", op="matmul", shape=(1024, 1024, 1024),
         tolerance_latency=0.20,
         tolerance_energy=0.25,
         bottleneck_layer="L2 / LLC capacity",
+        binding_tier=binding_tier,
     )
 
 
@@ -64,9 +79,9 @@ def test_aggregate_counts_per_assertion_type():
     """A record can fail multiple assertions; each must be tallied
     independently so the report can attribute correctly."""
     records = [
-        _record(pass_regime=True, pass_latency=True, pass_energy=True),     # all pass
-        _record(pass_regime=False, pass_latency=True, pass_energy=True),    # regime only
-        _record(pass_regime=True, pass_latency=False, pass_energy=True),    # latency only
+        _record(pass_regime=True, pass_latency=True, pass_energy=True),  # all pass
+        _record(pass_regime=False, pass_latency=True, pass_energy=True),  # regime only
+        _record(pass_regime=True, pass_latency=False, pass_energy=True),  # latency only
         _record(pass_regime=False, pass_latency=False, pass_energy=False),  # all fail
     ]
     cells = _aggregate(records)
@@ -82,9 +97,9 @@ def test_aggregate_treats_none_energy_as_not_failed():
     """A record where pass_energy is None (not measured) counts as
     'not failed' for energy aggregation."""
     records = [
-        _record(pass_energy=None),      # not measured -> not a fail
+        _record(pass_energy=None),  # not measured -> not a fail
         _record(pass_energy=True),
-        _record(pass_energy=False),     # only this one is a fail
+        _record(pass_energy=False),  # only this one is a fail
     ]
     cell = _aggregate(records)[("i7_12700k", "matmul", "l2_bound")]
     assert cell.n_fail_energy == 1
@@ -129,8 +144,7 @@ def _result(records, *, no_baseline=0, unsupported=0):
 
 
 def test_format_text_includes_record_skipped_counts():
-    text = format_text(_result([_record()], no_baseline=2, unsupported=3),
-                       op="matmul")
+    text = format_text(_result([_record()], no_baseline=2, unsupported=3), op="matmul")
     assert "records: 1" in text
     assert "skipped(no baseline): 2" in text
     assert "skipped(unsupported): 3" in text
@@ -142,8 +156,11 @@ def test_format_text_renders_heatmap_columns_in_severity_order():
     first."""
     text = format_text(_result([_record()]), op="matmul")
     # Find the header line (one with all four regime names)
-    header_idx = next(i for i, line in enumerate(text.splitlines())
-                      if "alu_bound" in line and "dram_bound" in line)
+    header_idx = next(
+        i
+        for i, line in enumerate(text.splitlines())
+        if "alu_bound" in line and "dram_bound" in line
+    )
     header = text.splitlines()[header_idx]
     assert header.index("alu_bound") < header.index("l2_bound")
     assert header.index("l2_bound") < header.index("dram_bound")
@@ -154,10 +171,18 @@ def test_format_text_lists_failures_with_attribution_tags():
     """Each failure row must show R/L/E tags so the reader can tell
     which assertion drifted."""
     records = [
-        _record(pass_regime=False, pass_latency=True, pass_energy=True,
-                regime_measured="ambiguous"),
-        _record(pass_regime=False, pass_latency=False, pass_energy=False,
-                regime_measured="ambiguous"),
+        _record(
+            pass_regime=False,
+            pass_latency=True,
+            pass_energy=True,
+            regime_measured="ambiguous",
+        ),
+        _record(
+            pass_regime=False,
+            pass_latency=False,
+            pass_energy=False,
+            regime_measured="ambiguous",
+        ),
     ]
     text = format_text(_result(records), op="matmul")
     assert "Failures (2 of 2 records)" in text
@@ -223,11 +248,80 @@ def test_format_json_records_have_full_field_set():
     payload = json.loads(format_json(_result([_record()])))
     rec = payload["records"][0]
     expected = {
-        "hardware", "op", "shape", "dtype",
-        "regime_predicted", "latency_predicted_ms", "energy_predicted_j",
-        "regime_measured", "latency_measured_ms", "energy_measured_j",
-        "pass_regime", "pass_latency", "pass_energy",
-        "tolerance_latency", "tolerance_energy",
-        "bottleneck_layer", "notes",
+        "hardware",
+        "op",
+        "shape",
+        "dtype",
+        "regime_predicted",
+        "latency_predicted_ms",
+        "energy_predicted_j",
+        "regime_measured",
+        "latency_measured_ms",
+        "energy_measured_j",
+        "pass_regime",
+        "pass_latency",
+        "pass_energy",
+        "tolerance_latency",
+        "tolerance_energy",
+        "bottleneck_layer",
+        "notes",
+        # V5-4 addition; must be in the JSON schema even when None
+        "binding_tier",
     }
     assert expected.issubset(set(rec.keys()))
+
+
+# ---------------------------------------------------------------------------
+# V5-4: binding_tier surfaces in the failure detail rows
+# ---------------------------------------------------------------------------
+
+
+def test_format_text_failure_row_shows_binding_tier_when_set():
+    """When a record has binding_tier set (V5-3b tier-aware path fired),
+    the text-format failure row should append a [tier:NAME] suffix so
+    the reader can pinpoint which tier's BW assumption is drifting."""
+    failing = _record(
+        pass_latency=False,
+        latency_predicted_ms=5.0,
+        latency_measured_ms=10.0,
+        binding_tier="L3",
+    )
+    text = format_text(_result([failing]), op="matmul")
+    assert "[tier:L3]" in text
+
+
+def test_format_text_failure_row_omits_binding_tier_suffix_when_none():
+    """When binding_tier is None (V5-3b path didn't fire), the failure
+    row should not append a [tier:None] noise suffix."""
+    failing = _record(
+        pass_latency=False,
+        latency_predicted_ms=5.0,
+        latency_measured_ms=10.0,
+        binding_tier=None,
+    )
+    text = format_text(_result([failing]), op="matmul")
+    assert "[tier:" not in text
+
+
+def test_format_markdown_failures_table_has_binding_tier_column():
+    """The markdown failures table gains a 'binding tier' column. When
+    set, the column shows the tier name; when None, it shows '-'."""
+    records = [
+        _record(
+            pass_latency=False,
+            latency_predicted_ms=5.0,
+            latency_measured_ms=10.0,
+            binding_tier="DRAM",
+        ),
+        _record(
+            pass_regime=False,
+            regime_predicted="dram_bound",
+            regime_measured="alu_bound",
+            binding_tier=None,
+        ),
+    ]
+    md = format_markdown(_result(records), op="matmul")
+    assert "binding tier" in md
+    assert "DRAM" in md
+    # The None record renders as '-' in the column
+    assert "| - |" in md

--- a/validation/model_v4/cli/validate.py
+++ b/validation/model_v4/cli/validate.py
@@ -41,23 +41,53 @@ BASELINE_DIR = Path(__file__).resolve().parents[1] / "results" / "baselines"
 
 
 def _build_argparser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--hw", required=True,
-                   choices=sorted(SWEEP_HW_TO_MAPPER.keys()),
-                   help="Hardware key (matches sweep JSON 'regime_per_hw')")
-    p.add_argument("--op", required=True, choices=["matmul", "linear"],
-                   help="Operator to validate")
-    p.add_argument("--purpose", default="validation",
-                   choices=["validation", "calibration"],
-                   help="Which sweep file to use (default: validation)")
-    p.add_argument("--format", default="text",
-                   choices=["text", "markdown", "json"],
-                   help="Output format")
-    p.add_argument("--baseline-dir", type=Path, default=BASELINE_DIR,
-                   help=f"Where the cached baselines live (default: {BASELINE_DIR})")
-    p.add_argument("--output", type=Path, default=None,
-                   help="Write the report to a file instead of stdout")
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--hw",
+        required=True,
+        choices=sorted(SWEEP_HW_TO_MAPPER.keys()),
+        help="Hardware key (matches sweep JSON 'regime_per_hw')",
+    )
+    p.add_argument(
+        "--op", required=True, choices=["matmul", "linear"], help="Operator to validate"
+    )
+    p.add_argument(
+        "--purpose",
+        default="validation",
+        choices=["validation", "calibration"],
+        help="Which sweep file to use (default: validation)",
+    )
+    p.add_argument(
+        "--format",
+        default="text",
+        choices=["text", "markdown", "json"],
+        help="Output format",
+    )
+    p.add_argument(
+        "--baseline-dir",
+        type=Path,
+        default=BASELINE_DIR,
+        help=f"Where the cached baselines live (default: {BASELINE_DIR})",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write the report to a file instead of stdout",
+    )
+    p.add_argument(
+        "--use-tier-aware-memory",
+        action="store_true",
+        help="V5-3b opt-in: route MATMUL/LINEAR through the "
+        "tier picker so V4 reports show the binding "
+        "tier per shape. Default off keeps the scalar "
+        "bw_efficiency_scale path active (V4 floors "
+        "byte-identical to pre-V5-3b). Will become the "
+        "default after V5-5 calibrates per-tier "
+        "achievable_fraction values.",
+    )
     return p
 
 
@@ -75,6 +105,7 @@ def main(argv: list[str] | None = None) -> int:
         # Prediction-only: do NOT auto-refresh missing measurements.
         refresh_measurements=False,
         measurer=None,
+        use_tier_aware_memory=args.use_tier_aware_memory,
     )
     result = run_sweep(cfg)
 

--- a/validation/model_v4/harness/assertions.py
+++ b/validation/model_v4/harness/assertions.py
@@ -38,18 +38,18 @@ from validation.model_v4.sweeps.classify import Regime
 # FLOPS is a clean spec; widest for LAUNCH_BOUND because launch is
 # inherently noisy.
 TOL_LATENCY: dict[Regime, float] = {
-    Regime.ALU_BOUND:    0.10,
-    Regime.L2_BOUND:     0.20,
-    Regime.DRAM_BOUND:   0.25,
+    Regime.ALU_BOUND: 0.10,
+    Regime.L2_BOUND: 0.20,
+    Regime.DRAM_BOUND: 0.25,
     Regime.LAUNCH_BOUND: 0.30,
 }
 
 # Energy tolerance (relative error). Wider than latency because energy
 # also varies with op mix and DVFS state.
 TOL_ENERGY: dict[Regime, float] = {
-    Regime.ALU_BOUND:    0.15,
-    Regime.L2_BOUND:     0.25,
-    Regime.DRAM_BOUND:   0.30,
+    Regime.ALU_BOUND: 0.15,
+    Regime.L2_BOUND: 0.25,
+    Regime.DRAM_BOUND: 0.30,
     Regime.LAUNCH_BOUND: 0.40,
 }
 
@@ -93,32 +93,40 @@ class ValidationRecord:
 
     # Identity
     hardware: str
-    op: str                                # "matmul" or "linear"
-    shape: tuple                           # (M, K, N) or (B, IN, OUT)
+    op: str  # "matmul" or "linear"
+    shape: tuple  # (M, K, N) or (B, IN, OUT)
     dtype: str
 
     # Predicted (from the analyzer)
-    regime_predicted: str                  # one of Regime.value
+    regime_predicted: str  # one of Regime.value
     latency_predicted_ms: float
-    energy_predicted_j: Optional[float]    # None when energy not modelled
+    energy_predicted_j: Optional[float]  # None when energy not modelled
 
     # Measured (from the ground-truth measurer)
     regime_measured: str
     latency_measured_ms: float
-    energy_measured_j: Optional[float]     # None when RAPL/NVML unreadable
+    energy_measured_j: Optional[float]  # None when RAPL/NVML unreadable
 
     # Per-assertion outcomes
     pass_regime: bool
     pass_latency: bool
-    pass_energy: Optional[bool]            # None when energy not measured
+    pass_energy: Optional[bool]  # None when energy not measured
 
     # Tolerances applied (per-regime, see TOL_LATENCY / TOL_ENERGY)
     tolerance_latency: float
     tolerance_energy: float
 
     # Diagnostics
-    bottleneck_layer: str                  # human-readable: "ALU peak FLOPS", "DRAM BW", ...
-    notes: str = ""                        # free-form, e.g., "L2_BOUND inference soft (v4-1)"
+    bottleneck_layer: str  # human-readable: "ALU peak FLOPS", "DRAM BW", ...
+    notes: str = ""  # free-form, e.g., "L2_BOUND inference soft (v4-1)"
+
+    # V5-4: binding tier from the V5-3b tier-aware roofline path. Set
+    # only when the runner was configured with use_tier_aware_memory=True
+    # AND the analyzer's eligibility predicate fired (single-op
+    # MATMUL/LINEAR with a clean 2D shape on a >=2-tier hierarchy).
+    # None means "tier-aware path didn't run for this record" -- not an
+    # error condition.
+    binding_tier: Optional[str] = None
 
     def all_pass(self) -> bool:
         """True iff every applicable assertion passed.
@@ -152,9 +160,10 @@ class MeasurementContext:
     Pulled out as a struct so the harness can build it once per target
     and reuse across many measurements.
     """
-    peak_flops: float                      # ops/sec at the measurement dtype
+
+    peak_flops: float  # ops/sec at the measurement dtype
     peak_dram_bandwidth_bps: float
-    launch_overhead_s: float               # default 5e-6
+    launch_overhead_s: float  # default 5e-6
 
 
 def infer_regime_measured(
@@ -178,8 +187,11 @@ def infer_regime_measured(
     achieved_flops = flops / measured_latency_s
     achieved_bw = working_set_bytes / measured_latency_s
     flops_util = achieved_flops / ctx.peak_flops if ctx.peak_flops > 0 else 0.0
-    bw_util = (achieved_bw / ctx.peak_dram_bandwidth_bps
-               if ctx.peak_dram_bandwidth_bps > 0 else 0.0)
+    bw_util = (
+        achieved_bw / ctx.peak_dram_bandwidth_bps
+        if ctx.peak_dram_bandwidth_bps > 0
+        else 0.0
+    )
 
     if flops_util >= UTILIZATION_THRESHOLD:
         return Regime.ALU_BOUND
@@ -196,9 +208,9 @@ def infer_regime_measured(
 
 
 _BOTTLENECK_LAYER: dict[Regime, str] = {
-    Regime.ALU_BOUND:    "ALU peak FLOPS",
-    Regime.L2_BOUND:     "L2 / LLC capacity",  # capacity-only in v4-1
-    Regime.DRAM_BOUND:   "DRAM peak bandwidth",
+    Regime.ALU_BOUND: "ALU peak FLOPS",
+    Regime.L2_BOUND: "L2 / LLC capacity",  # capacity-only in v4-1
+    Regime.DRAM_BOUND: "DRAM peak bandwidth",
     Regime.LAUNCH_BOUND: "kernel-launch overhead",
 }
 
@@ -214,12 +226,13 @@ def check_regime(predicted: Regime, measured: Regime) -> tuple[bool, str]:
         return True, ""
     if predicted == Regime.L2_BOUND:
         if measured not in (Regime.ALU_BOUND, Regime.DRAM_BOUND):
-            return True, ("predicted L2_BOUND, measured "
-                          f"{measured.value} (v4-1 soft match)")
-        return False, (f"predicted L2_BOUND, measured "
-                       f"{measured.value} (boundary drift)")
-    return False, (f"predicted {predicted.value}, "
-                   f"measured {measured.value}")
+            return True, (
+                "predicted L2_BOUND, measured " f"{measured.value} (v4-1 soft match)"
+            )
+        return False, (
+            f"predicted L2_BOUND, measured " f"{measured.value} (boundary drift)"
+        )
+    return False, (f"predicted {predicted.value}, " f"measured {measured.value}")
 
 
 def _within_band(predicted: float, measured: float, tol: float) -> bool:
@@ -244,6 +257,7 @@ def assert_record(
     measured_latency_s: float,
     measured_energy_j: Optional[float],
     ctx: MeasurementContext,
+    binding_tier: Optional[str] = None,
 ) -> ValidationRecord:
     """Build a fully-populated ValidationRecord from a prediction +
     measurement pair.
@@ -253,8 +267,9 @@ def assert_record(
     distinguishes "regime drift" from "latency math drift" from "energy
     math drift" in a single run.
     """
-    regime_measured = infer_regime_measured(flops, working_set_bytes,
-                                            measured_latency_s, ctx)
+    regime_measured = infer_regime_measured(
+        flops, working_set_bytes, measured_latency_s, ctx
+    )
     pass_regime, regime_notes = check_regime(regime_predicted, regime_measured)
 
     tol_lat = TOL_LATENCY.get(regime_predicted, 0.30)
@@ -289,4 +304,5 @@ def assert_record(
         tolerance_energy=tol_egy,
         bottleneck_layer=_BOTTLENECK_LAYER.get(regime_predicted, "(unknown)"),
         notes=regime_notes,
+        binding_tier=binding_tier,
     )

--- a/validation/model_v4/harness/report.py
+++ b/validation/model_v4/harness/report.py
@@ -35,6 +35,7 @@ _REGIME_DISPLAY_ORDER = ["alu_bound", "l2_bound", "dram_bound", "launch_bound"]
 @dataclass
 class CellSummary:
     """One (hardware, regime) cell of the heatmap."""
+
     hardware: str
     op: str
     regime: str
@@ -49,7 +50,9 @@ class CellSummary:
         return self.n_total > 0 and self.n_pass == self.n_total
 
 
-def _aggregate(records: List[ValidationRecord]) -> dict[Tuple[str, str, str], CellSummary]:
+def _aggregate(
+    records: List[ValidationRecord],
+) -> dict[Tuple[str, str, str], CellSummary]:
     """Group records by (hardware, op, regime_predicted) and tally
     pass/fail counts per assertion."""
     groups: dict[Tuple[str, str, str], List[ValidationRecord]] = defaultdict(list)
@@ -65,8 +68,11 @@ def _aggregate(records: List[ValidationRecord]) -> dict[Tuple[str, str, str], Ce
         n_fail_lat = sum(1 for r in bucket if not r.pass_latency)
         n_fail_egy = sum(1 for r in bucket if r.pass_energy is False)
         out[(hw, op, regime)] = CellSummary(
-            hardware=hw, op=op, regime=regime,
-            n_total=n_total, n_pass=n_pass,
+            hardware=hw,
+            op=op,
+            regime=regime,
+            n_total=n_total,
+            n_pass=n_pass,
             n_fail_regime=n_fail_regime,
             n_fail_latency=n_fail_lat,
             n_fail_energy=n_fail_egy,
@@ -111,9 +117,11 @@ def format_text(result: RunnerResult, *, op: str = "(any)") -> str:
 
     # Header
     lines.append(f"V4 validation -- op={op}")
-    lines.append(f"  records: {len(result.records)}  "
-                 f"skipped(no baseline): {len(result.skipped_no_baseline)}  "
-                 f"skipped(unsupported): {len(result.skipped_unsupported)}")
+    lines.append(
+        f"  records: {len(result.records)}  "
+        f"skipped(no baseline): {len(result.skipped_no_baseline)}  "
+        f"skipped(unsupported): {len(result.skipped_unsupported)}"
+    )
     lines.append("")
 
     # Heatmap: rows = (hw, op), cols = regime
@@ -123,7 +131,12 @@ def format_text(result: RunnerResult, *, op: str = "(any)") -> str:
     else:
         col_w = max(len(r) for r in _REGIME_DISPLAY_ORDER)
         # Header row
-        header = "  " + " " * 28 + "  " + "  ".join(r.rjust(col_w) for r in _REGIME_DISPLAY_ORDER)
+        header = (
+            "  "
+            + " " * 28
+            + "  "
+            + "  ".join(r.rjust(col_w) for r in _REGIME_DISPLAY_ORDER)
+        )
         lines.append(header)
         lines.append("  " + "-" * (len(header) - 2))
         for hw, op_name in hardware_op_pairs:
@@ -145,15 +158,19 @@ def format_text(result: RunnerResult, *, op: str = "(any)") -> str:
         lines.append("    " + "-" * 100)
         for r in failures[:30]:  # cap so a flood doesn't drown the report
             tag = []
-            if not r.pass_regime: tag.append("R")
-            if not r.pass_latency: tag.append("L")
-            if r.pass_energy is False: tag.append("E")
+            if not r.pass_regime:
+                tag.append("R")
+            if not r.pass_latency:
+                tag.append("L")
+            if r.pass_energy is False:
+                tag.append("E")
+            tier_suffix = f" [tier:{r.binding_tier}]" if r.binding_tier else ""
             lines.append(
                 f"    [{''.join(tag):3s}] {r.op:7s} {str(r.shape):20s} {r.dtype:5s} "
                 f"pred={r.regime_predicted:11s} meas={r.regime_measured:11s} "
                 f"lat={r.latency_predicted_ms:>8.3f}ms vs {r.latency_measured_ms:>8.3f}ms "
                 f"({_relative(r.latency_predicted_ms, r.latency_measured_ms):>+5.0%}) "
-                f"-- {r.bottleneck_layer}"
+                f"-- {r.bottleneck_layer}{tier_suffix}"
             )
         if len(failures) > 30:
             lines.append(f"    ... and {len(failures) - 30} more failures")
@@ -204,15 +221,18 @@ def format_markdown(result: RunnerResult, *, op: str = "(any)") -> str:
     if failures:
         lines.append(f"### Failures ({len(failures)} of {len(result.records)})")
         lines.append("")
-        lines.append("| op | shape | dtype | regime pred -> meas | latency pred vs meas | bottleneck |")
-        lines.append("| --- | --- | --- | --- | --- | --- |")
+        lines.append(
+            "| op | shape | dtype | regime pred -> meas | latency pred vs meas | bottleneck | binding tier |"
+        )
+        lines.append("| --- | --- | --- | --- | --- | --- | --- |")
         for r in failures[:50]:
             lines.append(
                 f"| {r.op} | {r.shape} | {r.dtype} | "
                 f"{r.regime_predicted} -> {r.regime_measured} | "
                 f"{r.latency_predicted_ms:.3f}ms vs {r.latency_measured_ms:.3f}ms "
                 f"({_relative(r.latency_predicted_ms, r.latency_measured_ms):+.0%}) | "
-                f"{r.bottleneck_layer} |"
+                f"{r.bottleneck_layer} | "
+                f"{r.binding_tier or '-'} |"
             )
         if len(failures) > 50:
             lines.append(f"")
@@ -248,14 +268,16 @@ def format_json(result: RunnerResult) -> str:
         },
         "cells": [
             {
-                "hardware": c.hardware, "op": c.op, "regime": c.regime,
-                "n_total": c.n_total, "n_pass": c.n_pass,
+                "hardware": c.hardware,
+                "op": c.op,
+                "regime": c.regime,
+                "n_total": c.n_total,
+                "n_pass": c.n_pass,
                 "n_fail_regime": c.n_fail_regime,
                 "n_fail_latency": c.n_fail_latency,
                 "n_fail_energy": c.n_fail_energy,
             }
-            for c in sorted(cells.values(),
-                            key=lambda x: (x.hardware, x.op, x.regime))
+            for c in sorted(cells.values(), key=lambda x: (x.hardware, x.op, x.regime))
         ],
         "records": [r.to_dict() for r in result.records],
     }

--- a/validation/model_v4/harness/runner.py
+++ b/validation/model_v4/harness/runner.py
@@ -41,6 +41,7 @@ from typing import List, Optional, Tuple
 from graphs.core.structures import (
     OperationType,
     SubgraphDescriptor,
+    create_tensor_descriptor,
 )
 from graphs.estimation.energy import EnergyAnalyzer
 from graphs.estimation.roofline import RooflineAnalyzer
@@ -90,17 +91,23 @@ SWEEP_HW_TO_MAPPER: dict[str, str] = {
 @dataclass
 class RunnerConfig:
     sweep_path: Path
-    hardware_key: str               # sweep-JSON key, e.g. "i7_12700k"
+    hardware_key: str  # sweep-JSON key, e.g. "i7_12700k"
     measurer: Optional[Measurer] = None
-    refresh_measurements: bool = False    # True: capture missing entries via measurer
+    refresh_measurements: bool = False  # True: capture missing entries via measurer
     baseline_dir: Path = field(default=DEFAULT_BASELINE_DIR)
     launch_overhead_s: float = 5e-6
+    # V5-4 opt-in: when True, the runner constructs RooflineAnalyzer
+    # with use_tier_aware_memory=True so each ValidationRecord is
+    # annotated with the binding tier. Default False keeps V4 floors
+    # byte-identical to pre-V5-3b until V5-5 calibrates per-tier
+    # achievable_fraction.
+    use_tier_aware_memory: bool = False
 
 
 @dataclass
 class RunnerResult:
     records: List[ValidationRecord]
-    skipped_no_baseline: List[Tuple[str, tuple, str]]   # (op, shape, dtype)
+    skipped_no_baseline: List[Tuple[str, tuple, str]]  # (op, shape, dtype)
     skipped_unsupported: List[Tuple[str, tuple, str]]
 
 
@@ -140,7 +147,12 @@ def run_sweep(config: RunnerConfig) -> RunnerResult:
         sg = _build_subgraph(op, shape, dtype)
         precision = _resolve_precision(dtype)
 
-        latency_pred_s = _predict_latency_s(sg, hw, precision)
+        latency_pred_s, binding_tier = _predict_latency_s(
+            sg,
+            hw,
+            precision,
+            use_tier_aware_memory=config.use_tier_aware_memory,
+        )
         energy_pred_j = _predict_energy_j(sg, hw, precision, latency_pred_s)
 
         # Lookup or capture the measurement
@@ -175,6 +187,7 @@ def run_sweep(config: RunnerConfig) -> RunnerResult:
             measured_latency_s=meas.latency_s,
             measured_energy_j=meas.energy_j,
             ctx=ctx,
+            binding_tier=binding_tier,
         )
         records.append(rec)
 
@@ -192,13 +205,20 @@ def run_sweep(config: RunnerConfig) -> RunnerResult:
 
 def _resolve_precision(dtype: str) -> Precision:
     table = {
-        "fp64": Precision.FP64, "fp32": Precision.FP32, "tf32": Precision.TF32,
-        "fp16": Precision.FP16, "bf16": Precision.BF16,
-        "fp8": Precision.FP8, "fp8_e4m3": Precision.FP8_E4M3,
+        "fp64": Precision.FP64,
+        "fp32": Precision.FP32,
+        "tf32": Precision.TF32,
+        "fp16": Precision.FP16,
+        "bf16": Precision.BF16,
+        "fp8": Precision.FP8,
+        "fp8_e4m3": Precision.FP8_E4M3,
         "fp8_e5m2": Precision.FP8_E5M2,
-        "int64": Precision.INT64, "int32": Precision.INT32,
-        "int16": Precision.INT16, "int8": Precision.INT8,
-        "int4": Precision.INT4, "fp4": Precision.FP4,
+        "int64": Precision.INT64,
+        "int32": Precision.INT32,
+        "int16": Precision.INT16,
+        "int8": Precision.INT8,
+        "int4": Precision.INT4,
+        "fp4": Precision.FP4,
     }
     if dtype.lower() not in table:
         raise ValueError(f"Unknown dtype {dtype!r}")
@@ -211,9 +231,22 @@ def _build_subgraph(op: str, shape: tuple, dtype: str) -> SubgraphDescriptor:
     Bypasses the partitioner -- the v4 harness owns the closed-form
     footprint formula in classify.op_footprint, so a partitioner
     regression cannot silently shift the harness baseline.
+
+    V5-4: also populates ``input_tensors`` / ``weight_tensors`` /
+    ``output_tensors`` with the canonical shapes per op kind so the
+    V5-3b roofline tier-aware path (when opted in) can extract
+    (M, K, N) / (B, IN, OUT) / (N,) from the subgraph. Without these
+    fields the V5-3b shape extractors return None and the analyzer
+    silently falls back to the scalar path -- which would defeat
+    V5-4's whole point of surfacing binding tiers in V4 reports.
     """
     fp = op_footprint(op, shape, dtype)
     bpe = bytes_per_element(dtype)
+    # Use a dtype string that TensorDescriptor / RooflineAnalyzer
+    # normalize_dtype both speak. The V4 dtype shortform ('fp32') is
+    # passed through normalize_dtype since 'fp32' is already a valid
+    # bytes_per_element key.
+    td_dtype = dtype
 
     if op == "matmul":
         M, K, N = shape
@@ -222,6 +255,12 @@ def _build_subgraph(op: str, shape: tuple, dtype: str) -> SubgraphDescriptor:
         output_bytes = int(round(M * N * bpe))
         weight_bytes = 0
         op_type = OperationType.MATMUL
+        input_tensors = [
+            create_tensor_descriptor((M, K), td_dtype),
+            create_tensor_descriptor((K, N), td_dtype),
+        ]
+        output_tensors = [create_tensor_descriptor((M, N), td_dtype)]
+        weight_tensors: list = []
     elif op == "linear":
         B, IN, OUT = shape
         input_bytes = int(round(B * IN * bpe))
@@ -229,6 +268,9 @@ def _build_subgraph(op: str, shape: tuple, dtype: str) -> SubgraphDescriptor:
         # Weight matrix + bias (mirrors what build_linear() actually allocates)
         weight_bytes = int(round((IN * OUT + OUT) * bpe))
         op_type = OperationType.LINEAR
+        input_tensors = [create_tensor_descriptor((B, IN), td_dtype)]
+        output_tensors = [create_tensor_descriptor((B, OUT), td_dtype)]
+        weight_tensors = [create_tensor_descriptor((OUT, IN), td_dtype)]
     elif op == "vector_add":
         # c[i] = a[i] + b[i]. Two N-element inputs, one N-element output,
         # no weights. The zero-reuse op the V5 plan uses for tier-BW
@@ -238,6 +280,12 @@ def _build_subgraph(op: str, shape: tuple, dtype: str) -> SubgraphDescriptor:
         output_bytes = int(round(N_elems * bpe))
         weight_bytes = 0
         op_type = OperationType.ELEMENTWISE
+        input_tensors = [
+            create_tensor_descriptor((N_elems,), td_dtype),
+            create_tensor_descriptor((N_elems,), td_dtype),
+        ]
+        output_tensors = [create_tensor_descriptor((N_elems,), td_dtype)]
+        weight_tensors = []
     else:
         raise ValueError(f"Unsupported op {op!r} for v4 runner")
 
@@ -252,30 +300,54 @@ def _build_subgraph(op: str, shape: tuple, dtype: str) -> SubgraphDescriptor:
         total_input_bytes=input_bytes,
         total_output_bytes=output_bytes,
         total_weight_bytes=weight_bytes,
+        input_tensors=input_tensors,
+        output_tensors=output_tensors,
+        weight_tensors=weight_tensors,
     )
 
 
-def _predict_latency_s(sg: SubgraphDescriptor,
-                       hw: HardwareResourceModel,
-                       precision: Precision) -> float:
+def _predict_latency_s(
+    sg: SubgraphDescriptor,
+    hw: HardwareResourceModel,
+    precision: Precision,
+    *,
+    use_tier_aware_memory: bool = False,
+) -> Tuple[float, Optional[str]]:
     """Run the subgraph through RooflineAnalyzer (the same code path
-    UnifiedAnalyzer uses) and return the predicted latency in seconds."""
-    analyzer = RooflineAnalyzer(hw, precision=precision)
+    UnifiedAnalyzer uses) and return ``(latency_s, binding_tier_name)``.
+
+    ``binding_tier_name`` is populated only when ``use_tier_aware_memory``
+    is True AND the V5-3b eligibility predicate passes (single-op
+    MATMUL/LINEAR with a clean 2D shape on a >=2-tier hierarchy).
+    Otherwise it's None and callers should treat that as "the tier-aware
+    path didn't fire" rather than an error.
+    """
+    analyzer = RooflineAnalyzer(
+        hw, precision=precision, use_tier_aware_memory=use_tier_aware_memory
+    )
     lat = analyzer._analyze_subgraph(sg)
-    return float(lat.actual_latency)
+    binding_tier = (
+        lat.memory_explanation.binding_tier_name
+        if lat.memory_explanation is not None
+        else None
+    )
+    return float(lat.actual_latency), binding_tier
 
 
-def _predict_energy_j(sg: SubgraphDescriptor,
-                      hw: HardwareResourceModel,
-                      precision: Precision,
-                      latency_s: float) -> Optional[float]:
+def _predict_energy_j(
+    sg: SubgraphDescriptor,
+    hw: HardwareResourceModel,
+    precision: Precision,
+    latency_s: float,
+) -> Optional[float]:
     """Predict energy via EnergyAnalyzer. Returns None if the analyzer
     raises (e.g., precision unsupported by the energy model)."""
     try:
         analyzer = EnergyAnalyzer(hw, precision=precision)
         report = analyzer.analyze(subgraphs=[sg], latencies=[latency_s])
-        return float(report.compute_energy_j + report.memory_energy_j
-                     + report.static_energy_j)
+        return float(
+            report.compute_energy_j + report.memory_energy_j + report.static_energy_j
+        )
     except Exception:
         return None
 


### PR DESCRIPTION
## Summary

V5-4 from `docs/plans/v5-memory-hierarchy-rewrite-plan.md`: ships
the explainability surface for the V5-3b tier-aware path. Default
opt-out preserves V4 floors byte-for-byte; opt-in with
`--use-tier-aware-memory` (or `RunnerConfig.use_tier_aware_memory=True`)
makes V4 failure rows show the binding tier per shape.

## What landed

### `MemoryExplanation` + `LatencyDescriptor.memory_explanation`
Frozen dataclass capturing the V5-3b tier picker's decision:
- `binding_tier_name` (e.g. 'L1', 'L3', 'DRAM')
- `residency_tier_name`
- `tile_dims` (op-specific: `(N,)` vector_add, `(Mt, Nt)` matmul/linear)
- `residency_bytes`, `bytes_loaded`, `effective_bandwidth_bps`

Populated only when the V5-3b tier-aware path fires; `None` otherwise
(scalar path, declined opt-in, or default off). The analyzer resets
the stash before each `_try_tier_aware_memory_time` call so a
decline never inherits a prior subgraph's explanation.

`LatencyDescriptor.format_summary` now renders a 'Memory binding'
line when set.

### V4 harness wiring
- `RunnerConfig.use_tier_aware_memory: bool = False` opt-in
- `_build_subgraph` populates `input_tensors` / `weight_tensors` /
  `output_tensors` for matmul / linear / vector_add. Without these
  the V5-3b shape extractors return None and the analyzer silently
  falls back to scalar even with the flag on -- defeating V5-4's
  whole point.
- `ValidationRecord.binding_tier: Optional[str] = None` (additive)
- `assert_record(binding_tier=...)` keyword arg
- `_predict_latency_s` returns `(latency_s, binding_tier_name)`

### V4 report output
- `format_text` failure rows: `' [tier:NAME]'` suffix when set,
  nothing when None
- `format_markdown` failures table: new 'binding tier' column
- `format_json`: passes through via `to_dict()` automatically

### CLI
`--use-tier-aware-memory` flag on
`validation/model_v4/cli/validate.py`.

## Smoke-test result (i7-12700K matmul, 60 records)

```
[L  ] matmul (64, 192, 768)  fp32 pred=l2_bound   meas=ambiguous lat=0.051ms vs 0.042ms (+23%) -- L2 / LLC capacity [tier:L3]
[RE ] matmul (64, 1024, 8192) fp32 pred=dram_bound meas=ambiguous lat=2.486ms vs 3.277ms (-24%) -- DRAM peak bandwidth [tier:L3]
```

Every failure shows `[tier:L3]`. The V5-3b tier picker correctly
identifies L3 as binding for these matmul shapes (their optimal-square
C-tile fits in L1; streaming source = L3, not DRAM) -- even when the
V4 regime classifier called them `dram_bound`. **This is exactly the
V5-5 calibration signal the plan called for**: failures cluster at
the L3 tier, so V5-5 can dial in `L3.achievable_fraction` to fix
them.

## Test plan

- [x] **7 new tests**:
  - `tests/analysis/test_roofline_tier_aware.py` (4):
    `memory_explanation` populated when path fires; None on
    default-off + decline; no leak across subgraphs;
    `format_summary` renders the breakdown
  - `tests/validation_model_v4/test_report.py` (3): text-format
    `[tier:NAME]` suffix when set / omitted when None;
    markdown failures table has 'binding tier' column;
    JSON schema includes `binding_tier` even when None
- [x] **V4 floor preservation**: 437 pre-V5-4 tests still pass; the
  existing `test_default_off_produces_identical_memory_time_to_pre_v5_3b`
  pins this
- [x] CLI smoke-tested end-to-end (`--use-tier-aware-memory` produces
  `[tier:L3]` annotations on real i7 baseline)
- [x] Total: 444 passed locally
- [ ] CI: full matrix passes

## What this PR is NOT

- Not the default-on flip. V5-3b's flag stays opt-in until V5-5
  calibrates per-tier `achievable_fraction`.
- Not a visualizer annotation mode. The plan mentions 'visualizer
  adds a per-shape annotation mode' as part of V5-4; deferring as a
  V5-4 follow-up since the report column is the load-bearing
  exit-criterion deliverable.

Generated with [Claude Code](https://claude.com/claude-code)