### PR TITLE
feat(hardware): V5-5 -- DRAM achievable_fraction calibration for i7 + Orin Nano

### DIFF
--- a/src/graphs/hardware/mappers/cpu.py
+++ b/src/graphs/hardware/mappers/cpu.py
@@ -1132,6 +1132,11 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
             "consumer-continuous-large": thermal_profile,
         },
         default_thermal_profile="consumer-continuous-large",
+        # V5-5: same physical DDR5 subsystem as create_i7_12700k_mapper(),
+        # so the calibrated DRAM achievable_fraction applies identically.
+        # See the tiny-model variant for derivation (median 35 GB/s
+        # plateau on N=16M/67M/268M vector_add baseline; peak 75 GB/s).
+        tier_achievable_fractions={"DRAM": 0.47},
     )
 
     return CPUMapper(model)

--- a/src/graphs/hardware/mappers/cpu.py
+++ b/src/graphs/hardware/mappers/cpu.py
@@ -45,6 +45,7 @@ class CPUVectorization:
     CPUs use SIMD (Single Instruction Multiple Data) to process
     multiple elements in parallel within a single core.
     """
+
     simd_width: int  # Elements processed in parallel (8 for AVX-2, 16 for AVX-512)
     vector_operations: int  # Number of SIMD operations needed
     scalar_operations: int  # Remaining scalar operations (not vectorized)
@@ -75,13 +76,15 @@ class CPUMapper(HardwareMapper):
         self,
         resource_model: HardwareResourceModel,
         thermal_profile: str = None,
-        calibration = None  # Type hint: Optional[HardwareCalibration]
+        calibration=None,  # Type hint: Optional[HardwareCalibration]
     ):
         super().__init__(resource_model, thermal_profile=thermal_profile)
 
         # Validate this is a CPU model
         if resource_model.hardware_type.value != "cpu":
-            raise ValueError(f"CPUMapper requires CPU resource model, got {resource_model.hardware_type}")
+            raise ValueError(
+                f"CPUMapper requires CPU resource model, got {resource_model.hardware_type}"
+            )
 
         # CPU-specific parameters
         self.simd_width = resource_model.warp_size  # Reuse warp_size for SIMD width
@@ -93,9 +96,7 @@ class CPUMapper(HardwareMapper):
         self.default_efficiency = 0.20  # Fallback if no calibration available
 
     def compute_energy_with_idle_power(
-        self,
-        latency: float,
-        dynamic_energy: float
+        self, latency: float, dynamic_energy: float
     ) -> Tuple[float, float]:
         """
         Compute total energy including idle power consumption.
@@ -124,19 +125,25 @@ class CPUMapper(HardwareMapper):
         # Datacenter CPUs have multiple thermal profiles (different core counts, frequencies)
         tdp_watts = None
         if self.thermal_profile and self.resource_model.thermal_operating_points:
-            thermal_point = self.resource_model.thermal_operating_points.get(self.thermal_profile)
+            thermal_point = self.resource_model.thermal_operating_points.get(
+                self.thermal_profile
+            )
             if thermal_point:
                 tdp_watts = thermal_point.tdp_watts
 
         # If no thermal profile specified, try to use the first available one
         if tdp_watts is None and self.resource_model.thermal_operating_points:
             # Try "default" first
-            default_thermal = self.resource_model.thermal_operating_points.get("default")
+            default_thermal = self.resource_model.thermal_operating_points.get(
+                "default"
+            )
             if default_thermal:
                 tdp_watts = default_thermal.tdp_watts
             else:
                 # Use the first available thermal profile
-                first_profile = next(iter(self.resource_model.thermal_operating_points.values()), None)
+                first_profile = next(
+                    iter(self.resource_model.thermal_operating_points.values()), None
+                )
                 if first_profile:
                     tdp_watts = first_profile.tdp_watts
 
@@ -160,9 +167,7 @@ class CPUMapper(HardwareMapper):
         return total_energy, average_power
 
     def _analyze_vectorization(
-        self,
-        subgraph: FusedSubgraph,
-        precision: Precision
+        self, subgraph: FusedSubgraph, precision: Precision
     ) -> CPUVectorization:
         """
         Analyze how well an operation vectorizes on CPU SIMD units.
@@ -178,15 +183,21 @@ class CPUMapper(HardwareMapper):
         # AVX-512: 16 FP32, 32 FP16, 64 INT8
         # AVX-2:   8 FP32, 16 FP16, 32 INT8
         bytes_per_element = self._get_bytes_per_element(precision)
-        vector_register_bytes = 64 if self.simd_width >= 16 else 32  # 512-bit or 256-bit
+        vector_register_bytes = (
+            64 if self.simd_width >= 16 else 32
+        )  # 512-bit or 256-bit
         effective_simd_width = vector_register_bytes // bytes_per_element
 
         # For matrix operations (Conv, Linear), vectorization is good
         # For element-wise ops (ReLU, Add), vectorization is excellent
-        is_matrix_op = any(op.value in ['conv2d', 'linear', 'matmul']
-                          for op in subgraph.operation_types)
-        is_elementwise = any(op.value in ['relu', 'relu6', 'gelu', 'sigmoid']
-                            for op in subgraph.operation_types)
+        is_matrix_op = any(
+            op.value in ["conv2d", "linear", "matmul"]
+            for op in subgraph.operation_types
+        )
+        is_elementwise = any(
+            op.value in ["relu", "relu6", "gelu", "sigmoid"]
+            for op in subgraph.operation_types
+        )
 
         # Estimate vectorization efficiency
         if is_elementwise:
@@ -197,14 +208,24 @@ class CPUMapper(HardwareMapper):
             vectorization_efficiency = 0.70  # Conservative estimate
 
         # Calculate vector operations
-        total_ops = subgraph.total_flops if subgraph.total_flops > 0 else subgraph.total_macs * 2
+        total_ops = (
+            subgraph.total_flops
+            if subgraph.total_flops > 0
+            else subgraph.total_macs * 2
+        )
         vectorizable_ops = int(total_ops * vectorization_efficiency)
         vector_operations = math.ceil(vectorizable_ops / effective_simd_width)
         scalar_operations = total_ops - vectorizable_ops
 
         # Check for special accelerators (AMX for matrix ops, VNNI for INT8)
-        uses_amx = is_matrix_op and precision in [Precision.BF16, Precision.INT8] and self.simd_width >= 16
-        uses_vnni = is_matrix_op and precision == Precision.INT8 and self.simd_width >= 8
+        uses_amx = (
+            is_matrix_op
+            and precision in [Precision.BF16, Precision.INT8]
+            and self.simd_width >= 16
+        )
+        uses_vnni = (
+            is_matrix_op and precision == Precision.INT8 and self.simd_width >= 8
+        )
 
         return CPUVectorization(
             simd_width=effective_simd_width,
@@ -248,7 +269,7 @@ class CPUMapper(HardwareMapper):
         ops = [op.value for op in subgraph.operation_types]
 
         # Matrix multiplication (highest priority for compute-bound ops)
-        if any(op in ['matmul', 'linear', 'addmm', 'bmm'] for op in ops):
+        if any(op in ["matmul", "linear", "addmm", "bmm"] for op in ops):
             # Estimate matrix size from memory footprint
             # For matmul: C = A @ B where A is [M, K], B is [K, N], C is [M, N]
             # Memory = M*K + K*N + M*N elements
@@ -259,29 +280,32 @@ class CPUMapper(HardwareMapper):
 
             # Categorize by size
             if matrix_size < 768:
-                size_category = 'small'
+                size_category = "small"
             elif matrix_size < 3072:
-                size_category = 'medium'
+                size_category = "medium"
             else:
-                size_category = 'large'
+                size_category = "large"
 
-            return 'matmul', {'matrix_size': matrix_size}
+            return "matmul", {"matrix_size": matrix_size}
 
         # Convolution
-        if any('conv' in op for op in ops):
-            return 'conv2d', {}
+        if any("conv" in op for op in ops):
+            return "conv2d", {}
 
         # Element-wise operations (memory-bound)
-        if any(op in ['relu', 'relu6', 'gelu', 'sigmoid', 'add', 'mul', 'sub'] for op in ops):
+        if any(
+            op in ["relu", "relu6", "gelu", "sigmoid", "add", "mul", "sub"]
+            for op in ops
+        ):
             # Use 'add' as proxy for memory-bound elementwise ops
-            return 'add', {}
+            return "add", {}
 
         # Pooling
-        if any('pool' in op for op in ops):
-            return 'maxpool', {}
+        if any("pool" in op for op in ops):
+            return "maxpool", {}
 
         # Default: unknown operation
-        return 'unknown', {}
+        return "unknown", {}
 
     def _get_calibrated_efficiency(self, subgraph: FusedSubgraph) -> float:
         """
@@ -315,7 +339,7 @@ class CPUMapper(HardwareMapper):
         subgraph: FusedSubgraph,
         execution_stage: int,
         concurrent_subgraphs: int,
-        precision: Precision = Precision.FP32
+        precision: Precision = Precision.FP32,
     ) -> HardwareAllocation:
         """
         Map a single fused subgraph to CPU cores.
@@ -353,12 +377,14 @@ class CPUMapper(HardwareMapper):
                 # But effectiveness diminishes (Amdahl's law)
                 extra_parallelism = min(
                     self.cores - cores_allocated,
-                    subgraph.parallelism.channels // 4  # Need enough work per core
+                    subgraph.parallelism.channels // 4,  # Need enough work per core
                 )
                 cores_allocated = min(cores_allocated + extra_parallelism, self.cores)
 
         cores_allocated = max(1, cores_allocated)  # At least 1 core
-        threads_required = cores_allocated  # 1 thread per core (SMT doesn't help compute)
+        threads_required = (
+            cores_allocated  # 1 thread per core (SMT doesn't help compute)
+        )
 
         # Calculate occupancy (what fraction of cores are busy)
         occupancy = cores_allocated / self.cores
@@ -367,11 +393,15 @@ class CPUMapper(HardwareMapper):
         utilization = cores_allocated / self.cores
 
         # Calculate latency using roofline model
-        ops = subgraph.total_flops if subgraph.total_flops > 0 else subgraph.total_macs * 2
+        ops = (
+            subgraph.total_flops
+            if subgraph.total_flops > 0
+            else subgraph.total_macs * 2
+        )
         bytes_transferred = (
-            subgraph.total_input_bytes +
-            subgraph.total_output_bytes +
-            subgraph.total_weight_bytes
+            subgraph.total_input_bytes
+            + subgraph.total_output_bytes
+            + subgraph.total_weight_bytes
         )
 
         # Adjust ops for vectorization
@@ -395,7 +425,7 @@ class CPUMapper(HardwareMapper):
             bytes_transferred=bytes_transferred,
             allocated_units=cores_allocated,
             occupancy=occupancy,
-            precision=precision
+            precision=precision,
         )
 
         # Apply calibration correction if available
@@ -411,22 +441,24 @@ class CPUMapper(HardwareMapper):
             # Memory bandwidth correction
             # If measured bandwidth is lower than theoretical, memory ops are slower
             theoretical_bandwidth = self.resource_model.peak_bandwidth
-            measured_bandwidth = self.calibration.measured_bandwidth_gbps * 1e9  # Convert GB/s to bytes/s
+            measured_bandwidth = (
+                self.calibration.measured_bandwidth_gbps * 1e9
+            )  # Convert GB/s to bytes/s
             bandwidth_correction = theoretical_bandwidth / measured_bandwidth
             memory_time *= bandwidth_correction
 
         # Add threading overhead (OpenMP-style parallelism has overhead)
         # More cores = more overhead for synchronization
-        threading_overhead = 1.0 + (cores_allocated - 1) * 0.02  # 2% overhead per additional core
+        threading_overhead = (
+            1.0 + (cores_allocated - 1) * 0.02
+        )  # 2% overhead per additional core
         compute_time *= threading_overhead
 
         estimated_latency = max(compute_time, memory_time)
 
         # Calculate energy
         compute_energy, memory_energy = self._calculate_energy(
-            ops=ops,
-            bytes_transferred=bytes_transferred,
-            precision=precision
+            ops=ops, bytes_transferred=bytes_transferred, precision=precision
         )
         total_energy = compute_energy + memory_energy
 
@@ -459,7 +491,7 @@ class CPUMapper(HardwareMapper):
         fusion_report: FusionReport,
         execution_stages: List[List[int]],
         batch_size: int = 1,
-        precision: Precision = Precision.FP32
+        precision: Precision = Precision.FP32,
     ) -> GraphHardwareAllocation:
         """
         Map entire computation graph to CPU.
