### PR TITLE
feat(estimation,hardware): V5-5 follow-up -- operand-aware tier picker + i7 L3 calibration

### DIFF
--- a/src/graphs/estimation/reuse_models.py
+++ b/src/graphs/estimation/reuse_models.py
@@ -113,7 +113,6 @@ class ReuseModel(Protocol):
         window (3*N*bpe). The model is consistent across op kinds
         even when the answer is degenerate.
         """
-        ...
 
 
 class VectorAddReuseModel:

--- a/src/graphs/estimation/reuse_models.py
+++ b/src/graphs/estimation/reuse_models.py
@@ -95,6 +95,26 @@ class ReuseModel(Protocol):
         tile: TileChoice,
     ) -> int: ...
 
+    def operand_footprint_bytes(
+        self,
+        shape: Sequence[int],
+        dtype: str,
+    ) -> int:
+        """Total unique-data footprint the op needs to keep alive
+        somewhere in the memory hierarchy across one execution.
+
+        For ops with reuse (matmul, linear): A + B + C bytes -- this
+        is the working set that must live in some tier. The V5-5
+        operand-aware tier picker uses this to escalate the binding
+        tier when the C-tile fits a small inner cache but the
+        operands overflow it (skinny matmul case).
+
+        For ops without reuse (vector_add): same as the residency
+        window (3*N*bpe). The model is consistent across op kinds
+        even when the answer is degenerate.
+        """
+        ...
+
 
 class VectorAddReuseModel:
     """``c[i] = a[i] + b[i]`` on N elements -- the zero-reuse op.
@@ -129,6 +149,15 @@ class VectorAddReuseModel:
         shape: Sequence[int],
         dtype: str,
         tile: TileChoice,  # noqa: ARG002 -- not parameterized by tile choice
+    ) -> int:
+        (N,) = shape
+        bpe = bytes_per_element(dtype)
+        return int(round(3 * N * bpe))
+
+    def operand_footprint_bytes(
+        self,
+        shape: Sequence[int],
+        dtype: str,
     ) -> int:
         (N,) = shape
         bpe = bytes_per_element(dtype)
@@ -197,6 +226,17 @@ class MatmulReuseModel:
         c_bytes = 2 * M * N * bpe
         return int(round(a_bytes + b_bytes + c_bytes))
 
