### PR TITLE
feat(hardware): V5 follow-up -- Jetson Orin Nano on-chip BW peaks

### DIFF
--- a/src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py
+++ b/src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py
@@ -409,7 +409,32 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
         # Original Orin Nano (2023) was 68 GB/s LPDDR5-4267.
         # The V4 Phase B baseline was captured on a Super.
         l1_cache_per_unit=128 * 1024,
+        # V5 follow-up: on-chip BW peaks so memory_hierarchy emits a
+        # multi-tier view (L1 + L2 + DRAM). Without these, the V5-3b
+        # eligibility predicate's >=2 tier gate declines the
+        # tier-aware path on Orin Nano even when opted in.
+        #
+        # L1 per SM at sustained 650 MHz (the baseline_freq_hz used by
+        # the compute fabrics above): Ampere SM 8.6 spec is 128 B/cycle
+        # for L1 cache + shared memory throughput, so 128 * 650e6 =
+        # 83.2 GB/s/SM. The memory_hierarchy property aggregates by
+        # multiplying by compute_units (=8 SMs), giving 666 GB/s
+        # aggregate L1.
+        # Source: NVIDIA Ampere Architecture Whitepaper, "L1 Data
+        # Cache and Shared Memory" section.
+        l1_bandwidth_per_unit_bps=83e9,
         l2_cache_total=2 * 1024 * 1024,  # 2 MB (half of AGX)
+        # L2 BW: NVIDIA doesn't publish an Orin-Nano-specific number;
+        # for Ampere chips the L2 BW typically lands at 2-5x DRAM
+        # peak depending on partition count and clock. Using 2x DRAM
+        # (204 GB/s) as a conservative analytical estimate that
+        # preserves L2 > DRAM ordering for the tier picker. Pending
+        # an L2-isolating microbench, the achievable_fraction
+        # calibration will tighten this; see the i7 L1 analysis at
+        # docs/calibration/i7-12700k-l1-calibration-analysis.md for
+        # the same pattern (cache-resident BW is hard to measure
+        # directly because dispatch overhead dominates).
+        l2_bandwidth_bps=204e9,
         main_memory=8 * 1024**3,  # 8 GB
         energy_per_flop_fp32=cuda_fabric.energy_per_flop_fp32,  # 1.9 pJ (8nm Samsung, CUDA cores)
         energy_per_byte=18e-12,

--- a/tests/hardware/test_memory_hierarchy.py
+++ b/tests/hardware/test_memory_hierarchy.py
@@ -112,19 +112,20 @@ def test_h100_l2_is_shared_not_per_unit():
 # ---------------------------------------------------------------------------
 
 
-def test_jetson_orin_nano_hierarchy_dram_only_until_61_extended():
-    """The Orin Nano mapper hasn't populated ``l1_bandwidth_per_unit_bps``
-    or ``l2_bandwidth_bps`` (#61 only covered i7, H100, KPU-T64). Until
-    that gets extended, Orin's hierarchy is DRAM-only -- which is the
-    correct backward-compat behavior, not a bug. This test pins the
-    current state so a future PR adding on-chip BW peaks for Orin will
-    flip this test (and need to update the assertion to ``L1 -> L2 -> DRAM``)."""
+def test_jetson_orin_nano_hierarchy_is_three_tier():
+    """V5 follow-up (this PR): Orin Nano now populates
+    ``l1_bandwidth_per_unit_bps`` (Ampere SM 8.6 spec, 83 GB/s/SM at
+    650 MHz sustained) and ``l2_bandwidth_bps`` (204 GB/s, conservative
+    2x DRAM Ampere estimate). The hierarchy is now L1 -> L2 -> DRAM,
+    which lets the V5-3b eligibility predicate engage the tier-aware
+    path on Orin Nano. Pre-followup the hierarchy was DRAM-only and
+    the predicate declined the flag-on path."""
     hw = create_jetson_orin_nano_8gb_mapper().resource_model
     names = [t.name for t in hw.memory_hierarchy]