@@ -495,6 +527,7 @@ class CPUMapper(HardwareMapper):
                 # Scale parallelism by batch size
                 if subgraph.parallelism and batch_size > 1:
                     import copy
+
                     subgraph = copy.copy(subgraph)
                     subgraph.parallelism = copy.copy(subgraph.parallelism)
                     subgraph.parallelism.batch *= batch_size
@@ -504,14 +537,16 @@ class CPUMapper(HardwareMapper):
                     subgraph=subgraph,
                     execution_stage=stage_id,
                     concurrent_subgraphs=concurrent_subgraphs,
-                    precision=precision
+                    precision=precision,
                 )
                 stage_allocations.append(allocation)
                 subgraph_allocations.append(allocation)
 
             # For parallel subgraphs: max cores used, max latency
             if stage_allocations:
-                stage_cores_used = max(a.compute_units_allocated for a in stage_allocations)
+                stage_cores_used = max(
+                    a.compute_units_allocated for a in stage_allocations
+                )
                 stage_latency = max(a.estimated_latency for a in stage_allocations)
 
                 peak_cores_used = max(peak_cores_used, stage_cores_used)
@@ -523,7 +558,9 @@ class CPUMapper(HardwareMapper):
         # Calculate aggregate metrics
         total_subgraphs = len(subgraph_allocations)
         total_execution_stages = len(execution_stages)
-        average_cores_used = total_cores_used / total_cores_samples if total_cores_samples > 0 else 0
+        average_cores_used = (
+            total_cores_used / total_cores_samples if total_cores_samples > 0 else 0
+        )
 
         total_cores = self.resource_model.compute_units
         peak_utilization = peak_cores_used / total_cores
@@ -544,13 +581,29 @@ class CPUMapper(HardwareMapper):
         naive_latency = total_ops / peak_ops_per_sec if peak_ops_per_sec > 0 else 0
 
         # Correction factor
-        latency_correction_factor = total_latency / naive_latency if naive_latency > 0 else 1.0
+        latency_correction_factor = (
+            total_latency / naive_latency if naive_latency > 0 else 1.0
+        )
 
         # Bottleneck analysis
-        compute_bound_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.COMPUTE_BOUND)
-        memory_bound_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.MEMORY_BOUND)
-        bandwidth_bound_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.BANDWIDTH_BOUND)
-        balanced_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.BALANCED)
+        compute_bound_count = sum(
+            1
+            for a in subgraph_allocations
+            if a.bottleneck == BottleneckType.COMPUTE_BOUND
+        )
+        memory_bound_count = sum(
+            1
+            for a in subgraph_allocations
+            if a.bottleneck == BottleneckType.MEMORY_BOUND
+        )
+        bandwidth_bound_count = sum(
+            1
+            for a in subgraph_allocations
+            if a.bottleneck == BottleneckType.BANDWIDTH_BOUND
+        )
+        balanced_count = sum(
+            1 for a in subgraph_allocations if a.bottleneck == BottleneckType.BALANCED
+        )
 
         return GraphHardwareAllocation(
             model_name="Unknown",
@@ -688,7 +741,7 @@ def create_i7_12700k_mapper() -> CPUMapper:
     # CLOCK DOMAIN (P-cores dominate)
     # ========================================================================
     clock = ClockDomain(
-        base_clock_hz=3.6e9,       # 3.6 GHz base (P-cores)
+        base_clock_hz=3.6e9,  # 3.6 GHz base (P-cores)
         max_boost_clock_hz=5.0e9,  # 5.0 GHz max boost (single P-core)
         sustained_clock_hz=4.5e9,  # 4.5 GHz all-core sustained
         dvfs_enabled=True,
@@ -765,7 +818,7 @@ def create_i7_12700k_mapper() -> CPUMapper:
                 tile_utilization=1.0,
                 native_acceleration=True,
             ),
-        }
+        },
     )
 
     # ========================================================================
@@ -778,7 +831,6 @@ def create_i7_12700k_mapper() -> CPUMapper:
         threads_per_unit=2,  # Weighted average (P-cores dominate)
         warps_per_unit=1,
         warp_size=8,  # AVX2 (8-wide)
-
         # Precision profiles (for legacy compatibility)
         precision_profiles={
             Precision.FP32: PrecisionProfile(
@@ -798,7 +850,6 @@ def create_i7_12700k_mapper() -> CPUMapper:
             ),
         },
         default_precision=Precision.FP32,
-
         # ====================================================================
         # MEMORY HIERARCHY - i7-12700K Cache Structure
         # ====================================================================
@@ -826,7 +877,6 @@ def create_i7_12700k_mapper() -> CPUMapper:
         l1_cache_per_unit=32 * 1024,  # 32 KB L1 data per core
         l2_cache_total=25 * 1024 * 1024,  # 25 MB L3 shared (LLC)
         main_memory=64 * 1024**3,  # 64 GB typical
-
         # On-chip bandwidth peaks (#61). Sourced from Intel(R) 64 and IA-32
         # Architectures Optimization Reference Manual Vol. 3, Alder Lake
         # P-core (Golden Cove) and E-core (Gracemont) chapters:
@@ -851,23 +901,30 @@ def create_i7_12700k_mapper() -> CPUMapper:
         # Lake review) put Alder Lake L3 sustained at ~150-300 GB/s
         # depending on access pattern. Conservative midpoint = 200 GB/s.
         # Stored in ``l3_bandwidth_bps`` since on x86 the LLC IS L3.
-        l1_bandwidth_per_unit_bps=350e9,   # weighted per-effective-unit
+        l1_bandwidth_per_unit_bps=350e9,  # weighted per-effective-unit
         l3_bandwidth_bps=200e9,
-
         # Energy (consumer CPU)
         energy_per_flop_fp32=1.5e-12,  # Higher than server (less efficient)
         energy_per_byte=25e-12,
-
         # Scheduling
         min_occupancy=0.4,  # Hybrid scheduling challenges
         max_concurrent_kernels=20,  # 20 threads total
         wave_quantization=1,
-
         # Thermal profiles
         thermal_operating_points={
             "consumer-continuous": thermal_profile,
         },
         default_thermal_profile="consumer-continuous",
+        # V5-5 calibration: DRAM achievable_fraction derived from the
+        # vector_add baseline at validation/model_v4/results/baselines/
+        # i7_12700k_vector_add.csv. Plateau rows (N=16M, 67M, 268M;
+        # working set 192 MB to 3 GB, all well past the 25 MB LLC):
+        # measured 35.2 / 34.7 / 36.7 GB/s, median ~35 GB/s. Peak DDR5
+        # is 75 GB/s, so achievable_fraction = 35 / 75 = 0.47. Used by
+        # the V5-3b tier-aware roofline path when opt-in (or after the
+        # V5-5 follow-up flips the default). L1 / L3 entries stay
+        # absent (default 1.0) until matmul-anchored calibration.
+        tier_achievable_fractions={"DRAM": 0.47},
     )
 
     return CPUMapper(model)
@@ -1026,7 +1083,7 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
                 tile_utilization=0.85,  # Better utilization with VNNI
                 native_acceleration=True,
             ),
-        }
+        },
     )
 
     # ========================================================================
@@ -1039,7 +1096,6 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
         threads_per_unit=2,
         warps_per_unit=1,
         warp_size=8,  # AVX2
-
         # Precision profiles
         precision_profiles={
             Precision.FP32: PrecisionProfile(
@@ -1059,22 +1115,18 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
             ),
         },
         default_precision=Precision.FP32,
-
         # Memory hierarchy (same hardware)
         peak_bandwidth=75e9,  # 75 GB/s DDR5
         l1_cache_per_unit=32 * 1024,  # 32 KB L1 data
         l2_cache_total=25 * 1024 * 1024,  # 25 MB L3 (LLC)
         main_memory=64 * 1024**3,
-
         # Energy
         energy_per_flop_fp32=1.5e-12,
         energy_per_byte=25e-12,
-
         # Scheduling
         min_occupancy=0.6,  # ↑ from 0.4 (large models keep cores busy)
         max_concurrent_kernels=20,
         wave_quantization=1,