+    def operand_footprint_bytes(
+        self,
+        shape: Sequence[int],
+        dtype: str,
+    ) -> int:
+        if len(shape) != 3:
+            raise ValueError(f"matmul expects 3-D shape (M, K, N), got {tuple(shape)}")
+        M, K, N = shape
+        bpe = bytes_per_element(dtype)
+        return int(round((M * K + K * N + M * N) * bpe))
+
 
 class LinearReuseModel:
     """``y = x @ W^T + b`` with shape ``(B, IN, OUT)``.
@@ -232,6 +272,18 @@ class LinearReuseModel:
     ) -> int:
         B, IN, OUT = shape
         return self._delegate.bytes_loaded_from_binding((B, IN, OUT), dtype, tile)
+
+    def operand_footprint_bytes(
+        self,
+        shape: Sequence[int],
+        dtype: str,
+    ) -> int:
+        if len(shape) != 3:
+            raise ValueError(
+                f"linear expects 3-D shape (B, IN, OUT), got {tuple(shape)}"
+            )
+        B, IN, OUT = shape
+        return self._delegate.operand_footprint_bytes((B, IN, OUT), dtype)
 
 
 REUSE_MODELS: Dict[str, ReuseModel] = {

--- a/src/graphs/estimation/tier_picker.py
+++ b/src/graphs/estimation/tier_picker.py
@@ -72,58 +72,78 @@ def pick_binding_tier(
     dtype: str,
     hierarchy: Sequence[MemoryTier],
 ) -> Optional[BindingTierResult]:
-    """Walk the memory hierarchy innermost-out to find the binding tier.
+    """Walk the memory hierarchy to pick (residency tier, binding tier).
 
-    Algorithm (per the V5 plan):
-      1. Sort tiers by aggregate capacity (already innermost-out for
-         standard mapper-built hierarchies; explicit sort guards against
-         mappers that emit out-of-order).
-      2. For each tier, ask the reuse model what tile and residency
-         window it would pick if this tier were the residency tier.
-      3. The first tier whose total capacity holds that residency window
-         is the residency tier. The binding tier is the next-larger one
-         (or itself if we're already at the outermost).
-      4. Bytes loaded from the binding tier come from the reuse model
-         applied at the chosen tile.
+    Algorithm (V5-5 follow-up; supersedes the simpler "binding = next
+    outward of residency" rule from V5-3b):
 
-    Returns ``None`` if the hierarchy is empty (the caller should fall
-    back to the scalar bw_efficiency_scale path). All other inputs are
-    handled by the reuse model and ``MemoryTier`` invariants -- no
-    silent NaNs / negatives slip through.
+      1. Sort tiers innermost-out by aggregate capacity.
+      2. Residency tier = smallest tier whose capacity holds the per-op
+         tile (sized for that tier). For matmul this is the C-tile; for
+         vector_add the full working set.
+      3. Binding tier = smallest tier whose capacity holds the
+         **operand footprint** (A + B + C for matmul; full WS for
+         vector_add). This is independent of where residency landed.
+         If the operand footprint exceeds even the outermost tier, the
+         outermost tier (typically DRAM) is the binding tier and the
+         analyzer will surface the right "memory-bound" verdict from
+         the resulting bytes_loaded / effective_bw math.
+
+    Why operand-aware? Skinny matmul shapes like (M=64, K=1024, N=8192)
+    fp32 have an L1-resident C-tile but A+B+C = 35.9 MB which doesn't
+    fit i7's 25 MB L3. The simple "binding = residency + 1" rule
+    pinned binding=L3 -> apparent throughput at L3 BW (200 GB/s peak),
+    but the operands actually have to come from DRAM (75 GB/s peak,
+    35 GB/s calibrated). Operand-aware binding correctly escalates to
+    DRAM for these shapes, which is exactly the case where the V5-5
+    DRAM calibration bites.
+
+    For vector_add at small N (e.g. 12 KB working set), this also
+    changes the answer: instead of binding=L3 (next outward of L1
+    residency), binding=L1 (operands fit L1). For warm-cache
+    benchmarks that's the realistic answer.
+
+    Returns ``None`` if the hierarchy is empty (the caller falls back
+    to the scalar bw_efficiency_scale path).
     """
     if not hierarchy:
         return None
 
     tiers = sorted(hierarchy, key=lambda t: t.total_capacity_bytes)
 
-    for idx, tier in enumerate(tiers):
-        tile = reuse_model.residency_window(
+    # 1) Residency tier: smallest tier whose capacity holds the op's tile.
+    residency_tier: Optional[MemoryTier] = None
+    tile: Optional[TileChoice] = None
+    for tier in tiers:
+        candidate_tile = reuse_model.residency_window(
             shape, dtype, tier_capacity_bytes=tier.total_capacity_bytes
         )
-        if tile.residency_bytes <= tier.total_capacity_bytes:
-            binding_tier = tiers[idx + 1] if idx + 1 < len(tiers) else tier
-            bytes_loaded = reuse_model.bytes_loaded_from_binding(shape, dtype, tile)
-            return BindingTierResult(
-                binding_tier=binding_tier,
-                residency_tier=tier,
-                tile=tile,
-                bytes_loaded=int(bytes_loaded),
-            )
+        if candidate_tile.residency_bytes <= tier.total_capacity_bytes:
+            residency_tier = tier
+            tile = candidate_tile
+            break
 
-    # No tier holds the residency window -- the working set overflows even
-    # the outermost tier (typically only happens for vector ops at sizes
-    # that exceed DRAM, which is an OOM scenario, not a roofline one).
-    # Fall through: bind at the outermost tier with whatever tile the
-    # reuse model picks for that capacity. The analyzer will see a very
-    # large bytes_loaded and surface the right "memory-bound" verdict.
-    outer = tiers[-1]
-    tile = reuse_model.residency_window(
-        shape, dtype, tier_capacity_bytes=outer.total_capacity_bytes
-    )
+    if residency_tier is None:
+        # No tier holds the tile (working set overflows even outermost).
+        # Fall through: residency = outermost; tile sized for it.
+        residency_tier = tiers[-1]
+        tile = reuse_model.residency_window(
+            shape, dtype, tier_capacity_bytes=residency_tier.total_capacity_bytes
+        )
+
+    # 2) Binding tier: smallest tier whose capacity holds the operand
+    #    footprint. Walks innermost-out independent of residency tier.
+    operand_bytes = reuse_model.operand_footprint_bytes(shape, dtype)
+    binding_tier: MemoryTier = tiers[-1]  # default = outermost
+    for tier in tiers:
+        if operand_bytes <= tier.total_capacity_bytes:
+            binding_tier = tier
+            break
+
     bytes_loaded = reuse_model.bytes_loaded_from_binding(shape, dtype, tile)
     return BindingTierResult(
-        binding_tier=outer,
-        residency_tier=outer,
+        binding_tier=binding_tier,
+        residency_tier=residency_tier,
         tile=tile,
         bytes_loaded=int(bytes_loaded),
     )

--- a/src/graphs/hardware/mappers/cpu.py
+++ b/src/graphs/hardware/mappers/cpu.py
@@ -924,7 +924,14 @@ def create_i7_12700k_mapper() -> CPUMapper:
         # the V5-3b tier-aware roofline path when opt-in (or after the
         # V5-5 follow-up flips the default). L1 / L3 entries stay
         # absent (default 1.0) until matmul-anchored calibration.
-        tier_achievable_fractions={"DRAM": 0.47},
+        # V5-5 + follow-up calibration:
+        #   DRAM = 0.47 (i7_12700k_vector_add.csv plateau, peak 75 GB/s)
+        #   L3   = 0.82 (i7_12700k_vector_add.csv at N=1M fp32, the
+        #                cleanest L3-resident measurement: WS=12 MB
+        #                between L1=512 KB and L3=25 MB, measured
+        #                163 GB/s vs L3 peak 200 GB/s -> 163/200 = 0.82).
+        # L1 stays absent until matmul-anchored calibration.
+        tier_achievable_fractions={"L3": 0.82, "DRAM": 0.47},
     )
 
     return CPUMapper(model)