-    assert names == ["DRAM"], (
-        f"Orin Nano hierarchy {names} != ['DRAM']. If you populated "
-        f"l1_bandwidth_per_unit_bps and/or l2_bandwidth_bps on the Orin "
-        f"Nano mapper, update this test to assert ['L1', 'L2', 'DRAM']."
+    assert names == ["L1", "L2", "DRAM"], (
+        f"Orin Nano hierarchy {names} != ['L1', 'L2', 'DRAM']. If on-chip "
+        f"BW peaks were unset, update both this test AND the V5 follow-up "
+        f"calibration tests in test_tier_achievable_fractions.py."
     )
 
 
@@ -148,6 +149,7 @@ def test_mapper_without_onchip_bw_peaks_returns_dram_only():
     # Mutate a copy to clear the on-chip BW peaks, simulating an
     # un-augmented mapper:
     import copy
+
     hw2 = copy.copy(hw)
     hw2.l1_bandwidth_per_unit_bps = None
     hw2.l2_bandwidth_bps = None
@@ -164,11 +166,14 @@ def test_mapper_without_onchip_bw_peaks_returns_dram_only():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("mapper_factory", [
-    create_i7_12700k_mapper,
-    create_h100_sxm5_80gb_mapper,
-    create_jetson_orin_nano_8gb_mapper,
-])
+@pytest.mark.parametrize(
+    "mapper_factory",
+    [
+        create_i7_12700k_mapper,
+        create_h100_sxm5_80gb_mapper,
+        create_jetson_orin_nano_8gb_mapper,
+    ],
+)
 def test_hierarchy_ordered_innermost_first(mapper_factory):
     """The contract: tiers[0] is innermost (smallest total capacity);
     tiers[-1] is DRAM. The tier_picker (V5-3) walks innermost-out."""
@@ -178,8 +183,7 @@ def test_hierarchy_ordered_innermost_first(mapper_factory):
     # Total capacity strictly increases (innermost is smallest)
     capacities = [t.total_capacity_bytes for t in tiers]
     assert capacities == sorted(capacities), (
-        f"hierarchy {[t.name for t in tiers]} not ordered by capacity: "
-        f"{capacities}"
+        f"hierarchy {[t.name for t in tiers]} not ordered by capacity: " f"{capacities}"
     )
 
 
@@ -206,8 +210,9 @@ def test_access_latency_respects_mapper_override():
     typical defaults."""
     hw = create_i7_12700k_mapper().resource_model
     import copy
+
     hw2 = copy.copy(hw)
-    hw2.l1_access_latency_ns = 0.8   # custom override
+    hw2.l1_access_latency_ns = 0.8  # custom override
     hw2.dram_access_latency_ns = 75.0
 
     tiers = {t.name: t for t in hw2.memory_hierarchy}
@@ -234,9 +239,13 @@ def test_effective_bandwidth_defaults_to_peak():
 def test_effective_bandwidth_scales_with_achievable_fraction():
     """Property contract: effective = peak * fraction."""
     t = MemoryTier(
-        name="L2", capacity_bytes=1 << 22, is_per_unit=False,
-        num_units=1, peak_bandwidth_bps=1e12,
-        access_latency_ns=10.0, achievable_fraction=0.6,
+        name="L2",
+        capacity_bytes=1 << 22,
+        is_per_unit=False,
+        num_units=1,
+        peak_bandwidth_bps=1e12,
+        access_latency_ns=10.0,
+        achievable_fraction=0.6,
     )
     assert t.effective_bandwidth_bps == 6e11
 
@@ -250,8 +259,12 @@ def _valid_kwargs(**overrides):
     """Baseline-valid MemoryTier kwargs; tests override one field at a
     time to exercise each invariant check."""
     base = dict(
-        name="L1", capacity_bytes=32 * 1024, is_per_unit=True,
-        num_units=8, peak_bandwidth_bps=500e9, access_latency_ns=1.5,
+        name="L1",
+        capacity_bytes=32 * 1024,
+        is_per_unit=True,
+        num_units=8,
+        peak_bandwidth_bps=500e9,
+        access_latency_ns=1.5,
         achievable_fraction=0.85,
     )
     base.update(overrides)
@@ -289,20 +302,27 @@ def test_post_init_rejects_achievable_fraction_above_one():
     """A tier achieving > 100% of its peak BW would be physically
     impossible -- cache hits reflect a *different* tier's BW, not this
     one's peak * a >1 factor."""
-    with pytest.raises(ValueError, match=r"achievable_fraction must be in \[0\.0, 1\.0\]"):
+    with pytest.raises(
+        ValueError, match=r"achievable_fraction must be in \[0\.0, 1\.0\]"
+    ):
         MemoryTier(**_valid_kwargs(achievable_fraction=1.5))
 
 
 def test_post_init_rejects_negative_achievable_fraction():
-    with pytest.raises(ValueError, match=r"achievable_fraction must be in \[0\.0, 1\.0\]"):
+    with pytest.raises(
+        ValueError, match=r"achievable_fraction must be in \[0\.0, 1\.0\]"
+    ):
         MemoryTier(**_valid_kwargs(achievable_fraction=-0.1))
 
 
 def test_post_init_accepts_zero_bandwidth_and_zero_latency():
     """Zero is a valid sentinel (e.g., a tier in test fixtures); only
     negatives are rejected."""
-    t = MemoryTier(**_valid_kwargs(peak_bandwidth_bps=0.0, access_latency_ns=0.0,
-                                    achievable_fraction=0.0))
+    t = MemoryTier(
+        **_valid_kwargs(
+            peak_bandwidth_bps=0.0, access_latency_ns=0.0, achievable_fraction=0.0
+        )
+    )
     assert t.effective_bandwidth_bps == 0.0
 
 
@@ -321,8 +341,11 @@ def test_post_init_does_not_break_real_mapper_construction():
     """Sanity: the existing reference mappers still construct cleanly
     after adding the invariant checks. (i7 / H100 / Orin all parse the
     hierarchy without raising.)"""
-    for factory in (create_i7_12700k_mapper, create_h100_sxm5_80gb_mapper,
-                    create_jetson_orin_nano_8gb_mapper):
+    for factory in (
+        create_i7_12700k_mapper,
+        create_h100_sxm5_80gb_mapper,
+        create_jetson_orin_nano_8gb_mapper,
+    ):
         hw = factory().resource_model
         # Just access the property; any tier with bad values would raise
         tiers = hw.memory_hierarchy

--- a/tests/hardware/test_tier_achievable_fractions.py
+++ b/tests/hardware/test_tier_achievable_fractions.py
@@ -162,6 +162,73 @@ def test_i7_12700k_large_mapper_inherits_dram_calibration():
     assert hw.tier_achievable_fractions.get("L3") == 0.82
 
 
+def test_jetson_orin_nano_emits_three_tier_hierarchy():
+    """V5 follow-up: Orin Nano now populates l1_bandwidth_per_unit_bps
+    and l2_bandwidth_bps so memory_hierarchy emits L1 + L2 + DRAM.
+    Without these, the V5-3b eligibility predicate's >= 2 tier gate
+    declines the tier-aware path even with the flag on."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    tier_names = [t.name for t in hw.memory_hierarchy]
+    assert tier_names == ["L1", "L2", "DRAM"], (
+        f"Orin Nano memory_hierarchy must be L1 -> L2 -> DRAM (3 tiers); "
+        f"got {tier_names}. Did the on-chip BW peaks get unset?"
+    )
+
+
+def test_jetson_orin_nano_l1_bandwidth_matches_ampere_spec():
+    """Ampere SM 8.6 L1 cache + shared memory throughput is 128 B/cycle.
+    At Orin Nano's 650 MHz sustained baseline (the same clock used by
+    the compute fabrics in the mapper), per-SM L1 BW = 83.2 GB/s.
+    The mapper rounds this to 83 GB/s.
+
+    Per the V5-1 contract, ``l1_bandwidth_per_unit_bps`` is per-SM and
+    the memory_hierarchy aggregates by multiplying by ``compute_units``
+    (= 8 SMs), giving 664 GB/s aggregate L1."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    assert hw.l1_bandwidth_per_unit_bps == 83e9
+    l1 = next(t for t in hw.memory_hierarchy if t.name == "L1")
+    assert l1.peak_bandwidth_bps == 83e9 * hw.compute_units
+    assert l1.peak_bandwidth_bps == pytest.approx(664e9)
+
+
+def test_jetson_orin_nano_l2_bandwidth_preserves_tier_ordering():
+    """L2 BW = 204 GB/s (2x DRAM peak, conservative Ampere estimate;
+    not directly published by NVIDIA for Orin Nano). The exact value
+    will tighten with calibration; the test that matters is that the
+    tier ordering holds: L1 > L2 > DRAM. Without this ordering the
+    V5-3b tier picker would walk in the wrong direction."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    assert hw.l2_bandwidth_bps == 204e9
+    tiers = {t.name: t for t in hw.memory_hierarchy}
+    assert (
+        tiers["L1"].peak_bandwidth_bps
+        > tiers["L2"].peak_bandwidth_bps
+        > tiers["DRAM"].peak_bandwidth_bps
+    )
+
+
+def test_jetson_orin_nano_v5_3b_path_now_activates():
+    """The V5-3b eligibility predicate gates on memory_hierarchy
+    having >= 2 tiers. Pre-followup Orin Nano emitted DRAM-only and
+    the flag was a no-op; post-followup the path activates and the
+    DRAM achievable_fraction = 0.55 from V5-5 (#103) reaches
+    DRAM-bound shapes through the analyzer."""
+    from graphs.estimation.reuse_models import REUSE_MODELS
+    from graphs.estimation.tier_picker import pick_binding_tier
+
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    assert len(hw.memory_hierarchy) >= 2
+
+    # Large vector_add binds at DRAM and uses the calibrated
+    # effective_bandwidth_bps (102 * 0.55 = 56.1 GB/s).
+    result = pick_binding_tier(
+        REUSE_MODELS["vector_add"], (16777216,), "fp16", hw.memory_hierarchy
+    )
+    assert result is not None
+    assert result.binding_tier.name == "DRAM"
+    assert result.binding_tier.effective_bandwidth_bps == pytest.approx(102e9 * 0.55)
+
+
 def test_jetson_orin_nano_dram_calibration():
     """Jetson Orin Nano (Super) DRAM achievable_fraction = 0.55
     derived from the V5-2b vector_add baseline at the 15W thermal


### PR DESCRIPTION
## Summary

Populates `l1_bandwidth_per_unit_bps` and `l2_bandwidth_bps` on the
Jetson Orin Nano 8GB mapper so `memory_hierarchy` emits a 3-tier view
(L1 + L2 + DRAM) instead of DRAM-only.

**Why this matters:** without on-chip BW peaks, V5-3b's `>= 2 tiers`
eligibility gate declines the tier-aware path on Orin even when
opted in. The V5-5 DRAM `achievable_fraction = 0.55` (#103) was
effectively dead code on Orin until now.

## Values

### L1 per SM = 83 GB/s
Ampere SM 8.6 spec is 128 B/cycle for L1 cache + shared memory
throughput. At Orin Nano's 650 MHz sustained baseline (matches
`baseline_freq_hz` used by the existing CUDA + tensor compute
fabrics): `128 * 650e6 = 83.2 GB/s/SM`, rounded to 83. The
`memory_hierarchy` property aggregates by multiplying by
`compute_units` (= 8 SMs), giving 664 GB/s aggregate L1.

**Source:** NVIDIA Ampere Architecture Whitepaper, "L1 Data Cache
and Shared Memory" section.

### L2 chip-wide = 204 GB/s
NVIDIA doesn't publish a Orin-Nano-specific L2 BW. For Ampere chips
L2 BW typically lands at 2-5x DRAM peak. Using **2x DRAM** as a
conservative analytical estimate that preserves L1 > L2 > DRAM
ordering for the tier picker. The exact value will tighten with an
L2-isolating microbench; same calibration-deferred pattern as the
i7 L1 analysis at `docs/calibration/i7-12700k-l1-calibration-analysis.md`.

## V5-3b activation, post-followup

Tier picker spot check on representative shapes:

| op + shape | residency | binding | effective BW |
|---|---|---|---|
| vector_add(N=1024) fp16 | L1 | L1 | 664 GB/s |
| vector_add(N=16M) fp16 | DRAM | DRAM | **56 GB/s (V5-5 calibrated)** |
| matmul(512^3) fp16 | L1 | L2 | 204 GB/s |
| matmul(4096^3) fp16 | L1 | DRAM | **56 GB/s (V5-5 calibrated)** |

DRAM-bound shapes now correctly route through the V5-5 DRAM
calibration, which was previously unreachable on Orin.

## Tests

- [x] **5 changes** to existing pinning tests:
  - `test_jetson_orin_nano_hierarchy_is_three_tier` (replaces
    `_dram_only_until_61_extended` -- the prior test was a
    deliberate tripwire for this PR; its docstring even said so)
  - `test_jetson_orin_nano_l1_bandwidth_matches_ampere_spec`
  - `test_jetson_orin_nano_l2_bandwidth_preserves_tier_ordering`
  - `test_jetson_orin_nano_v5_3b_path_now_activates`
  - `test_jetson_orin_nano_emits_three_tier_hierarchy`
- [x] **V4 floor preservation**: V5-3b default flag stays off; the
  default-off path is byte-identical to scalar
- [x] Total: 625 tests pass (621 + 4 new; 1 pre-existing tripwire test
  flipped from "asserts DRAM-only" to "asserts L1 -> L2 -> DRAM")
- [ ] CI: full matrix passes

## V5 status after this PR

**Calibration coverage:**
| target | DRAM | L2/L3 | L1 |
|---|---|---|---|
| i7-12700K | 0.47 ✓ | L3 = 0.82 ✓ | doc'd as no-op (#105) |
| Jetson Orin Nano | 0.55 ✓ + **now reachable** | (default 1.0, awaiting microbench) | (default 1.0, awaiting microbench) |

**Remaining V5 follow-ups:**
1. V4 vector_add validation harness -- would let DRAM calibration's value
   show up as floor improvements
2. L2 / L1 calibration microbenches for Orin (separate workloads needed)
3. V5-3b default-flag flip (gated on V4 vector_add validation showing
   floors equal-or-improve)
4. V5-6: retire `_get_bandwidth_efficiency_scale`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added explicit L1 and L2 bandwidth modeling for Jetson Orin Nano 8GB hardware, enabling three-tier memory hierarchy (`L1 → L2 → DRAM`) representation.

* **Tests**
  * Enhanced memory hierarchy validation tests to verify bandwidth calculations and tier ordering across the updated hardware model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->