-
         # Thermal profiles
         thermal_operating_points={
             "consumer-continuous-large": thermal_profile,
@@ -1130,7 +1182,9 @@ def create_ampere_ampereone_192_mapper() -> CPUMapper:
     Returns:
         CPUMapper configured for Ampere AmpereOne 192-core
     """
-    from ..models.datacenter.ampere_ampereone_192 import ampere_ampereone_192_resource_model
+    from ..models.datacenter.ampere_ampereone_192 import (
+        ampere_ampereone_192_resource_model,
+    )
 
     model = ampere_ampereone_192_resource_model()
     return CPUMapper(model)
@@ -1185,7 +1239,9 @@ def create_intel_xeon_platinum_8490h_mapper() -> CPUMapper:
     Returns:
         CPUMapper configured for Intel Xeon Platinum 8490H
     """
-    from ..models.datacenter.intel_xeon_platinum_8490h import intel_xeon_platinum_8490h_resource_model
+    from ..models.datacenter.intel_xeon_platinum_8490h import (
+        intel_xeon_platinum_8490h_resource_model,
+    )
     from ..architectural_energy import StoredProgramEnergyModel
     from ..technology_profile import DATACENTER_7NM_DDR5
 
@@ -1377,7 +1433,9 @@ def create_intel_xeon_platinum_8592plus_mapper() -> CPUMapper:
     Returns:
         CPUMapper configured for Intel Xeon Platinum 8592+
     """
-    from ..models.datacenter.intel_xeon_platinum_8592plus import intel_xeon_platinum_8592plus_resource_model
+    from ..models.datacenter.intel_xeon_platinum_8592plus import (
+        intel_xeon_platinum_8592plus_resource_model,
+    )
 
     model = intel_xeon_platinum_8592plus_resource_model()
     return CPUMapper(model)
@@ -1440,7 +1498,9 @@ def create_ampere_ampereone_128_mapper() -> CPUMapper:
     Returns:
         CPUMapper configured for Ampere AmpereOne 128-core
     """
-    from ..models.datacenter.ampere_ampereone_128 import ampere_ampereone_128_resource_model
+    from ..models.datacenter.ampere_ampereone_128 import (
+        ampere_ampereone_128_resource_model,
+    )
 
     model = ampere_ampereone_128_resource_model()
     return CPUMapper(model)
@@ -1507,7 +1567,9 @@ def create_intel_granite_rapids_mapper() -> CPUMapper:
     Returns:
         CPUMapper configured for Intel Granite Rapids
     """
-    from ..models.datacenter.intel_granite_rapids import intel_granite_rapids_resource_model
+    from ..models.datacenter.intel_granite_rapids import (
+        intel_granite_rapids_resource_model,
+    )
 
     model = intel_granite_rapids_resource_model()
     return CPUMapper(model)

--- a/src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py
+++ b/src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py
@@ -65,7 +65,7 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
     tensor_cores_per_sm = 4  # Nano has 4 TCs/SM like AGX
     total_tensor_cores = num_sms * tensor_cores_per_sm  # 32 TCs
     # ops are flops, so MACs count as 2 ops
-    fp32_ops_per_sm_per_clock =  256  # 128 CUDA cores × 1 FMA = 128 MACs/clock/SM
+    fp32_ops_per_sm_per_clock = 256  # 128 CUDA cores × 1 FMA = 128 MACs/clock/SM
     # Tensor Core throughput (Ampere SM 8.6, FP16 TC fragment is 8x8x4 ->
     # 256 MACs/clock/TC = 512 ops/clock/TC; INT8 is 2x that). Per the
     # Ampere whitepaper and verified against V4 Phase B baseline on
@@ -78,7 +78,6 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
     # Baseline frequency (sustained at 15W with active cooling)
     baseline_freq_hz = 650e6  # 650 MHz sustained (typical)
 
-
     # | Precision          | Ops/clock/SM |         Notes                       |
     # +--------------------+--------------+-------------------------------------+
     # | FP32               |      128     | 1 op/clock per CUDA core            |
@@ -86,7 +85,7 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
     # | FP64               |        2     | Severely limited on Jetson/consumer |
     # | INT32              |       64     | Shares with half the FP32 units     |
     # | INT8               |      256     | via dp4a instruction                |
-    # | Tensor Core (INT8) |      512+    | 4x4x4 matrix ops per clock (64 MACs)|            
+    # | Tensor Core (INT8) |      512+    | 4x4x4 matrix ops per clock (64 MACs)|
     # | Tensor Core (FP16) |      512+    | Matrix ops only, layout constraints |
 
     # ========================================================================
@@ -100,19 +99,19 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
         num_units=num_sms * cuda_cores_per_sm,  # 8 SMs × 128 cores/SM = 1,024 cores
         ops_per_unit_per_clock={
             Precision.FP64: 0.03125,  # 1/32 rate (emulated)
-            Precision.FP32: 2,         # FMA = 2 ops/clock (mul + add)
-            Precision.FP16: 2,         # FP16 emulated on CUDA cores
-            Precision.INT8: 2,         # INT8 emulated on CUDA cores
+            Precision.FP32: 2,  # FMA = 2 ops/clock (mul + add)
+            Precision.FP16: 2,  # FP16 emulated on CUDA cores
+            Precision.INT8: 2,  # INT8 emulated on CUDA cores
         },
         core_frequency_hz=baseline_freq_hz,  # 650 MHz sustained (15W)
-        process_node_nm=8,             # Samsung 8nm
-        energy_per_flop_fp32=get_base_alu_energy(8, 'standard_cell'),  # 1.9 pJ
+        process_node_nm=8,  # Samsung 8nm
+        energy_per_flop_fp32=get_base_alu_energy(8, "standard_cell"),  # 1.9 pJ
         energy_scaling={
-            Precision.FP64: 2.0,       # Double precision = 2× energy
-            Precision.FP32: 1.0,       # Baseline
-            Precision.FP16: 0.5,       # Half precision (emulated on CUDA cores)
-            Precision.INT8: 0.125,     # INT8 (emulated on CUDA cores)
-        }
+            Precision.FP64: 2.0,  # Double precision = 2× energy
+            Precision.FP32: 1.0,  # Baseline
+            Precision.FP16: 0.5,  # Half precision (emulated on CUDA cores)
+            Precision.INT8: 0.125,  # INT8 (emulated on CUDA cores)
+        },
     )
 
     # ========================================================================
@@ -127,23 +126,25 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
             # MACs/clock/TC = 512 ops/clock/TC. Pre-fix value of 64 was
             # half the spec; #94 calibrated against measured 7-8 TFLOPS
             # on Orin Nano Super at 650 MHz sustained.
-            Precision.FP16: 512,       # 256 MACs/clock/TC × 2 ops/MAC
-            Precision.INT8: 1024,      # 2x FP16 rate on Ampere
+            Precision.FP16: 512,  # 256 MACs/clock/TC × 2 ops/MAC
+            Precision.INT8: 1024,  # 2x FP16 rate on Ampere
         },
         core_frequency_hz=baseline_freq_hz,  # 650 MHz sustained (15W)
         process_node_nm=8,
-        energy_per_flop_fp32=get_base_alu_energy(8, 'tensor_core'),  # 1.62 pJ (15% better)
+        energy_per_flop_fp32=get_base_alu_energy(
+            8, "tensor_core"
+        ),  # 1.62 pJ (15% better)
         energy_scaling={
-            Precision.FP16: 0.5,       # Half precision
-            Precision.INT8: 0.25,      # INT8
-        }
+            Precision.FP16: 0.5,  # Half precision
+            Precision.INT8: 0.25,  # INT8
+        },
     )
 
     # CUDA cores:
     # FP32: 128 cores × 1 ops/clock   = 128 ops/clock per SM
     # Total: 8 SMs × 128 ops/clock/SM = 1,024 ops/clock
     # At 918 MHz boost: 1,024 × 918e6 = 1.88 TFLOPS FP32 (peak)
-    
+
     # INT8: 128 cores × 2 ops/clock   = 256 ops/clock per SM
     # Total: 8 SMs × 256 ops/clock/SM = 2,048 ops/clock
 
@@ -153,7 +154,7 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
     # Sustained INT8:2,048 ×  300 MHz = 0.614 TOPS
     # Effective: 1.228 × 0.40 = 0.98 TOPS (4.7% of 21 TOPS dense peak)
 
-    # Tensor cores: 
+    # Tensor cores:
     # Tensor Core INT8: 4×4×4 matmul      = 64 MACs/clock per Tensor Core
     # Total: 32 TCs × 64 MACs/TC/clock    = 2,048 MACs/clock
     # At 918 MHz boost:     2,048 × 918e6 = 1.88 TOPS INT8 (peak)
@@ -205,7 +206,7 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
                 efficiency_factor=0.20,
                 native_acceleration=True,
             ),
-        }
+        },
     )
 
     # ========================================================================
@@ -220,8 +221,8 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
     # 0.85 = 7.1 TFLOPS, matching the V4 baseline.
     clock_15w = ClockDomain(
         base_clock_hz=306e6,
-        max_boost_clock_hz=1020e6,    # Super raised boost from 918 MHz
-        sustained_clock_hz=1020e6,    # Super can sustain boost at 15W under cuBLAS
+        max_boost_clock_hz=1020e6,  # Super raised boost from 918 MHz
+        sustained_clock_hz=1020e6,  # Super can sustain boost at 15W under cuBLAS
         dvfs_enabled=True,
     )
 
@@ -246,7 +247,7 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
                 compute_resource=compute_resource_15w,
                 instruction_efficiency=0.95,
                 memory_bottleneck_factor=0.80,
-                efficiency_factor=0.80,   # Tensor Core INT8 well-utilized
+                efficiency_factor=0.80,  # Tensor Core INT8 well-utilized
                 native_acceleration=True,
             ),
             Precision.FP16: PerformanceCharacteristics(
@@ -267,7 +268,7 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
                 efficiency_factor=0.40,
                 native_acceleration=True,
             ),
-        }
+        },
     )
 
     # ========================================================================
@@ -283,8 +284,8 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
     # 8.36 TFLOPS theoretical; * 0.85 efficiency = 7.1 TFLOPS effective.
     clock_maxn = ClockDomain(
         base_clock_hz=306e6,
-        max_boost_clock_hz=1020e6,    # Super raised boost to 1.02 GHz
-        sustained_clock_hz=1020e6,    # cuBLAS pegs at boost; no throttling at 25W
+        max_boost_clock_hz=1020e6,  # Super raised boost to 1.02 GHz
+        sustained_clock_hz=1020e6,  # cuBLAS pegs at boost; no throttling at 25W
         dvfs_enabled=False,
     )
 
@@ -301,7 +302,7 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
 
     thermal_maxn = ThermalOperatingPoint(
         name="MAXN-Super",
-        tdp_watts=25.0,                # Super raised TDP cap from 15W to 25W
+        tdp_watts=25.0,  # Super raised TDP cap from 15W to 25W
         cooling_solution="active-fan",
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
@@ -328,7 +329,7 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
                 efficiency_factor=0.40,
                 native_acceleration=True,
             ),
-        }
+        },
     )
 
     # ========================================================================
@@ -356,19 +357,16 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
     return HardwareResourceModel(
         name="Jetson-Orin-Nano-8GB",
         hardware_type=HardwareType.GPU,
-
         # NEW: Multi-fabric architecture
         compute_fabrics=[cuda_fabric, tensor_fabric],
-
         compute_units=num_sms,
         threads_per_unit=64,
         warps_per_unit=2,
         warp_size=32,
-
         # Thermal operating points with DVFS modeling
         thermal_operating_points={
-            "7W":   thermal_7w,    # Battery-powered devices
-            "15W":  thermal_15w,   # Orin Nano Super 15W (Phase B baseline)
+            "7W": thermal_7w,  # Battery-powered devices
+            "15W": thermal_15w,  # Orin Nano Super 15W (Phase B baseline)
             "MAXN": thermal_maxn,  # Orin Nano Super at full 25W power
         },
         # 15W is the default because the V4 Phase B baseline (#90) was
@@ -377,7 +375,6 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
         # should pass "7W". On the Super silicon, 15W can sustain
         # near-boost clocks under cuBLAS Tensor Core load.
         default_thermal_profile="15W",
-
         # Legacy precision profiles (backward compatibility).
         # FP16/FP32 added for issue #53: get_peak_ops now raises on missing
         # precision instead of silently falling back to INT8. Values follow
@@ -408,10 +405,9 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
             ),
         },
         default_precision=Precision.INT8,
-
         peak_bandwidth=102e9,  # 102 GB/s LPDDR5-6400 (Orin Nano Super, Dec 2024).
-                               # Original Orin Nano (2023) was 68 GB/s LPDDR5-4267.
-                               # The V4 Phase B baseline was captured on a Super.
+        # Original Orin Nano (2023) was 68 GB/s LPDDR5-4267.
+        # The V4 Phase B baseline was captured on a Super.
         l1_cache_per_unit=128 * 1024,
         l2_cache_total=2 * 1024 * 1024,  # 2 MB (half of AGX)
         main_memory=8 * 1024**3,  # 8 GB
@@ -421,6 +417,14 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
         max_concurrent_kernels=4,  # Fewer than AGX
         wave_quantization=2,  # Smaller wave size
         bom_cost_profile=bom_cost,
+        # V5-5 calibration: DRAM achievable_fraction derived from
+        # validation/model_v4/results/baselines/jetson_orin_nano_8gb_vector_add.csv
+        # captured at the 15W thermal profile per #94. Plateau rows
+        # (N=16M, 67M, 268M; fp16 working set 100 MB to 1.6 GB, all
+        # well past the 2 MB L2): measured 61.6 / 56.4 / 56.6 GB/s,
+        # median ~57 GB/s. Peak LPDDR5-6400 is 102 GB/s, so
+        # achievable_fraction = 57 / 102 = 0.55. Used by the V5-3b
+        # tier-aware roofline path when opt-in. L1 / L2 entries stay
+        # absent (default 1.0) until matmul-anchored calibration.
+        tier_achievable_fractions={"DRAM": 0.55},
     )
-
-

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
 class HardwareType(Enum):
     """Supported hardware types"""
+
     GPU = "gpu"
     CPU = "cpu"
     TPU = "tpu"
@@ -51,20 +52,21 @@ class HardwareType(Enum):
 
 class Precision(Enum):
     """Numerical precision types"""
-    FP64 = "fp64"          # IEEE Double Precision, 64-bit, 1 sign, 11 exponent, 52 mantissa
-    FP32 = "fp32"          # IEEE Single Precision, 32-bit, 1 sign, 8 exponent, 23 mantissa
-    TF32 = "tf32"          # NVIDIA TensorFloat-32, 19-bit (1 sign, 8 exp, 10 mantissa), Tensor Cores only
-    FP16 = "fp16"          # IEEE Half Precision, 16-bit, 1 sign, 5 exponent, 10 mantissa
-    FP8 = "fp8"            # IEEE FP8 (generic), 1 sign, 3 exponent, 4 mantissa
+
+    FP64 = "fp64"  # IEEE Double Precision, 64-bit, 1 sign, 11 exponent, 52 mantissa
+    FP32 = "fp32"  # IEEE Single Precision, 32-bit, 1 sign, 8 exponent, 23 mantissa
+    TF32 = "tf32"  # NVIDIA TensorFloat-32, 19-bit (1 sign, 8 exp, 10 mantissa), Tensor Cores only
+    FP16 = "fp16"  # IEEE Half Precision, 16-bit, 1 sign, 5 exponent, 10 mantissa
+    FP8 = "fp8"  # IEEE FP8 (generic), 1 sign, 3 exponent, 4 mantissa
     FP8_E4M3 = "fp8_e4m3"  # 4-bit exponent, 3-bit mantissa
     FP8_E5M2 = "fp8_e5m2"  # 5-bit exponent, 2-bit mantissa
-    FP4 = "fp4"            # 4-bit floating point, 1 sign, 2 exponent, 1 mantissa
-    BF16 = "bf16"          # Brain Floating Point, 16-bit, 1 sign, 8 exponent, 7 mantissa
-    INT64 = "int64"        # 64-bit integer
-    INT32 = "int32"        # 32-bit integer
-    INT16 = "int16"        # 16-bit integer
-    INT8 = "int8"          # 8-bit integer
-    INT4 = "int4"          # 4-bit integer
+    FP4 = "fp4"  # 4-bit floating point, 1 sign, 2 exponent, 1 mantissa
+    BF16 = "bf16"  # Brain Floating Point, 16-bit, 1 sign, 8 exponent, 7 mantissa
+    INT64 = "int64"  # 64-bit integer
+    INT32 = "int32"  # 32-bit integer
+    INT16 = "int16"  # 16-bit integer
+    INT8 = "int8"  # 8-bit integer
+    INT4 = "int4"  # 4-bit integer
 
 
 # Canonical operand byte width per Precision (used for weight/activation sizing).
@@ -81,22 +83,24 @@ def precision_bytes_per_element(precision: "Precision") -> float:
     than defaulting to fp32. Sub-byte precisions (int4, fp4) return 0.5.
     """
     if not _PRECISION_BYTES_PER_ELEMENT:
-        _PRECISION_BYTES_PER_ELEMENT.update({
-            Precision.FP64: 8,
-            Precision.FP32: 4,
-            Precision.TF32: 4,   # stored as fp32; only the multiplier is narrower
-            Precision.FP16: 2,
-            Precision.BF16: 2,
-            Precision.INT64: 8,
-            Precision.INT32: 4,
-            Precision.INT16: 2,
-            Precision.INT8: 1,
-            Precision.FP8: 1,
-            Precision.FP8_E4M3: 1,
-            Precision.FP8_E5M2: 1,
-            Precision.INT4: 0.5,
-            Precision.FP4: 0.5,
-        })
+        _PRECISION_BYTES_PER_ELEMENT.update(
+            {
+                Precision.FP64: 8,
+                Precision.FP32: 4,
+                Precision.TF32: 4,  # stored as fp32; only the multiplier is narrower
+                Precision.FP16: 2,
+                Precision.BF16: 2,
+                Precision.INT64: 8,
+                Precision.INT32: 4,
+                Precision.INT16: 2,
+                Precision.INT8: 1,
+                Precision.FP8: 1,
+                Precision.FP8_E4M3: 1,
+                Precision.FP8_E5M2: 1,
+                Precision.INT4: 0.5,
+                Precision.FP4: 0.5,
+            }
+        )
     return _PRECISION_BYTES_PER_ELEMENT.get(precision, 4)
 
 
@@ -108,29 +112,32 @@ def precision_bytes_per_element(precision: "Precision") -> float:
 # Based on: Energy = Capacitance × Voltage² per switch
 # Frequency does NOT affect energy per operation (only power)
 PROCESS_NODE_ENERGY = {
-    3:   1.2e-12,  # 1.2 pJ @ 3nm (Intel 18A, TSMC N3, AMD Zen 5)
-    4:   1.3e-12,  # 1.3 pJ @ 4nm (TSMC N4/N4P)
-    5:   1.5e-12,  # 1.5 pJ @ 5nm (TSMC N5, Samsung 5LPE)
-    6:   1.65e-12, # 1.65 pJ @ 6nm (TSMC N6 - 7nm extension with slightly better density)
-    7:   1.8e-12,  # 1.8 pJ @ 7nm (TSMC N7, Samsung 7LPP)
-    8:   1.9e-12,  # 1.9 pJ @ 8nm (Samsung 8LPP)
-    10:  2.1e-12,  # 2.1 pJ @ 10nm (Intel 10nm/7)
-    12:  2.5e-12,  # 2.5 pJ @ 12nm (TSMC 12FFC)
-    14:  2.6e-12,  # 2.6 pJ @ 14nm (Intel 14nm, Samsung 14LPP)
-    16:  2.7e-12,  # 2.7 pJ @ 16nm (TSMC 16FFC)
-    28:  4.0e-12,  # 4.0 pJ @ 28nm (TSMC 28HPC+)
+    3: 1.2e-12,  # 1.2 pJ @ 3nm (Intel 18A, TSMC N3, AMD Zen 5)
+    4: 1.3e-12,  # 1.3 pJ @ 4nm (TSMC N4/N4P)
+    5: 1.5e-12,  # 1.5 pJ @ 5nm (TSMC N5, Samsung 5LPE)
+    6: 1.65e-12,  # 1.65 pJ @ 6nm (TSMC N6 - 7nm extension with slightly better density)
+    7: 1.8e-12,  # 1.8 pJ @ 7nm (TSMC N7, Samsung 7LPP)
+    8: 1.9e-12,  # 1.9 pJ @ 8nm (Samsung 8LPP)
+    10: 2.1e-12,  # 2.1 pJ @ 10nm (Intel 10nm/7)
+    12: 2.5e-12,  # 2.5 pJ @ 12nm (TSMC 12FFC)
+    14: 2.6e-12,  # 2.6 pJ @ 14nm (Intel 14nm, Samsung 14LPP)
+    16: 2.7e-12,  # 2.7 pJ @ 16nm (TSMC 16FFC)
+    28: 4.0e-12,  # 4.0 pJ @ 28nm (TSMC 28HPC+)
 }
 
 # Circuit type multipliers (relative to standard cell baseline)
 # Captures layout efficiency and parallelism benefits
 CIRCUIT_TYPE_MULTIPLIER = {
-    'standard_cell':     1.0,    # Baseline: Standard cell library ALU
-    'tensor_core':       0.85,   # 15% more efficient: Amortized control, fused MAC+accumulate
-    'simd_packed':       0.90,   # 10% more efficient: Packed operations (AVX-512, NEON)
-    'custom_datacenter': 2.75,   # 2.75× higher: 5+ GHz custom circuits, wide datapath, extra pipeline
+    "standard_cell": 1.0,  # Baseline: Standard cell library ALU
+    "tensor_core": 0.85,  # 15% more efficient: Amortized control, fused MAC+accumulate
+    "simd_packed": 0.90,  # 10% more efficient: Packed operations (AVX-512, NEON)
+    "custom_datacenter": 2.75,  # 2.75× higher: 5+ GHz custom circuits, wide datapath, extra pipeline
 }
 
-def get_base_alu_energy(process_node_nm: int, circuit_type: str = 'standard_cell') -> float:
+
+def get_base_alu_energy(
+    process_node_nm: int, circuit_type: str = "standard_cell"
+) -> float:
     """
     Calculate base ALU energy per FP32 operation.
 
@@ -158,9 +165,12 @@ def get_base_alu_energy(process_node_nm: int, circuit_type: str = 'standard_cell
         else:
             # Linear interpolation
             for i in range(len(nodes) - 1):
-                if nodes[i] <= process_node_nm <= nodes[i+1]:
-                    e1, e2 = PROCESS_NODE_ENERGY[nodes[i]], PROCESS_NODE_ENERGY[nodes[i+1]]
-                    t = (process_node_nm - nodes[i]) / (nodes[i+1] - nodes[i])
+                if nodes[i] <= process_node_nm <= nodes[i + 1]:
+                    e1, e2 = (
+                        PROCESS_NODE_ENERGY[nodes[i]],
+                        PROCESS_NODE_ENERGY[nodes[i + 1]],
+                    )
+                    t = (process_node_nm - nodes[i]) / (nodes[i + 1] - nodes[i])
                     base_energy = e1 + t * (e2 - e1)
                     break
 
@@ -171,6 +181,7 @@ def get_base_alu_energy(process_node_nm: int, circuit_type: str = 'standard_cell
 # ============================================================================
 # Compute Fabric Model - Multi-Fabric Hardware Support
 # ============================================================================
+
 
 @dataclass
 class ComputeFabric:
@@ -200,15 +211,20 @@ class ComputeFabric:
           - energy: 1.28 pJ @ 5nm (15% more efficient)
           - ops_per_clock: {BF16: 512, FP8: 1024}
     """
-    fabric_type: str                    # "cuda_core", "tensor_core", "int8_tile", "matrix_tile", "avx512", "neon"
-    circuit_type: str                   # "standard_cell", "tensor_core", "simd_packed", "custom_datacenter"
-    num_units: int                      # Count of this fabric type
+
+    fabric_type: (
+        str  # "cuda_core", "tensor_core", "int8_tile", "matrix_tile", "avx512", "neon"
+    )
+    circuit_type: (
+        str  # "standard_cell", "tensor_core", "simd_packed", "custom_datacenter"
+    )
+    num_units: int  # Count of this fabric type
     ops_per_unit_per_clock: Dict[Precision, int]  # Peak throughput
-    core_frequency_hz: float            # Operating frequency (for power calculation)
+    core_frequency_hz: float  # Operating frequency (for power calculation)
 
     # Energy model (process + circuit type)
-    process_node_nm: int                # Process node (4, 5, 7, 16, etc.)
-    energy_per_flop_fp32: float         # Base energy (calculated from process + circuit)
+    process_node_nm: int  # Process node (4, 5, 7, 16, etc.)
+    energy_per_flop_fp32: float  # Base energy (calculated from process + circuit)
 
     # Precision-specific energy scaling
     energy_scaling: Dict[Precision, float] = field(default_factory=dict)
@@ -217,8 +233,7 @@ class ComputeFabric:
         """Calculate energy_per_flop_fp32 if not provided"""
         if self.energy_per_flop_fp32 == 0:
             self.energy_per_flop_fp32 = get_base_alu_energy(
-                self.process_node_nm,
-                self.circuit_type
+                self.process_node_nm, self.circuit_type
             )
 
     def get_energy_per_op(self, precision: Precision) -> float:
@@ -243,6 +258,7 @@ class ComputeFabric:
 # BOM Cost Modeling for Market Analysis
 # ============================================================================
 
+
 @dataclass
 class BOMCostProfile:
     """
@@ -261,37 +277,38 @@ class BOMCostProfile:
         → Total BOM: $120
         → Retail (2.5x margin): $299
     """
+
     # Component costs
-    silicon_die_cost: float          # Die fabrication cost (process node dependent)
-    package_cost: float               # Package cost (flip-chip BGA, etc.)
-    memory_cost: float                # On-package/on-module DRAM cost
-    pcb_assembly_cost: float          # PCB, passives, assembly labor
-    thermal_solution_cost: float      # Heatsink, thermal interface materials
-    other_costs: float = 0.0          # Connectors, housing, testing, etc.
+    silicon_die_cost: float  # Die fabrication cost (process node dependent)
+    package_cost: float  # Package cost (flip-chip BGA, etc.)
+    memory_cost: float  # On-package/on-module DRAM cost
+    pcb_assembly_cost: float  # PCB, passives, assembly labor
+    thermal_solution_cost: float  # Heatsink, thermal interface materials
+    other_costs: float = 0.0  # Connectors, housing, testing, etc.
 
     # Totals and pricing
-    total_bom_cost: float = 0.0       # Sum of all component costs (auto-calculated if 0)
-    margin_multiplier: float = 2.5    # Typical margin: retail = BOM × margin
-    retail_price: float = 0.0         # Customer-facing price (if known)
+    total_bom_cost: float = 0.0  # Sum of all component costs (auto-calculated if 0)
+    margin_multiplier: float = 2.5  # Typical margin: retail = BOM × margin
+    retail_price: float = 0.0  # Customer-facing price (if known)
 
     # Context
-    volume_tier: str = "10K+"         # Volume pricing tier ("1K+", "10K+", "100K+", "1M+")
-    process_node: str = "16nm"        # Fabrication process (affects die cost)
-    year: int = 2025                  # Year of pricing (inflation adjustments)
+    volume_tier: str = "10K+"  # Volume pricing tier ("1K+", "10K+", "100K+", "1M+")
+    process_node: str = "16nm"  # Fabrication process (affects die cost)
+    year: int = 2025  # Year of pricing (inflation adjustments)
 
     # Notes
-    notes: str = ""                   # Additional context or assumptions
+    notes: str = ""  # Additional context or assumptions
 
     def __post_init__(self):
         """Calculate total BOM if not provided"""
         if self.total_bom_cost == 0:
             self.total_bom_cost = (
-                self.silicon_die_cost +
-                self.package_cost +
-                self.memory_cost +
-                self.pcb_assembly_cost +
-                self.thermal_solution_cost +
-                self.other_costs
+                self.silicon_die_cost
+                + self.package_cost
+                + self.memory_cost
+                + self.pcb_assembly_cost
+                + self.thermal_solution_cost
+                + self.other_costs
             )
 
         # Estimate retail if not provided
@@ -315,6 +332,7 @@ class BOMCostProfile:
 # NEW: DVFS-Aware Performance Modeling with Heterogeneous Compute Resources
 # ============================================================================
 
+
 @dataclass
 class ClockDomain:
     """
@@ -331,10 +349,11 @@ class ClockDomain:
         Jetson Orin @ 15W: 306 MHz base, 1.02 GHz boost, 400 MHz sustained
         → thermal_throttle_factor = 0.39 (severe throttling!)
     """
-    base_clock_hz: float          # Minimum guaranteed frequency
-    max_boost_clock_hz: float     # Maximum burst frequency (datasheet)
-    sustained_clock_hz: float     # Actual frequency under thermal load (empirical)
-    dvfs_enabled: bool = True     # Dynamic voltage/frequency scaling support
+
+    base_clock_hz: float  # Minimum guaranteed frequency
+    max_boost_clock_hz: float  # Maximum burst frequency (datasheet)
+    sustained_clock_hz: float  # Actual frequency under thermal load (empirical)
+    dvfs_enabled: bool = True  # Dynamic voltage/frequency scaling support
 
     @property
     def thermal_throttle_factor(self) -> float:
@@ -355,24 +374,21 @@ class ComputeResource:
     Example:
         16 ALUs x 4 INT8 ops/ALU/clock x 1.5 GHz = 96 GOPS INT8
     """
-    resource_type: str            # "Ampere-SM", "Systolic-Array", "AVX512-Core"
-    num_units: int                # Count of compute units (SMs, cores, tiles)
+
+    resource_type: str  # "Ampere-SM", "Systolic-Array", "AVX512-Core"
+    num_units: int  # Count of compute units (SMs, cores, tiles)
     ops_per_unit_per_clock: Dict[Precision, int]  # SIMD width per precision
-    clock_domain: ClockDomain     # Frequency specifications
+    clock_domain: ClockDomain  # Frequency specifications
 
     def calc_peak_ops(self, precision: Precision) -> float:
         """Calculate peak from first principles (datasheet number)"""
         ops_per_clock = self.ops_per_unit_per_clock.get(precision, 0)
-        return (self.num_units *
-                ops_per_clock *
-                self.clock_domain.max_boost_clock_hz)
+        return self.num_units * ops_per_clock * self.clock_domain.max_boost_clock_hz
 
     def calc_sustained_ops(self, precision: Precision) -> float:
         """Sustained performance under thermal load (DVFS throttled)"""
         ops_per_clock = self.ops_per_unit_per_clock.get(precision, 0)
-        return (self.num_units *
-                ops_per_clock *
-                self.clock_domain.sustained_clock_hz)
+        return self.num_units * ops_per_clock * self.clock_domain.sustained_clock_hz
 
 
 class TileScheduleClass(Enum):
@@ -422,6 +438,7 @@ class TileScheduleClass(Enum):
             Effective utilization is treated as 1.0; other utilization
             penalties are modeled elsewhere.
     """
+
     OUTPUT_STATIONARY = "output_stationary"
     WEIGHT_STATIONARY = "weight_stationary"
     ROW_STATIONARY = "row_stationary"
@@ -455,8 +472,9 @@ class TileSpecialization:
             energy model derives it from CIRCUIT_TYPE_MULTIPLIER and the
             precision-specific energy_scaling.
     """
-    tile_type: str                # "INT8-primary", "BF16-primary", "Matrix-8x8"
-    num_tiles: int                # Count of tiles with this specialization
+
+    tile_type: str  # "INT8-primary", "BF16-primary", "Matrix-8x8"
+    num_tiles: int  # Count of tiles with this specialization
 
     # Performance characteristics per precision
     # (all precisions are native, but some are more optimized)
@@ -470,7 +488,7 @@ class TileSpecialization:
 
     # Array processor characteristics
     array_dimensions: Tuple[int, int] = (16, 8)  # e.g., 16×8 systolic array
-    pe_configuration: str = "Mixed"              # "INT8-MAC", "BF16-FMA", "Mixed"
+    pe_configuration: str = "Mixed"  # "INT8-MAC", "BF16-FMA", "Mixed"
 
     # Domain-flow-tile scheduling parameters (M0.5)
     schedule_class: TileScheduleClass = TileScheduleClass.UNSPECIFIED
@@ -480,9 +498,9 @@ class TileSpecialization:
 
     # SIMT_DATA_PARALLEL parameters (GPU Tensor Core, warp-level execution)
     # Defaults are neutral (no penalty) for non-SIMT tiles.
-    warp_divergence_rate: float = 0.0    # fraction of warp-issue cycles with divergence
-    warp_occupancy: float = 1.0          # achieved warps / theoretical max warps
-    coherence_efficiency: float = 1.0    # memory coherence / reuse efficiency
+    warp_divergence_rate: float = 0.0  # fraction of warp-issue cycles with divergence
+    warp_occupancy: float = 1.0  # achieved warps / theoretical max warps
+    coherence_efficiency: float = 1.0  # memory coherence / reuse efficiency
 
     @property
     def pe_count(self) -> int:
@@ -537,8 +555,10 @@ class TileSpecialization:
         drain = int(self.pipeline_drain_cycles)
         steady = max(int(steady_cycles_per_tile), 1)
 
-        if self.schedule_class == TileScheduleClass.OUTPUT_STATIONARY or \
-           self.schedule_class == TileScheduleClass.ROW_STATIONARY:
+        if (
+            self.schedule_class == TileScheduleClass.OUTPUT_STATIONARY
+            or self.schedule_class == TileScheduleClass.ROW_STATIONARY
+        ):
             total = num_tiles_in_workload * steady + fill + drain
             useful = num_tiles_in_workload * steady
             return useful / total if total > 0 else 1.0
@@ -551,7 +571,9 @@ class TileSpecialization:
         if self.schedule_class == TileScheduleClass.SIMT_DATA_PARALLEL:
             # Divergence: a divergent warp serializes 2 code paths, so
             # the fractional cost is ~0.5 * divergence_rate.
-            divergence_penalty = 1.0 - 0.5 * max(0.0, min(1.0, self.warp_divergence_rate))
+            divergence_penalty = 1.0 - 0.5 * max(
+                0.0, min(1.0, self.warp_divergence_rate)
+            )
             occ = max(0.0, min(1.0, self.warp_occupancy))
             coh = max(0.0, min(1.0, self.coherence_efficiency))
             return divergence_penalty * occ * coh
@@ -572,13 +594,17 @@ class KPUComputeResource:
         - 20% BF16 tiles (normalization, attention)
         - 10% TC32 tiles (large matmuls)  tensorcore processing elements
     """
+
     total_tiles: int
     tile_specializations: List[TileSpecialization]
 
     def get_tiles_for_precision(self, precision: Precision) -> List[TileSpecialization]:
         """Find which tile types support this precision natively"""
-        return [ts for ts in self.tile_specializations
-                if precision in ts.ops_per_tile_per_clock]
+        return [
+            ts
+            for ts in self.tile_specializations
+            if precision in ts.ops_per_tile_per_clock
+        ]
 
     def calc_peak_ops(self, precision: Precision) -> float:
         """
@@ -609,8 +635,10 @@ class KPUComputeResource:
 
     def get_silicon_allocation(self) -> Dict[str, float]:
         """Show silicon budget allocation across tile types"""
-        return {ts.tile_type: ts.num_tiles / self.total_tiles
-                for ts in self.tile_specializations}
+        return {
+            ts.tile_type: ts.num_tiles / self.total_tiles
+            for ts in self.tile_specializations
+        }
 
 
 @dataclass
@@ -636,17 +664,18 @@ class PerformanceCharacteristics:
 
       This is NOT a reduction factor! Higher values = better performance.
     """
+
     precision: Precision
     compute_resource: Optional[Union[ComputeResource, KPUComputeResource]] = None
 
     # Microarchitectural efficiency factors (all are multipliers 0.0-1.0)
-    instruction_efficiency: float = 0.85     # Compiler/ISA efficiency
-    memory_bottleneck_factor: float = 0.75   # Memory system limits
-    tile_utilization: float = 1.0            # For KPU: fraction of tiles used
+    instruction_efficiency: float = 0.85  # Compiler/ISA efficiency
+    memory_bottleneck_factor: float = 0.75  # Memory system limits
+    tile_utilization: float = 1.0  # For KPU: fraction of tiles used
 
     # Hardware support
-    native_acceleration: bool = True         # True = HW accelerated, False = emulated
-    emulation_penalty: float = 0.01          # 100× slowdown if not native
+    native_acceleration: bool = True  # True = HW accelerated, False = emulated
+    emulation_penalty: float = 0.01  # 100× slowdown if not native
 
     # Combined efficiency factor (measured on real hardware)
     # efficiency_factor = empirical_performance / sustained_performance
@@ -711,12 +740,15 @@ class ThermalOperatingPoint:
 
     Each thermal point has different clock behavior and per-precision performance.
     """
-    name: str                     # "15W-passive", "60W-active"
-    tdp_watts: float              # Thermal Design Power
-    cooling_solution: str         # "passive-heatsink", "active-fan", "liquid"
+
+    name: str  # "15W-passive", "60W-active"
+    tdp_watts: float  # Thermal Design Power
+    cooling_solution: str  # "passive-heatsink", "active-fan", "liquid"
 
     # Per-precision performance characteristics at this thermal point
-    performance_specs: Dict[Precision, PerformanceCharacteristics] = field(default_factory=dict)
+    performance_specs: Dict[Precision, PerformanceCharacteristics] = field(
+        default_factory=dict
+    )
 
     def get_effective_ops(self, precision: Precision) -> float:
         """Get actual achieved performance for a precision"""
@@ -736,6 +768,7 @@ class ThermalOperatingPoint:
 # innermost-out to find the binding bottleneck for a given (op, shape).
 # This dataclass is V5-1 scaffolding; nothing in the analyzer reads it
 # yet.
+
 
 @dataclass(frozen=True)
 class MemoryTier:
@@ -766,15 +799,16 @@ class MemoryTier:
     V5-5 calibration hangs the per-(hardware, tier) measured-vs-peak
     ratio (currently captured in the scalar bw_efficiency_scale).
     """
-    name: str                         # "L1", "L2", "L3", "DRAM", "scratchpad"
-    capacity_bytes: int               # per-unit if is_per_unit else aggregate
+
+    name: str  # "L1", "L2", "L3", "DRAM", "scratchpad"
+    capacity_bytes: int  # per-unit if is_per_unit else aggregate
     is_per_unit: bool
-    num_units: int                    # compute_units when is_per_unit=True; else 1
-    peak_bandwidth_bps: float         # aggregate, for both per-unit and shared tiers
-                                      # (per-unit BW is multiplied by num_units when
-                                      # the property derives this -- the field is
-                                      # always the aggregate the kernel sees)
-    access_latency_ns: float          # first-request startup latency for this tier
+    num_units: int  # compute_units when is_per_unit=True; else 1
+    peak_bandwidth_bps: float  # aggregate, for both per-unit and shared tiers
+    # (per-unit BW is multiplied by num_units when
+    # the property derives this -- the field is
+    # always the aggregate the kernel sees)
+    access_latency_ns: float  # first-request startup latency for this tier
     achievable_fraction: float = 1.0  # V5-5 calibration knob; default = ideal
 
     def __post_init__(self) -> None:
@@ -788,23 +822,28 @@ class MemoryTier:
         if self.capacity_bytes < 0:
             raise ValueError(
                 f"MemoryTier({self.name!r}).capacity_bytes must be >= 0; "
-                f"got {self.capacity_bytes}")
+                f"got {self.capacity_bytes}"
+            )
         if self.num_units < 1:
             raise ValueError(
                 f"MemoryTier({self.name!r}).num_units must be >= 1; "
-                f"got {self.num_units}")
+                f"got {self.num_units}"
+            )
         if self.peak_bandwidth_bps < 0:
             raise ValueError(
                 f"MemoryTier({self.name!r}).peak_bandwidth_bps must be >= 0; "
-                f"got {self.peak_bandwidth_bps}")
+                f"got {self.peak_bandwidth_bps}"
+            )
         if self.access_latency_ns < 0:
             raise ValueError(
                 f"MemoryTier({self.name!r}).access_latency_ns must be >= 0; "
-                f"got {self.access_latency_ns}")
+                f"got {self.access_latency_ns}"
+            )
         if not (0.0 <= self.achievable_fraction <= 1.0):
             raise ValueError(
                 f"MemoryTier({self.name!r}).achievable_fraction must be in "
-                f"[0.0, 1.0]; got {self.achievable_fraction}")
+                f"[0.0, 1.0]; got {self.achievable_fraction}"
+            )
 
     @property
     def total_capacity_bytes(self) -> int:
@@ -824,6 +863,7 @@ class MemoryTier:
 # OLD: Legacy PrecisionProfile (kept for backward compatibility)
 # ============================================================================
 
+
 @dataclass
 class PrecisionProfile:
     """
@@ -836,6 +876,7 @@ class PrecisionProfile:
     - BF16: 750 TFLOPS (with Tensor Cores, 12.5x faster!)
     - FP8: 1.5 PFLOPS (with Tensor Cores, 25x faster!)
     """
+
     precision: Precision
     peak_ops_per_sec: float  # Operations per second at this precision
     tensor_core_supported: bool = False  # Uses specialized matrix units?
@@ -856,6 +897,7 @@ class HardwareResourceModel:
     This defines the physical resources available on a hardware accelerator,
     including precision-specific peak performance.
     """
+
     # Required fields (no defaults)
     name: str
     hardware_type: HardwareType
@@ -873,7 +915,7 @@ class HardwareResourceModel:
 
     # NEW: Architectural energy modeling
     # Captures architecture-specific energy events (instruction fetch, coherence, etc.)
-    architecture_energy_model: Optional['ArchitecturalEnergyModel'] = None
+    architecture_energy_model: Optional["ArchitecturalEnergyModel"] = None
     warp_size: int = 32  # Threads per warp (32 for NVIDIA, varies for others)
 
     # NEW: Multi-fabric support (CUDA + Tensor Cores, INT8 + Matrix tiles, Scalar + SIMD)
@@ -888,19 +930,21 @@ class HardwareResourceModel:
     default_precision: Precision = Precision.FP32
 
     # Energy scaling factors by precision (relative to FP32)
-    energy_scaling: Dict[Precision, float] = field(default_factory=lambda: {
-        Precision.FP64: 2.0,    # 2× energy of FP32
-        Precision.FP32: 1.0,    # Baseline
-        Precision.FP16: 0.5,    # Half energy
-        Precision.BF16: 0.5,
-        Precision.FP8_E4M3: 0.25,
-        Precision.FP8_E5M2: 0.25,
-        Precision.FP4: 0.125,
-        Precision.INT32: 0.5,
-        Precision.INT16: 0.25,
-        Precision.INT8: 0.125,
-        Precision.INT4: 0.0625,
-    })
+    energy_scaling: Dict[Precision, float] = field(
+        default_factory=lambda: {
+            Precision.FP64: 2.0,  # 2× energy of FP32
+            Precision.FP32: 1.0,  # Baseline
+            Precision.FP16: 0.5,  # Half energy
+            Precision.BF16: 0.5,
+            Precision.FP8_E4M3: 0.25,
+            Precision.FP8_E5M2: 0.25,
+            Precision.FP4: 0.125,
+            Precision.INT32: 0.5,
+            Precision.INT16: 0.25,
+            Precision.INT8: 0.125,
+            Precision.INT4: 0.0625,
+        }
+    )
 
     # Scheduling characteristics
     min_occupancy: float = 0.25  # Minimum occupancy for efficiency
@@ -913,14 +957,18 @@ class HardwareResourceModel:
 
     # GPU Microarchitecture (for accurate compute modeling)
     # These parameters define the actual hardware implementation
-    cuda_cores_per_sm: Optional[int] = None           # 64 (Pascal-Turing), 128 (Ampere-Hopper)
-    ops_per_clock_per_core: Optional[float] = 2.0     # FMA: 2 ops/clock for FP32
-    sm_boost_clock_hz: Optional[float] = None         # Maximum boost frequency (short bursts)
-    sm_sustained_clock_hz: Optional[float] = None     # Sustained frequency under thermal load
+    cuda_cores_per_sm: Optional[int] = None  # 64 (Pascal-Turing), 128 (Ampere-Hopper)
+    ops_per_clock_per_core: Optional[float] = 2.0  # FMA: 2 ops/clock for FP32
+    sm_boost_clock_hz: Optional[float] = None  # Maximum boost frequency (short bursts)
+    sm_sustained_clock_hz: Optional[float] = (
+        None  # Sustained frequency under thermal load
+    )
 
     # Tensor Core microarchitecture (for matrix operations)
-    tensor_cores_per_sm: Optional[int] = None         # 4 (Volta/Turing/Ampere/Hopper)
-    tensor_core_ops_per_clock: Optional[float] = None # Varies by precision and generation
+    tensor_cores_per_sm: Optional[int] = None  # 4 (Volta/Turing/Ampere/Hopper)
+    tensor_core_ops_per_clock: Optional[float] = (
+        None  # Varies by precision and generation
+    )
 
     # NEW: BOM cost modeling for market analysis
     bom_cost_profile: Optional[BOMCostProfile] = None
@@ -1032,6 +1080,18 @@ class HardwareResourceModel:
     l3_access_latency_ns: Optional[float] = None
     dram_access_latency_ns: Optional[float] = None
 
+    # V5-5: per-tier achievable_fraction overrides for the V5-3b
+    # tier-aware roofline path. Maps tier name ("L1", "L2", "L3", "DRAM")
+    # to the calibrated achievable BW fraction (peak * fraction =
+    # effective). Empty default -> every tier defaults to 1.0 (ideal),
+    # which is what V5-1 / V5-3b shipped with.
+    #
+    # V5-5 only calibrates DRAM from vector_add baselines; L1 / L2 / L3
+    # entries stay absent until matmul-anchored calibration lands as a
+    # V5-5 follow-up. Per-mapper overrides are set in the factory
+    # functions, not here.
+    tier_achievable_fractions: Dict[str, float] = field(default_factory=dict)
+
     # M5 Layer 5: cache-coherence protocol class.
     # ``"snoopy_mesi"`` -- snoopy MESI / MOESI on shared bus or
     # ring (CPU multi-core, single-socket).
@@ -1110,27 +1170,46 @@ class HardwareResourceModel:
         per tier class when the mapper doesn't override (1.5 ns L1,
         10 ns L2, 30 ns L3, 100 ns DRAM). These defaults match consumer
         x86 / Ampere ballparks; specific mappers should override.
+
+        V5-5: ``tier_achievable_fractions`` overrides MemoryTier's default
+        ``achievable_fraction = 1.0`` per tier name. Mappers calibrated
+        against the V5-2b vector_add baselines set DRAM here (i7 = 0.47,
+        Jetson Orin Nano = 0.55 as of V5-5 PR). L1 / L2 / L3 entries
+        stay absent until the V5-5 follow-up calibrates them from
+        matmul data.
         """
         tiers: list["MemoryTier"] = []