@@ -1136,7 +1143,14 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
         # so the calibrated DRAM achievable_fraction applies identically.
         # See the tiny-model variant for derivation (median 35 GB/s
         # plateau on N=16M/67M/268M vector_add baseline; peak 75 GB/s).
-        tier_achievable_fractions={"DRAM": 0.47},
+        # V5-5 + follow-up calibration:
+        #   DRAM = 0.47 (i7_12700k_vector_add.csv plateau, peak 75 GB/s)
+        #   L3   = 0.82 (i7_12700k_vector_add.csv at N=1M fp32, the
+        #                cleanest L3-resident measurement: WS=12 MB
+        #                between L1=512 KB and L3=25 MB, measured
+        #                163 GB/s vs L3 peak 200 GB/s -> 163/200 = 0.82).
+        # L1 stays absent until matmul-anchored calibration.
+        tier_achievable_fractions={"L3": 0.82, "DRAM": 0.47},
     )
 
     return CPUMapper(model)

--- a/tests/analysis/test_reuse_models.py
+++ b/tests/analysis/test_reuse_models.py
@@ -313,6 +313,55 @@ def test_get_reuse_model_returns_correct_op(op_kind):
     assert model.op_kind == op_kind
 
 
+# ---------------------------------------------------------------------------
+# operand_footprint_bytes (V5-5 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def test_vector_add_operand_footprint_equals_three_times_n_bytes():
+    """vector_add operand footprint is 3*N*bpe -- same as residency
+    (degenerate case for zero-reuse op). The V5-5 tier picker uses
+    this to decide where the data lives."""
+    model = VectorAddReuseModel()
+    assert model.operand_footprint_bytes((1024,), "fp32") == 3 * 1024 * 4
+    assert model.operand_footprint_bytes((4096,), "fp16") == 3 * 4096 * 2
+    assert model.operand_footprint_bytes((1,), "fp64") == 24
+
+
+def test_matmul_operand_footprint_is_a_plus_b_plus_c():
+    """matmul (M, K, N) fp32: A=M*K, B=K*N, C=M*N elements; *bpe each."""
+    model = MatmulReuseModel()
+    M, K, N = 1024, 1024, 1024
+    expected = (M * K + K * N + M * N) * 4
+    assert model.operand_footprint_bytes((M, K, N), "fp32") == expected
+
+    # Skinny shape: small C-tile, but operands are big
+    M, K, N = 64, 1024, 8192
+    expected = (M * K + K * N + M * N) * 4
+    assert model.operand_footprint_bytes((M, K, N), "fp32") == expected
+
+
+def test_matmul_operand_footprint_rejects_non_3d_shape():
+    model = MatmulReuseModel()
+    with pytest.raises(ValueError, match="3-D shape"):
+        model.operand_footprint_bytes((1024, 1024), "fp32")
+
+
+def test_linear_operand_footprint_matches_matmul_delegate():
+    lin = LinearReuseModel()
+    mm = MatmulReuseModel()
+    B, IN, OUT = 32, 512, 256
+    assert lin.operand_footprint_bytes(
+        (B, IN, OUT), "fp32"
+    ) == mm.operand_footprint_bytes((B, IN, OUT), "fp32")
+
+
+def test_linear_operand_footprint_rejects_non_3d():
+    lin = LinearReuseModel()
+    with pytest.raises(ValueError, match="3-D shape"):
+        lin.operand_footprint_bytes((512, 256), "fp32")
+
+
 def test_get_reuse_model_unknown_raises():
     with pytest.raises(ValueError, match="No reuse model"):
         get_reuse_model("conv2d")

--- a/tests/analysis/test_tier_picker.py
+++ b/tests/analysis/test_tier_picker.py
@@ -129,40 +129,45 @@ def test_matmul_residency_in_l1_binds_at_l3():
     assert result.tile.residency_bytes <= hierarchy[0].total_capacity_bytes
 
 
-def test_matmul_residency_in_l3_binds_at_dram():
-    """Big matmul whose tile would not fit L1 but fits in L3 should
-    bind at DRAM. Pick a shape whose L1-sized tile chooses min(M,N)=64
-    (clamped, residency = 49 KB << L1 = 512 KB)... wait: clamping
-    means the residency is small even with a huge cache. Need to use
-    a shape big enough that the optimal-square tile under L1 is the
-    L1-sized one (not clamped). Use (4096, 4096, 4096): with L1
-    capacity 512 KB, tile = floor(sqrt(512K/12)) = 209; residency
-    = 524,108 bytes ~= 512 KB -- fits L1, binds at L3.
-
-    To force binding at DRAM, the residency window when computed
-    for L3's capacity must overflow L1. Use (4096, 4096, 4096) with
-    L1 hierarchy returns L3-bound? No -- L1 fits because the tile
-    sizing scales with capacity.
-
-    Real test: when the residency for L1 picks a tile that still
-    fits L1, the algorithm correctly returns L3 as binding. To
-    actually bind at DRAM we'd need the L3 tier's residency-window
-    to overflow L3, which only happens when min(M,N) is so large
-    that the L3-sized clamp blows past L3 -- a contrived case.
-    For now assert the L3 tier is correctly identified as binding
-    for a representative shape."""
+def test_matmul_4096_cube_binds_at_dram_due_to_operand_overflow():
+    """Big matmul (4096, 4096, 4096) fp32: operand footprint =
+    3 * 4096^2 * 4 = 192 MB, well past i7's 25 MB L3. Even though
+    the L1-sized C-tile fits, the V5-5 operand-aware binding walk
+    correctly escalates to DRAM."""
     hierarchy = _i7_like_hierarchy()
     result = pick_binding_tier(
         MatmulReuseModel(), (4096, 4096, 4096), "fp32", hierarchy
     )
     assert result is not None
-    # Whatever residency tier the algorithm picks, the binding tier
-    # must be the next-larger one, never the same tier (unless we're
-    # at DRAM, the outermost).
-    assert result.residency_tier in hierarchy
-    if result.residency_tier.name != "DRAM":
-        idx = hierarchy.index(result.residency_tier)
-        assert result.binding_tier == hierarchy[idx + 1]
+    assert result.binding_tier.name == "DRAM"
+
+
+def test_matmul_skinny_shape_escalates_to_dram_when_operands_overflow_l3():
+    """V5-5 follow-up regression: matmul (64, 1024, 8192) fp32 has
+    a tiny clamped C-tile that fits in L1, but operand footprint
+    = (64*1024 + 1024*8192 + 64*8192) * 4 = ~35.9 MB, doesn't fit
+    in i7's 25 MB L3. Operand-aware binding correctly returns
+    DRAM here (whereas the V5-3b "next-outward-of-residency" rule
+    that this PR replaces would have returned L3 -- the
+    motivation for the V5-5 follow-up)."""
+    hierarchy = _i7_like_hierarchy()
+    result = pick_binding_tier(MatmulReuseModel(), (64, 1024, 8192), "fp32", hierarchy)
+    assert result is not None
+    assert result.binding_tier.name == "DRAM"
+    assert result.residency_tier.name == "L1"
+
+
+def test_matmul_small_shape_binds_at_l3_when_operands_fit():
+    """Negative case: matmul (1024, 1024, 1024) fp32 has operand
+    footprint = 3 * 1024^2 * 4 = 12 MB which fits L3 (25 MB). The
+    binding tier should stay at L3, NOT escalate to DRAM."""
+    hierarchy = _i7_like_hierarchy()
+    result = pick_binding_tier(
+        MatmulReuseModel(), (1024, 1024, 1024), "fp32", hierarchy
+    )
+    assert result is not None
+    assert result.binding_tier.name == "L3"
+    assert result.residency_tier.name == "L1"
 
 
 # ---------------------------------------------------------------------------