+        # Per-tier achievable_fraction lookup; default to ideal (1.0)
+        # so existing un-calibrated mappers behave exactly as before.
+        af = self.tier_achievable_fractions
 
         # L1 (per-unit capacity, per-unit BW). Only emitted when both
         # capacity and BW are set. peak_bandwidth_bps stored on the tier
         # is the AGGREGATE (per-unit BW * compute_units) so callers can
         # treat all tiers uniformly; the per-unit value is recoverable
         # via tier.peak_bandwidth_bps / tier.num_units.
-        if (self.l1_cache_per_unit and self.l1_bandwidth_per_unit_bps
-                and self.l1_bandwidth_per_unit_bps > 0):
-            tiers.append(MemoryTier(
-                name="L1",
-                capacity_bytes=self.l1_cache_per_unit,
-                is_per_unit=True,
-                num_units=self.compute_units,
-                peak_bandwidth_bps=(self.l1_bandwidth_per_unit_bps
-                                    * self.compute_units),
-                access_latency_ns=(self.l1_access_latency_ns
-                                   if self.l1_access_latency_ns is not None
-                                   else 1.5),
-            ))
+        if (
+            self.l1_cache_per_unit
+            and self.l1_bandwidth_per_unit_bps
+            and self.l1_bandwidth_per_unit_bps > 0
+        ):
+            tiers.append(
+                MemoryTier(
+                    name="L1",
+                    capacity_bytes=self.l1_cache_per_unit,
+                    is_per_unit=True,
+                    num_units=self.compute_units,
+                    peak_bandwidth_bps=(
+                        self.l1_bandwidth_per_unit_bps * self.compute_units
+                    ),
+                    access_latency_ns=(
+                        self.l1_access_latency_ns
+                        if self.l1_access_latency_ns is not None
+                        else 1.5
+                    ),
+                    achievable_fraction=af.get("L1", 1.0),
+                )
+            )
 
         # L2. The M1 convention: ``l2_cache_total`` may carry either L2 (on
         # GPUs that have a distinct L2 -- e.g., H100) or LLC (on x86, where
@@ -1139,64 +1218,86 @@ class HardwareResourceModel:
         # is set; if the mapper has both ``l2_bandwidth_bps`` and
         # ``l3_bandwidth_bps``, the L3 tier is emitted as a separate hop
         # below.
-        if (self.l2_cache_total and self.l2_bandwidth_bps
-                and self.l2_bandwidth_bps > 0):
-            tiers.append(MemoryTier(
-                name="L2",
-                capacity_bytes=self.l2_cache_total,
-                is_per_unit=False,
-                num_units=1,
-                peak_bandwidth_bps=self.l2_bandwidth_bps,
-                access_latency_ns=(self.l2_access_latency_ns
-                                   if self.l2_access_latency_ns is not None
-                                   else 10.0),
-            ))
+        if self.l2_cache_total and self.l2_bandwidth_bps and self.l2_bandwidth_bps > 0:
+            tiers.append(
+                MemoryTier(
+                    name="L2",
+                    capacity_bytes=self.l2_cache_total,
+                    is_per_unit=False,
+                    num_units=1,
+                    peak_bandwidth_bps=self.l2_bandwidth_bps,
+                    access_latency_ns=(
+                        self.l2_access_latency_ns
+                        if self.l2_access_latency_ns is not None
+                        else 10.0
+                    ),
+                    achievable_fraction=af.get("L2", 1.0),
+                )
+            )
 
         # L3 / LLC (CPU only, typically). Distinct from L2 only on x86
         # where ``l2_cache_total`` carries the LLC value but we want a
         # separate hop. On i7-12700K post-#94: l3_bandwidth_bps=200e9
         # but no l2_bandwidth_bps, so the hierarchy is L1 -> L3 -> DRAM
         # (no distinct L2 hop).