@@ -170,14 +175,18 @@ def test_matmul_residency_in_l3_binds_at_dram():
 # ---------------------------------------------------------------------------
 
 
-def test_vector_add_small_n_binds_at_l3():
-    """vector_add at N=1024 fp32 -> WS = 12 KB. Fits in L1 (aggregate
-    512 KB). Binding tier = L3."""
+def test_vector_add_small_n_binds_at_l1():
+    """vector_add at N=1024 fp32 -> operand footprint = 12 KB. Fits in
+    L1 (aggregate 512 KB), so V5-5 operand-aware binding correctly
+    returns L1 (the lowest tier holding the data; warm-cache hits at
+    L1 BW). Pre-V5-5-followup behavior was L3 (next outward of
+    residency); the new behavior is more honest about where the data
+    actually streams from."""
     hierarchy = _i7_like_hierarchy()
     result = pick_binding_tier(VectorAddReuseModel(), (1024,), "fp32", hierarchy)
     assert result is not None
     assert result.residency_tier.name == "L1"
-    assert result.binding_tier.name == "L3"
+    assert result.binding_tier.name == "L1"
     assert result.bytes_loaded == 3 * 1024 * 4
 
 

--- a/tests/hardware/test_tier_achievable_fractions.py
+++ b/tests/hardware/test_tier_achievable_fractions.py
@@ -125,13 +125,26 @@ def test_i7_12700k_dram_calibration():
     assert dram.effective_bandwidth_bps == pytest.approx(75e9 * 0.47)
 
 
-def test_i7_12700k_non_dram_tiers_uncalibrated():
-    """V5-5 only ships DRAM calibration; L1 and L3 stay at 1.0
-    pending the matmul-anchored follow-up."""
+def test_i7_12700k_l3_calibration():
+    """V5-5 follow-up: i7-12700K L3 achievable_fraction = 0.82
+    derived from the vector_add baseline at N=1M fp32 -- the
+    cleanest L3-resident row (working set 12 MB between L1=512 KB
+    and L3=25 MB, measured 163 GB/s vs L3 peak 200 GB/s)."""
     hw = create_i7_12700k_mapper().resource_model
-    for t in hw.memory_hierarchy:
-        if t.name != "DRAM":
-            assert t.achievable_fraction == 1.0
+    assert hw.tier_achievable_fractions.get("L3") == 0.82
+    l3 = next(t for t in hw.memory_hierarchy if t.name == "L3")
+    assert l3.achievable_fraction == 0.82
+    assert l3.effective_bandwidth_bps == pytest.approx(200e9 * 0.82)
+
+
+def test_i7_12700k_l1_uncalibrated():
+    """V5-5 follow-up still leaves L1 absent (default 1.0). Pure
+    L1-BW calibration would need a sub-microsecond benchmark that
+    isolates L1 BW from dispatch overhead, which the V5-2b
+    vector_add baseline doesn't provide cleanly."""
+    hw = create_i7_12700k_mapper().resource_model
+    l1 = next(t for t in hw.memory_hierarchy if t.name == "L1")
+    assert l1.achievable_fraction == 1.0
 
 
 def test_i7_12700k_large_mapper_inherits_dram_calibration():
@@ -144,6 +157,9 @@ def test_i7_12700k_large_mapper_inherits_dram_calibration():
 
     hw = create_i7_12700k_large_mapper().resource_model
     assert hw.tier_achievable_fractions.get("DRAM") == 0.47
+    # V5-5 follow-up also propagates the L3 calibration so the two
+    # sibling mappers stay in lock-step on the same hardware.
+    assert hw.tier_achievable_fractions.get("L3") == 0.82
 
 
 def test_jetson_orin_nano_dram_calibration():