-        if (self.l3_cache_total and self.l3_bandwidth_bps
-                and self.l3_bandwidth_bps > 0):
-            tiers.append(MemoryTier(
-                name="L3",
-                capacity_bytes=self.l3_cache_total,
-                is_per_unit=False,
-                num_units=1,
-                peak_bandwidth_bps=self.l3_bandwidth_bps,
-                access_latency_ns=(self.l3_access_latency_ns
-                                   if self.l3_access_latency_ns is not None
-                                   else 30.0),
-            ))
-        elif (self.l2_cache_total and not self.l2_bandwidth_bps
-              and self.l3_bandwidth_bps and self.l3_bandwidth_bps > 0):
+        if self.l3_cache_total and self.l3_bandwidth_bps and self.l3_bandwidth_bps > 0:
+            tiers.append(
+                MemoryTier(
+                    name="L3",
+                    capacity_bytes=self.l3_cache_total,
+                    is_per_unit=False,
+                    num_units=1,
+                    peak_bandwidth_bps=self.l3_bandwidth_bps,
+                    access_latency_ns=(
+                        self.l3_access_latency_ns
+                        if self.l3_access_latency_ns is not None
+                        else 30.0
+                    ),
+                    achievable_fraction=af.get("L3", 1.0),
+                )
+            )
+        elif (
+            self.l2_cache_total
+            and not self.l2_bandwidth_bps
+            and self.l3_bandwidth_bps
+            and self.l3_bandwidth_bps > 0
+        ):
             # x86 fallback: ``l2_cache_total`` carries the LLC (which IS L3
             # on x86), and ``l3_bandwidth_bps`` is the matching BW. Emit
             # this as a single L3 tier using the L2_total capacity.
-            tiers.append(MemoryTier(
-                name="L3",
-                capacity_bytes=self.l2_cache_total,
-                is_per_unit=False,
-                num_units=1,
-                peak_bandwidth_bps=self.l3_bandwidth_bps,
-                access_latency_ns=(self.l3_access_latency_ns
-                                   if self.l3_access_latency_ns is not None
-                                   else 30.0),
-            ))
+            tiers.append(
+                MemoryTier(
+                    name="L3",
+                    capacity_bytes=self.l2_cache_total,
+                    is_per_unit=False,
+                    num_units=1,
+                    peak_bandwidth_bps=self.l3_bandwidth_bps,
+                    access_latency_ns=(
+                        self.l3_access_latency_ns
+                        if self.l3_access_latency_ns is not None
+                        else 30.0
+                    ),
+                    achievable_fraction=af.get("L3", 1.0),
+                )
+            )
 
         # DRAM is always present (every mapper sets peak_bandwidth +
         # main_memory; these are required fields).
-        tiers.append(MemoryTier(
-            name="DRAM",
-            capacity_bytes=self.main_memory,
-            is_per_unit=False,
-            num_units=1,
-            peak_bandwidth_bps=self.peak_bandwidth,
-            access_latency_ns=(self.dram_access_latency_ns
-                               if self.dram_access_latency_ns is not None
-                               else 100.0),
-        ))
+        tiers.append(
+            MemoryTier(
+                name="DRAM",
+                capacity_bytes=self.main_memory,
+                is_per_unit=False,
+                num_units=1,
+                peak_bandwidth_bps=self.peak_bandwidth,
+                access_latency_ns=(
+                    self.dram_access_latency_ns
+                    if self.dram_access_latency_ns is not None
+                    else 100.0
+                ),
+                achievable_fraction=af.get("DRAM", 1.0),
+            )
+        )
 
         return tiers
 
@@ -1303,6 +1404,7 @@ class HardwareAllocation:
 
     This describes how one fused subgraph actually executes on hardware.
     """
+
     subgraph_id: str
     subgraph_name: str
     precision: Precision  # Numerical precision for this operation
@@ -1340,6 +1442,7 @@ class GraphHardwareAllocation:
 
     This is the final output of Phase 2: realistic utilization estimates.
     """
+
     model_name: str
     hardware_name: str
     batch_size: int
@@ -1415,7 +1518,7 @@ class HardwareMapper(ABC):
     def __init__(
         self,
         resource_model: HardwareResourceModel,
-        thermal_profile: Optional[str] = None
+        thermal_profile: Optional[str] = None,
     ):
         """
         Initialize hardware mapper.
@@ -1450,7 +1553,7 @@ class HardwareMapper(ABC):
         subgraph: FusedSubgraph,
         execution_stage: int,
         concurrent_subgraphs: int,
-        precision: Precision = Precision.FP32
+        precision: Precision = Precision.FP32,
     ) -> HardwareAllocation:
         """
         Map a single fused subgraph to hardware resources.
@@ -1472,7 +1575,7 @@ class HardwareMapper(ABC):
         fusion_report: FusionReport,
         execution_stages: List[List[int]],
         batch_size: int = 1,
-        precision: Precision = Precision.FP32
+        precision: Precision = Precision.FP32,
     ) -> GraphHardwareAllocation:
         """
         Map entire computation graph to hardware.
@@ -1498,7 +1601,7 @@ class HardwareMapper(ABC):
         bytes_transferred: int,
         allocated_units: int,
         occupancy: float,
-        precision: Precision
+        precision: Precision,
     ) -> Tuple[float, float, BottleneckType]:
         """
         Calculate latency for an operation using roofline model.
@@ -1519,7 +1622,9 @@ class HardwareMapper(ABC):
         # Get effective ops/sec for this precision
         if self.thermal_profile and self.resource_model.thermal_operating_points:
             # NEW: Use thermal operating point with DVFS and empirical derates
-            thermal_point = self.resource_model.thermal_operating_points[self.thermal_profile]
+            thermal_point = self.resource_model.thermal_operating_points[
+                self.thermal_profile
+            ]
 
             if precision in thermal_point.performance_specs:
                 perf_spec = thermal_point.performance_specs[precision]
@@ -1535,9 +1640,9 @@ class HardwareMapper(ABC):
 
         # Apply hardware utilization
         effective_ops_per_sec = (
-            base_ops_per_sec *
-            (allocated_units / self.resource_model.compute_units) *
-            occupancy
+            base_ops_per_sec
+            * (allocated_units / self.resource_model.compute_units)
+            * occupancy
         )
         compute_time = ops / effective_ops_per_sec if effective_ops_per_sec > 0 else 0
 
@@ -1555,10 +1660,7 @@ class HardwareMapper(ABC):
         return compute_time, memory_time, bottleneck
 
     def _calculate_energy(
-        self,
-        ops: int,
-        bytes_transferred: int,
-        precision: Precision
+        self, ops: int, bytes_transferred: int, precision: Precision
     ) -> Tuple[float, float]:
         """
         Calculate energy consumption.
@@ -1584,8 +1686,8 @@ class HardwareMapper(ABC):
         ops: int,
         bytes_transferred: int,
         precision: Precision,
-        execution_context: Optional[Dict] = None
-    ) -> Tuple[float, float, Optional['ArchitecturalEnergyBreakdown']]:
+        execution_context: Optional[Dict] = None,
+    ) -> Tuple[float, float, Optional["ArchitecturalEnergyBreakdown"]]:
         """
         Calculate energy consumption WITH architectural overhead.
 
@@ -1610,7 +1712,9 @@ class HardwareMapper(ABC):
 
         # Add architectural energy if model available
         if self.resource_model.architecture_energy_model:
-            from graphs.hardware.architectural_energy import ArchitecturalEnergyBreakdown
+            from graphs.hardware.architectural_energy import (
+                ArchitecturalEnergyBreakdown,
+            )
 
             if execution_context is None:
                 execution_context = {}
@@ -1620,7 +1724,7 @@ class HardwareMapper(ABC):
                 bytes_transferred=bytes_transferred,
                 compute_energy_baseline=compute_energy,
                 data_movement_energy_baseline=memory_energy,
-                execution_context=execution_context
+                execution_context=execution_context,
             )
 
             # Apply architectural overheads
@@ -1652,7 +1756,7 @@ class HardwareMapper(ABC):
 #
 # Models are organized by category:
 #   - models/datacenter/    : High-end GPUs, TPUs, and server CPUs
-#   - models/edge/          : Edge AI accelerators and SBCs  
+#   - models/edge/          : Edge AI accelerators and SBCs
 #   - models/automotive/    : Automotive-grade SoCs
 #   - models/mobile/        : Mobile GPUs and SoCs
 #   - models/accelerators/  : Fixed-function and reconfigurable accelerators

--- a/tests/hardware/test_tier_achievable_fractions.py
+++ b/tests/hardware/test_tier_achievable_fractions.py
@@ -19,7 +19,6 @@ from graphs.hardware.mappers.gpu import create_jetson_orin_nano_8gb_mapper
 from graphs.hardware.resource_model import (
     HardwareResourceModel,
     HardwareType,
-    MemoryTier,
     Precision,
     PrecisionProfile,
 )
@@ -133,6 +132,18 @@ def test_i7_12700k_non_dram_tiers_uncalibrated():
     for t in hw.memory_hierarchy:
         if t.name != "DRAM":
             assert t.achievable_fraction == 1.0