### PR DESCRIPTION
## Summary

V5-5 follow-up (the model-refinement + L3 calibration noted as known
limitations on PR #103). Two tightly-coupled pieces:

**Part A** -- `pick_binding_tier` now considers the operand footprint
when picking the binding tier, fixing skinny-matmul shapes that the
V5-3b \"next-outward-of-residency\" rule mis-classified.

**Part B** -- i7-12700K L3 `achievable_fraction` = 0.82, derived from
the V5-2b vector_add baseline at the cleanest L3-resident shape.

Both pieces are needed together: Part B's calibration only reaches
the right shapes once Part A correctly identifies them as L3-bound.

## Part A: operand-aware tier picker

`ReuseModel` gains `operand_footprint_bytes(shape, dtype) -> int`:
- **VectorAdd**: `3*N*bpe` (same as residency, since zero-reuse)
- **Matmul**:   `(M*K + K*N + M*N) * bpe`
- **Linear**:   delegates to matmul

`pick_binding_tier` picks binding tier as the smallest tier whose
capacity holds the operand footprint -- **independent of residency**.
This supersedes V5-3b's \"binding = next-outward-of-residency\" rule.

### Why

Matmul `(64, 1024, 8192)` fp32 has a tiny clamped C-tile (49 KB) that
fits L1, but operands are 35.9 MB and don't fit i7's 25 MB L3. The
V5-3b rule pinned `binding=L3` (next outward of L1) -- wrong, the
operands have to come from DRAM. Operand-aware binding correctly
returns DRAM.

### Vector_add binding tier change

Small-N vector_add (operands fit L1) now binds at L1 instead of L3.
For warm-cache steady-state benchmarks that's the honest answer.
Two V5-3b tests were updated to reflect the new behavior.

## Part B: i7 L3 calibration = 0.82

Derived from `i7_12700k_vector_add.csv` at N=1M fp32 -- working set
12 MB sits cleanly between L1 (512 KB) and L3 (25 MB). Measured
163 GB/s vs L3 peak 200 GB/s = 0.82.

Applied to both i7 mappers (`create_i7_12700k_mapper` and
`create_i7_12700k_large_mapper`) -- same hardware, lock-step
calibration enforced by test.

L1 stays uncalibrated. Vector_add at sub-microsecond latencies is
dispatch-dominated, so V5-2b doesn't isolate L1 BW cleanly. Needs
a different microbench.

## Smoke-test (i7 matmul, --use-tier-aware-memory)

**Binding tier distribution across 60 shapes:**
| tier | V5-3b base | V5-5 follow-up |
|---|---|---|
| L1 | 0 | **10** |
| L3 | ~50 | **20** |
| DRAM | ~0 | **30** |

The model correctness is now in place. Failure count is unchanged
at 43/60 because the regime classifier (separate from analyzer
memory_time) drives most failures, and latency tolerance bands
aren't sensitive at these specific shapes. Floors should improve
as L1 calibration lands and the V5-3b default flag flips.

## Test plan

- [x] **8 new tests**:
  - 5 in `test_reuse_models.py`: `operand_footprint_bytes` per op
    + rejects-non-3D guards
  - 3 in `test_tier_picker.py`: matmul (4096^3) binds at DRAM via
    operand overflow; matmul (64, 1024, 8192) skinny escalates to
    DRAM (the motivating regression); matmul (1024^3) stays at L3
  - 3 in `test_tier_achievable_fractions.py`: i7 L3 = 0.82; L1
    stays at 1.0; large_mapper inherits L3 = 0.82
- [x] **Updated 2 V5-3b tests** to reflect operand-aware behavior:
  - `test_vector_add_small_n_binds_at_l1` (was L3)
  - `test_matmul_4096_cube_binds_at_dram_due_to_operand_overflow`
    (replaces the V5-3b \"next-outward\" assertion)
- [x] **V4 floor preservation**: 453 pre-followup tests still pass;
  default flag stays off, byte-identical to scalar
- [x] Total: 461 passed locally
- [ ] CI: full matrix passes

## V5 status after this PR (7/8 phases done with calibration in flight)

- V5-1 through V5-5 ✓
- V5-5 follow-up ← here
- **V5-5 remaining**: L1 calibration, default-flag flip
- **V5-6**: retire `_get_bandwidth_efficiency_scale`

Generated with [Claude Code](https://claude.com/claude-code)