+
+
+def test_i7_12700k_large_mapper_inherits_dram_calibration():
+    """create_i7_12700k_large_mapper() represents the same DDR5
+    subsystem as the tiny-model variant. The DRAM achievable_fraction
+    must match (0.47), or once tier-aware memory is enabled the large
+    variant would over-predict throughput by 2x relative to its
+    sibling on the same hardware."""
+    from graphs.hardware.mappers.cpu import create_i7_12700k_large_mapper
+
+    hw = create_i7_12700k_large_mapper().resource_model
+    assert hw.tier_achievable_fractions.get("DRAM") == 0.47
 
 
 def test_jetson_orin_nano_dram_calibration():

--- a/tests/hardware/test_tier_achievable_fractions.py
+++ b/tests/hardware/test_tier_achievable_fractions.py
@@ -1,0 +1,147 @@
+"""V5-5 calibration tests for HardwareResourceModel.tier_achievable_fractions.
+
+Locks in:
+- The new field defaults to an empty dict; absence of an override means
+  the tier's effective_bandwidth_bps == peak_bandwidth_bps (i.e., the
+  V5-1 / V5-3b-shipped behavior).
+- Per-tier overrides flow through memory_hierarchy: setting
+  ``{"DRAM": 0.47}`` on the resource model produces a DRAM tier whose
+  effective_bandwidth_bps is 47% of peak.
+- The calibrated mappers (i7-12700K, Jetson Orin Nano 8GB) have the
+  V5-5 DRAM achievable_fraction values from the V5-2b vector_add
+  baselines (i7 = 0.47, Jetson = 0.55).
+"""
+
+import pytest
+
+from graphs.hardware.mappers.cpu import create_i7_12700k_mapper
+from graphs.hardware.mappers.gpu import create_jetson_orin_nano_8gb_mapper
+from graphs.hardware.resource_model import (
+    HardwareResourceModel,
+    HardwareType,
+    MemoryTier,
+    Precision,
+    PrecisionProfile,
+)
+
+
+# ---------------------------------------------------------------------------
+# Field default + plumbing
+# ---------------------------------------------------------------------------
+
+
+def _bare_resource_model(**overrides) -> HardwareResourceModel:
+    """Minimal HardwareResourceModel for testing the field plumbing.
+
+    Only the required fields + DRAM-bandwidth + main_memory are set;
+    omitting on-chip BW peaks gives a DRAM-only memory_hierarchy
+    (matches the V5-1 docstring on un-calibrated mappers)."""
+    base = dict(
+        name="test",
+        hardware_type=HardwareType.CPU,
+        compute_units=1,
+        threads_per_unit=1,
+        warps_per_unit=1,
+        warp_size=1,
+        precision_profiles={
+            Precision.FP32: PrecisionProfile(
+                precision=Precision.FP32,
+                peak_ops_per_sec=1e12,
+                tensor_core_supported=False,
+            )
+        },
+        default_precision=Precision.FP32,
+        peak_bandwidth=100e9,  # 100 GB/s
+        l1_cache_per_unit=32 * 1024,
+        l2_cache_total=1 * 1024 * 1024,
+        main_memory=16 * 1024**3,
+        energy_per_flop_fp32=1e-12,
+        energy_per_byte=1e-11,
+    )
+    base.update(overrides)
+    return HardwareResourceModel(**base)
+
+
+def test_default_tier_achievable_fractions_is_empty_dict():
+    """Field must default to an empty dict so existing un-calibrated
+    mappers keep their pre-V5-5 behavior (every tier at peak)."""
+    hw = _bare_resource_model()
+    assert hw.tier_achievable_fractions == {}
+
+
+def test_dram_tier_uses_peak_bandwidth_when_no_override():
+    """Without an override, MemoryTier.achievable_fraction defaults to
+    1.0 (V5-1 contract) and effective_bandwidth_bps == peak."""
+    hw = _bare_resource_model()
+    dram = next(t for t in hw.memory_hierarchy if t.name == "DRAM")
+    assert dram.achievable_fraction == 1.0
+    assert dram.effective_bandwidth_bps == dram.peak_bandwidth_bps == 100e9
+
+
+def test_dram_override_flows_through_to_effective_bandwidth():
+    """Setting {"DRAM": 0.47} on the resource model produces a DRAM
+    MemoryTier with effective_bandwidth_bps == 47% of peak."""
+    hw = _bare_resource_model(tier_achievable_fractions={"DRAM": 0.47})
+    dram = next(t for t in hw.memory_hierarchy if t.name == "DRAM")
+    assert dram.achievable_fraction == 0.47
+    assert dram.effective_bandwidth_bps == pytest.approx(100e9 * 0.47)
+
+
+def test_unset_tiers_default_to_one_when_other_tier_is_overridden():
+    """Setting only DRAM must not perturb other tiers (they default to
+    1.0 even though the overrides dict is non-empty)."""
+    hw = _bare_resource_model(
+        l1_bandwidth_per_unit_bps=200e9,
+        tier_achievable_fractions={"DRAM": 0.47},
+    )
+    tiers = {t.name: t for t in hw.memory_hierarchy}
+    assert tiers["L1"].achievable_fraction == 1.0
+    assert tiers["DRAM"].achievable_fraction == 0.47
+
+
+def test_invalid_fraction_raises_at_construction():
+    """MemoryTier validates achievable_fraction is in [0, 1] in
+    __post_init__. An override out of range must surface as a
+    construction-time ValueError, not a silent garbage value at
+    analysis time."""
+    hw = _bare_resource_model(tier_achievable_fractions={"DRAM": 1.5})
+    with pytest.raises(ValueError, match="achievable_fraction"):
+        _ = hw.memory_hierarchy
+
+
+# ---------------------------------------------------------------------------
+# Calibrated mappers: i7-12700K + Jetson Orin Nano 8GB
+# ---------------------------------------------------------------------------
+
+
+def test_i7_12700k_dram_calibration():
+    """i7-12700K DRAM achievable_fraction = 0.47 derived from the
+    V5-2b vector_add baseline (median of 35.2 / 34.7 / 36.7 GB/s on
+    16M / 67M / 268M elements; peak 75 GB/s)."""
+    hw = create_i7_12700k_mapper().resource_model
+    assert hw.tier_achievable_fractions.get("DRAM") == 0.47
+    dram = next(t for t in hw.memory_hierarchy if t.name == "DRAM")
+    assert dram.achievable_fraction == 0.47
+    # 75 GB/s * 0.47 = 35.25 GB/s -- matches the measured plateau
+    assert dram.effective_bandwidth_bps == pytest.approx(75e9 * 0.47)
+
+
+def test_i7_12700k_non_dram_tiers_uncalibrated():
+    """V5-5 only ships DRAM calibration; L1 and L3 stay at 1.0
+    pending the matmul-anchored follow-up."""
+    hw = create_i7_12700k_mapper().resource_model
+    for t in hw.memory_hierarchy:
+        if t.name != "DRAM":
+            assert t.achievable_fraction == 1.0
+
+
+def test_jetson_orin_nano_dram_calibration():
+    """Jetson Orin Nano (Super) DRAM achievable_fraction = 0.55
+    derived from the V5-2b vector_add baseline at the 15W thermal
+    profile (median of 61.6 / 56.4 / 56.6 GB/s on 16M / 67M / 268M
+    fp16 elements; peak 102 GB/s LPDDR5-6400)."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    assert hw.tier_achievable_fractions.get("DRAM") == 0.55
+    dram = next(t for t in hw.memory_hierarchy if t.name == "DRAM")
+    assert dram.achievable_fraction == 0.55
+    assert dram.effective_bandwidth_bps == pytest.approx(102e9 * 0.55)


### PR DESCRIPTION
## Summary

V5-5 from `docs/plans/v5-memory-hierarchy-rewrite-plan.md`: per-tier
`achievable_fraction` overrides land as a first-class field on
`HardwareResourceModel`, plus calibrated DRAM values for the two
mappers with V5-2b vector_add baselines on main.

## What landed

### `HardwareResourceModel.tier_achievable_fractions`
Empty `Dict[str, float]` default → every tier defaults to 1.0 (preserves
V5-1 / V5-3b shipped behavior). `memory_hierarchy` looks up the per-tier
fraction via `af.get(tier_name, 1.0)` for each `MemoryTier` it constructs.

### Calibrated mappers

| Mapper | tier | derivation | fraction |
|---|---|---|---|
| **i7-12700K** | DRAM | `i7_12700k_vector_add.csv` plateau rows (16M/67M/268M; WS 192MB-3GB ≫ 25MB LLC); median 35 GB/s; peak 75 GB/s | **0.47** |
| **Jetson Orin Nano 8GB (Super)** | DRAM | `jetson_orin_nano_8gb_vector_add.csv` 15W plateau rows (16M/67M/268M fp16; WS 100MB-1.6GB ≫ 2MB L2); median 57 GB/s; peak 102 GB/s | **0.55** |

Spot check after the change:

```
i7-12700K:
  L1    cap=        327680   peak_bw=3500.00 GB/s   achievable_fraction=1.00   effective=3500.00 GB/s
  L3    cap=     26214400    peak_bw= 200.00 GB/s   achievable_fraction=1.00   effective= 200.00 GB/s
  DRAM  cap=  68719476736    peak_bw=  75.00 GB/s   achievable_fraction=0.47   effective=  35.25 GB/s
```

## Known limitations (V5-5 follow-up)

1. **V4 matmul floors unchanged with `--use-tier-aware-memory`.** The
   V5-3b tier picker assigns binding=L3 (not DRAM) for matmul shapes
   whose optimal C-tile fits in L1. The DRAM calibration only helps
   shapes the picker actually binds to DRAM (vector_add at WS > LLC).
   V4 vector_add validation is the natural use site; the workload
   exists (V5-2a) but no validation harness wires it yet.

2. **Jetson Orin Nano declined by V5-3b's `>=2 tiers` gate.** The
   mapper doesn't populate `l1_bandwidth_per_unit_bps` /
   `l2_bandwidth_bps`, so `memory_hierarchy` emits DRAM-only. The
   calibration is set so it activates as soon as on-chip BW peaks
   are populated (separate follow-up).

3. **L1 / L2 / L3 entries stay absent.** Calibrating them needs
   matmul measurements (not vector_add) and a model refinement so
   V5-3b's tier picker considers operand size relative to the binding
   tier (currently only looks at C-tile fit).

## Default flag stays off

V5-3b's `use_tier_aware_memory` default stays False. Exit criterion
\"matmul + linear V4 floors equal or improve\" requires per-tier
calibration this PR doesn't provide; the default flip lands in the
V5-5 follow-up after L3 calibration.

## Test plan

- [x] **8 new tests** in `tests/hardware/test_tier_achievable_fractions.py`:
  - field defaults to empty dict
  - `MemoryTier.achievable_fraction == 1.0` when no override
  - DRAM override flows through to `MemoryTier.effective_bandwidth_bps`
  - setting only DRAM doesn't perturb other tiers
  - out-of-range fraction raises `ValueError` at construction
  - i7-12700K has DRAM = 0.47; non-DRAM tiers stay at 1.0
  - Jetson Orin Nano 8GB has DRAM = 0.55
- [x] **V4 floor preservation**: 444 pre-V5-5 tests still pass; the
  existing `test_default_off_produces_identical_memory_time_to_pre_v5_3b`
  pins this
- [x] Spot check: tier picker on vector_add at N=16M (DRAM-bound)
  returns `effective_bw=35.25 GB/s` (= 75 × 0.47)
- [x] Total: 452 passed locally
- [ ] CI: full matrix passes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-fabric GPU architecture modeling for enhanced precision in hardware performance analysis.
  * Introduced thermal operating point profiles for Jetson Orin Nano 8GB (7W, 15W, MAXN configurations).
  * Implemented tier-based memory bandwidth calibration system for more accurate roofline calculations.
  * Enhanced precision-aware compute performance modeling with DVFS-aware scaling.

* **Refactor**
  * Restructured hardware mapping infrastructure for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->