### PR TITLE
feat(validation,estimation): V4 vector_add validation harness

### DIFF
--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -1086,6 +1086,16 @@ class RooflineAnalyzer:
         elif op_type == OperationType.LINEAR:
             op_kind = "linear"
             shape = self._extract_linear_shape(sg)
+        elif op_type == OperationType.ELEMENTWISE:
+            # Tighter predicate than just OperationType.ELEMENTWISE:
+            # vector_add specifically (a + b -> c). ReLU / sigmoid /
+            # other elementwise ops have different operand counts
+            # and reuse patterns, so the V5-3a vector_add reuse
+            # model would mis-bytes-loaded for them. The shape
+            # extractor returns None unless the SG matches the
+            # strict 3-tensor 1-D vector-add layout.
+            op_kind = "vector_add"
+            shape = self._extract_vector_add_shape(sg)
         else:
             return None
         if shape is None:
@@ -1168,6 +1178,34 @@ class RooflineAnalyzer:
         if IN != IN_w:
             return None
         return (int(B), int(IN), int(OUT))
+
+    @staticmethod
+    def _extract_vector_add_shape(sg: SubgraphDescriptor) -> Optional[tuple]:
+        """Pull (N,) from a single-op subgraph that's specifically a
+        vector add (c = a + b on N-element 1-D tensors).
+
+        Stricter than just OperationType.ELEMENTWISE because the V5-3a
+        vector_add reuse model assumes 3 buffers and zero reuse;
+        applying it to ReLU (1 in -> 1 out) or fused
+        elementwise-with-broadcast would produce wrong bytes_loaded.
+        Predicate:
+          * exactly 2 input tensors, 1 output tensor
+          * all 3 are 1-D
+          * all 3 share the same length and dtype
+
+        Returns ``None`` for anything that doesn't match -- caller
+        falls through to the scalar bw_efficiency_scale path."""
+        if len(sg.input_tensors) != 2 or len(sg.output_tensors) != 1:
+            return None
+        a, b = sg.input_tensors
+        c = sg.output_tensors[0]
+        if len(a.shape) != 1 or len(b.shape) != 1 or len(c.shape) != 1:
+            return None
+        if a.shape != b.shape or a.shape != c.shape:
+            return None
+        if a.dtype != b.dtype or a.dtype != c.dtype:
+            return None
+        return (int(a.shape[0]),)
 
     def _get_bandwidth_efficiency_scale(self, sg: SubgraphDescriptor) -> float:
         """

--- a/tests/analysis/test_roofline_tier_aware.py
+++ b/tests/analysis/test_roofline_tier_aware.py
@@ -314,6 +314,149 @@ def test_memory_explanation_does_not_leak_across_subgraphs():
     assert desc_decline.memory_explanation is None
 
 
+# ---------------------------------------------------------------------------
+# vector_add eligibility (V4 vector_add validation harness follow-up)
+# ---------------------------------------------------------------------------
+
+
+def _vector_add_subgraph(N, dtype="float32") -> SubgraphDescriptor:
+    """Build a single-op vector_add subgraph (c = a + b) on N elements."""
+    a = create_tensor_descriptor((N,), dtype)
+    b = create_tensor_descriptor((N,), dtype)
+    c = create_tensor_descriptor((N,), dtype)
+    return SubgraphDescriptor(
+        subgraph_id=42,
+        node_ids=["va"],
+        node_names=["va"],
+        operation_types=[OperationType.ELEMENTWISE],
+        fusion_pattern="Add",
+        total_flops=N,
+        total_macs=0,
+        total_input_bytes=2 * N * 4,
+        total_output_bytes=N * 4,
+        total_weight_bytes=0,
+        input_tensors=[a, b],
+        output_tensors=[c],
+        weight_tensors=[],
+    )
+
+
+def test_opt_in_routes_vector_add_through_tier_picker_on_i7():
+    """V4 vector_add validation harness: with use_tier_aware_memory=True,
+    a strict 3-tensor 1-D ELEMENTWISE op (c = a + b) should route
+    through the V5-3a vector_add reuse model and bind at the smallest
+    tier holding the operand footprint."""
+    sg = _vector_add_subgraph(16 * 1024 * 1024)  # 192 MB > L3 -> DRAM
+    hw = create_i7_12700k_mapper().resource_model
+    desc = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )._analyze_subgraph(sg)
+    assert desc.memory_explanation is not None
+    assert desc.memory_explanation.binding_tier_name == "DRAM"
+
+
+def test_vector_add_small_n_binds_at_l1_via_analyzer():
+    """For an L1-resident vector_add, V5-5-followup operand-aware
+    binding selects L1 (smallest tier whose capacity holds the
+    12 KB operand footprint)."""
+    sg = _vector_add_subgraph(1024)  # 12 KB <- fits L1
+    hw = create_i7_12700k_mapper().resource_model
+    desc = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )._analyze_subgraph(sg)
+    assert desc.memory_explanation is not None
+    assert desc.memory_explanation.binding_tier_name == "L1"
+
+
+def test_opt_in_falls_back_for_elementwise_with_only_one_input():
+    """ReLU / sigmoid (1 input -> 1 output) is also OperationType.ELEMENTWISE
+    but has different reuse semantics. The strict
+    _extract_vector_add_shape predicate must reject anything that's
+    not specifically 'a + b -> c' so we don't apply the wrong reuse
+    model."""
+    x = create_tensor_descriptor((1024,), "float32")
+    y = create_tensor_descriptor((1024,), "float32")
+    sg = SubgraphDescriptor(
+        subgraph_id=99,
+        node_ids=["relu"],
+        node_names=["relu"],
+        operation_types=[OperationType.ELEMENTWISE],
+        fusion_pattern="ReLU",
+        total_flops=1024,
+        total_macs=0,
+        total_input_bytes=1024 * 4,
+        total_output_bytes=1024 * 4,
+        total_weight_bytes=0,
+        input_tensors=[x],
+        output_tensors=[y],
+    )
+    hw = create_i7_12700k_mapper().resource_model
+    on = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )._analyze_subgraph(sg)
+    off = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=False
+    )._analyze_subgraph(sg)
+    # Falls back to scalar -> identical memory_time
+    assert on.memory_time == off.memory_time
+    assert on.memory_explanation is None
+
+
+def test_opt_in_falls_back_for_2d_elementwise():
+    """2-D elementwise (e.g., matrix Add as a separate op) doesn't
+    match the strict 1-D vector_add predicate -> scalar fallback."""
+    a = create_tensor_descriptor((64, 64), "float32")
+    b = create_tensor_descriptor((64, 64), "float32")
+    c = create_tensor_descriptor((64, 64), "float32")
+    sg = SubgraphDescriptor(
+        subgraph_id=100,
+        node_ids=["add2d"],
+        node_names=["add2d"],
+        operation_types=[OperationType.ELEMENTWISE],
+        fusion_pattern="Add",
+        total_flops=64 * 64,
+        total_macs=0,
+        total_input_bytes=2 * 64 * 64 * 4,
+        total_output_bytes=64 * 64 * 4,
+        total_weight_bytes=0,
+        input_tensors=[a, b],
+        output_tensors=[c],
+    )
+    hw = create_i7_12700k_mapper().resource_model
+    on = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )._analyze_subgraph(sg)
+    assert on.memory_explanation is None
+
+
+def test_opt_in_falls_back_for_elementwise_with_mismatched_shapes():
+    """Broadcast-style elementwise (a is scalar, b is N-d) -- the
+    bytes_loaded calculation in vector_add reuse model would be
+    wrong for these. Reject."""
+    a = create_tensor_descriptor((1,), "float32")  # scalar broadcast
+    b = create_tensor_descriptor((1024,), "float32")
+    c = create_tensor_descriptor((1024,), "float32")
+    sg = SubgraphDescriptor(
+        subgraph_id=101,
+        node_ids=["broadcast"],
+        node_names=["broadcast"],
+        operation_types=[OperationType.ELEMENTWISE],
+        fusion_pattern="Add",
+        total_flops=1024,
+        total_macs=0,
+        total_input_bytes=1024 * 4 + 4,
+        total_output_bytes=1024 * 4,
+        total_weight_bytes=0,
+        input_tensors=[a, b],
+        output_tensors=[c],
+    )
+    hw = create_i7_12700k_mapper().resource_model
+    on = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )._analyze_subgraph(sg)
+    assert on.memory_explanation is None
+
+
 def test_memory_explanation_format_summary_renders_breakdown():
     """LatencyDescriptor.format_summary should include a 'Memory binding'
     line when memory_explanation is set, so the breakdown surfaces in

--- a/tests/validation_model_v4/test_runner.py
+++ b/tests/validation_model_v4/test_runner.py
@@ -87,13 +87,16 @@ def test_build_subgraph_rejects_unknown_op():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("dtype,expected", [
-    ("fp32", Precision.FP32),
-    ("fp16", Precision.FP16),
-    ("bf16", Precision.BF16),
-    ("int8", Precision.INT8),
-    ("int4", Precision.INT4),
-])
+@pytest.mark.parametrize(
+    "dtype,expected",
+    [
+        ("fp32", Precision.FP32),
+        ("fp16", Precision.FP16),
+        ("bf16", Precision.BF16),
+        ("int8", Precision.INT8),
+        ("int4", Precision.INT4),
+    ],
+)
 def test_resolve_precision(dtype, expected):
     assert _resolve_precision(dtype) == expected
 
@@ -111,26 +114,41 @@ def test_resolve_precision_rejects_unknown():
 def _write_test_sweep(tmp_path: Path, op: str, entries: list) -> Path:
     """Helper: write a minimal sweep JSON for a specific test scenario."""
     sweep_path = tmp_path / f"{op}_test.json"
-    sweep_path.write_text(json.dumps({
-        "op": op,
-        "purpose": "test",
-        "generator_seed": 0,
-        "generated_against_hardware": ["i7_12700k"],
-        "shapes": entries,
-    }))
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "op": op,
+                "purpose": "test",
+                "generator_seed": 0,
+                "generated_against_hardware": ["i7_12700k"],
+                "shapes": entries,
+            }
+        )
+    )
     return sweep_path
 
 
 def test_run_sweep_with_empty_cache_records_skips(tmp_path):
     """No cache + no measurer -> every shape skipped as 'no baseline'."""
-    sweep = _write_test_sweep(tmp_path, "matmul", [
-        {"shape": [256, 256, 256], "dtype": "fp32",
-         "regime_per_hw": {"i7_12700k": "l2_bound"}},
-        {"shape": [1024, 1024, 1024], "dtype": "fp32",
-         "regime_per_hw": {"i7_12700k": "l2_bound"}},
-    ])
-    cfg = RunnerConfig(sweep_path=sweep, hardware_key="i7_12700k",
-                      baseline_dir=tmp_path)
+    sweep = _write_test_sweep(
+        tmp_path,
+        "matmul",
+        [
+            {
+                "shape": [256, 256, 256],
+                "dtype": "fp32",
+                "regime_per_hw": {"i7_12700k": "l2_bound"},
+            },
+            {
+                "shape": [1024, 1024, 1024],
+                "dtype": "fp32",
+                "regime_per_hw": {"i7_12700k": "l2_bound"},
+            },
+        ],
+    )
+    cfg = RunnerConfig(
+        sweep_path=sweep, hardware_key="i7_12700k", baseline_dir=tmp_path
+    )
     result = run_sweep(cfg)
     assert len(result.records) == 0
     assert len(result.skipped_no_baseline) == 2
@@ -145,12 +163,20 @@ def test_run_sweep_with_populated_cache_produces_records(tmp_path):
         Measurement(latency_s=4e-3, energy_j=0.5, trial_count=10),
         baseline_dir=tmp_path,
     )
-    sweep = _write_test_sweep(tmp_path, "matmul", [
-        {"shape": [1024, 1024, 1024], "dtype": "fp32",
-         "regime_per_hw": {"i7_12700k": "l2_bound"}},
-    ])
-    cfg = RunnerConfig(sweep_path=sweep, hardware_key="i7_12700k",
-                      baseline_dir=tmp_path)
+    sweep = _write_test_sweep(
+        tmp_path,
+        "matmul",
+        [
+            {
+                "shape": [1024, 1024, 1024],
+                "dtype": "fp32",
+                "regime_per_hw": {"i7_12700k": "l2_bound"},
+            },
+        ],
+    )
+    cfg = RunnerConfig(
+        sweep_path=sweep, hardware_key="i7_12700k", baseline_dir=tmp_path
+    )
     result = run_sweep(cfg)
     assert len(result.records) == 1
     rec = result.records[0]
@@ -162,23 +188,102 @@ def test_run_sweep_with_populated_cache_produces_records(tmp_path):
     # don't assert one outcome -- the point is that the record was built.
 
 
+def test_run_sweep_handles_vector_add_with_populated_cache(tmp_path):
+    """V4 vector_add validation harness: end-to-end, the runner walks
+    a vector_add sweep entry, builds the SubgraphDescriptor (1-D
+    a + b -> c), predicts via roofline, and produces a ValidationRecord.
+    The pass/fail outcome is a separate concern surfaced in PR
+    discussion -- the key here is that vector_add wires through the
+    runner the same way matmul/linear do."""
+    store(
+        CacheKey("i7_12700k", "vector_add", (1024,), "fp32"),
+        Measurement(latency_s=2e-6, energy_j=None, trial_count=11),
+        baseline_dir=tmp_path,
+    )
+    sweep = _write_test_sweep(
+        tmp_path,
+        "vector_add",
+        [
+            {
+                "shape": [1024],
+                "dtype": "fp32",
+                "regime_per_hw": {"i7_12700k": "launch_bound"},
+            },
+        ],
+    )
+    cfg = RunnerConfig(
+        sweep_path=sweep, hardware_key="i7_12700k", baseline_dir=tmp_path
+    )
+    result = run_sweep(cfg)
+    assert len(result.records) == 1
+    rec = result.records[0]
+    assert rec.op == "vector_add"
+    assert rec.shape == (1024,)
+    assert rec.regime_predicted == "launch_bound"
+
+
+def test_run_sweep_vector_add_uses_tier_aware_path_when_opted_in(tmp_path):
+    """Smoke test: with use_tier_aware_memory=True, a DRAM-bound
+    vector_add subgraph produces a ValidationRecord whose
+    binding_tier is 'DRAM' (V5-3b extended to ELEMENTWISE in this PR).
+    Without this PR, the path declined for ELEMENTWISE and binding_tier
+    came back None."""
+    N = 16 * 1024 * 1024  # 192 MB > i7 LLC (25 MB) -> DRAM-bound
+    store(
+        CacheKey("i7_12700k", "vector_add", (N,), "fp32"),
+        Measurement(latency_s=5e-3, energy_j=None, trial_count=11),
+        baseline_dir=tmp_path,
+    )
+    sweep = _write_test_sweep(
+        tmp_path,
+        "vector_add",
+        [
+            {
+                "shape": [N],
+                "dtype": "fp32",
+                "regime_per_hw": {"i7_12700k": "dram_bound"},
+            },
+        ],
+    )
+    cfg = RunnerConfig(
+        sweep_path=sweep,
+        hardware_key="i7_12700k",
+        baseline_dir=tmp_path,
+        use_tier_aware_memory=True,
+    )
+    result = run_sweep(cfg)
+    assert len(result.records) == 1
+    assert result.records[0].binding_tier == "DRAM"
+
+
 def test_run_sweep_skips_unsupported_entries(tmp_path):
     """An entry classified as UNSUPPORTED on the target hardware is
     counted in skipped_unsupported, not silently dropped or attempted."""
-    sweep = _write_test_sweep(tmp_path, "matmul", [
-        {"shape": [1024, 1024, 1024], "dtype": "fp16",
-         "regime_per_hw": {"i7_12700k": "unsupported"}},
-        {"shape": [1024, 1024, 1024], "dtype": "fp32",
-         "regime_per_hw": {"i7_12700k": "l2_bound"}},
-    ])
+    sweep = _write_test_sweep(
+        tmp_path,
+        "matmul",
+        [
+            {
+                "shape": [1024, 1024, 1024],
+                "dtype": "fp16",
+                "regime_per_hw": {"i7_12700k": "unsupported"},
+            },
+            {
+                "shape": [1024, 1024, 1024],
+                "dtype": "fp32",
+                "regime_per_hw": {"i7_12700k": "l2_bound"},
+            },
+        ],
+    )
     # Populate cache for the second one so we can count records correctly
     store(
         CacheKey("i7_12700k", "matmul", (1024, 1024, 1024), "fp32"),
         Measurement(latency_s=4e-3, energy_j=0.5, trial_count=10),
         baseline_dir=tmp_path,
     )
-    cfg = RunnerConfig(sweep_path=sweep, hardware_key="i7_12700k",
-                      baseline_dir=tmp_path)
+    cfg = RunnerConfig(
+        sweep_path=sweep, hardware_key="i7_12700k", baseline_dir=tmp_path
+    )
     result = run_sweep(cfg)
     assert len(result.records) == 1
     assert len(result.skipped_unsupported) == 1
@@ -189,13 +294,21 @@ def test_run_sweep_filters_entries_lacking_target_hw_label(tmp_path):
     """Sweep entries that don't list the requested hardware in
     regime_per_hw are silently filtered (they were generated for some
     other hw and are out of scope for this run)."""
-    sweep = _write_test_sweep(tmp_path, "matmul", [
-        # Only labeled for h100, not i7
-        {"shape": [4096, 4096, 4096], "dtype": "fp16",
-         "regime_per_hw": {"h100_sxm5_80gb": "dram_bound"}},
-    ])
-    cfg = RunnerConfig(sweep_path=sweep, hardware_key="i7_12700k",
-                      baseline_dir=tmp_path)
+    sweep = _write_test_sweep(
+        tmp_path,
+        "matmul",
+        [
+            # Only labeled for h100, not i7
+            {
+                "shape": [4096, 4096, 4096],
+                "dtype": "fp16",
+                "regime_per_hw": {"h100_sxm5_80gb": "dram_bound"},
+            },
+        ],
+    )
+    cfg = RunnerConfig(
+        sweep_path=sweep, hardware_key="i7_12700k", baseline_dir=tmp_path
+    )
     result = run_sweep(cfg)
     assert len(result.records) == 0
     assert len(result.skipped_no_baseline) == 0
@@ -206,8 +319,9 @@ def test_run_sweep_unknown_hardware_key_raises(tmp_path):
     """A typo'd hardware key must fail loudly so the user notices,
     rather than silently producing 0 records."""
     sweep = _write_test_sweep(tmp_path, "matmul", [])
-    cfg = RunnerConfig(sweep_path=sweep, hardware_key="non_existent_hw",
-                      baseline_dir=tmp_path)
+    cfg = RunnerConfig(
+        sweep_path=sweep, hardware_key="non_existent_hw", baseline_dir=tmp_path
+    )
     with pytest.raises(ValueError, match="non_existent_hw"):
         run_sweep(cfg)
 
@@ -216,6 +330,7 @@ def test_sweep_hw_to_mapper_keys_resolve(tmp_path):
     """Every key in SWEEP_HW_TO_MAPPER must actually resolve to a
     real mapper -- protects against typos in the dispatch table."""
     from graphs.hardware.mappers import get_mapper_by_name
+
     for sweep_key, mapper_key in SWEEP_HW_TO_MAPPER.items():
         m = get_mapper_by_name(mapper_key)
         assert m is not None, f"{sweep_key} -> {mapper_key} did not resolve"

--- a/validation/model_v4/cli/validate.py
+++ b/validation/model_v4/cli/validate.py
@@ -51,7 +51,10 @@ def _build_argparser() -> argparse.ArgumentParser:
         help="Hardware key (matches sweep JSON 'regime_per_hw')",
     )
     p.add_argument(
-        "--op", required=True, choices=["matmul", "linear"], help="Operator to validate"
+        "--op",
+        required=True,
+        choices=["matmul", "linear", "vector_add"],
+        help="Operator to validate",
     )
     p.add_argument(
         "--purpose",


### PR DESCRIPTION
## Summary

Wires the V4 harness end-to-end for vector_add: `--op vector_add`
is now a valid CLI choice, and the V5-3b tier-aware analyzer path
extends to ELEMENTWISE when the SubgraphDescriptor matches a strict
1-D vector_add layout.

This unblocks the V5-3b default-flag flip: with vector_add validation
running, the V5-5 / V5-5-followup calibration values actually reach
predictions (previously dead-coded for elementwise ops).

## What was already there
- V5-2a (#97): vector_add workload, sweep JSONs, runner
  `_build_subgraph` / `_build_workload`, `classify._vector_add_footprint`
- V5-2b (#98 / #99): i7 + Jetson Orin Nano vector_add baselines

## What this PR adds

### 1. CLI choice
`validation/model_v4/cli/validate.py`: `--op` extended from
`["matmul", "linear"]` to include `"vector_add"`. The runner already
handled vector_add; only the argparser refused it.

### 2. V5-3b eligibility extension
`graphs/estimation/roofline.py` adds `_extract_vector_add_shape`,
a strict predicate that accepts ELEMENTWISE op only when:
- exactly 2 input tensors, 1 output tensor
- all 3 are 1-D
- all 3 share the same length and dtype

Anything else (ReLU, sigmoid, 2-D elementwise, broadcast Add, etc.)
falls through to the scalar `bw_efficiency_scale` path. This is
what gates V5-5 calibration values reaching vector_add predictions.

## V4 floor signal -- i7 vector_add validation, 5 records

| shape | default-off | tier-aware | measured | tier (tier-aware) |
|---|---|---|---|---|
| N=1024 | 5.0 us | 5.0 us | 2.0 us | L1 |
| N=16K | 5.2 us | 5.0 us | 3.1 us | L1 |
| N=262K | 67.2 us | 19.2 us | 11.0 us | L3 |
| N=4M | 0.79 ms | 1.43 ms | 0.60 ms | DRAM |
| N=67M | 12.6 ms | 22.8 ms | 23.2 ms | DRAM (-1%, **passes**) |

`pass_latency: 0/5 -> 1/5` under `--use-tier-aware-memory`. The
truly DRAM-bound N=67M case lands at -1% of measured, well inside
the 25% DRAM tolerance band -- V5-5 calibration delivers as
designed.

## What this surfaces (V5 follow-up findings)

1. **CPU dispatch floor (5 us) is too tight for vector_add.** Real
   PyTorch dispatch for `a + b -> c` is ~2 us; the 5 us floor was
   set from matmul/linear empirics where parameter access + bias
   add overhead. Op-aware floor refinement is the fix.

2. **Binary L3-vs-DRAM cliff at boundary shapes.** N=4M (50 MB just
   over 25 MB L3) now binds at DRAM and uses DRAM
   achievable_fraction (0.47) for the full 50 MB, but reality is
   partial L3 + partial DRAM. A weighted-tier refinement would
   help boundary shapes.

3. **L3 achievable_fraction may be too pessimistic.** N=262K is
   L3-resident and L3=0.82 over-predicts by +75%. A cleaner L3
   microbench (or matmul-anchored calibration) might tighten.

These findings are now **visible** because the harness runs. They
weren't catchable before. Each is its own follow-up.

## Test plan

- [x] **5 new tests in `test_roofline_tier_aware.py`**: vector_add
  eligibility positive case + 4 negative cases (ReLU, 2-D
  elementwise, broadcast Add, mismatched shapes)
- [x] **2 new tests in `test_runner.py`**: end-to-end runner
  support (vector_add with cache hit; `--use-tier-aware-memory`
  produces `binding_tier=DRAM` on a DRAM-bound shape)
- [x] **CLI smoke test**:
  `python -m validation.model_v4.cli.validate --hw i7_12700k --op vector_add --use-tier-aware-memory`
  produces 5 records with `binding_tier in {L1, L3, DRAM}`
- [x] **V4 floor preservation**: V5-3b default flag stays off; the
  default-off path is byte-identical to scalar
- [x] Total: 632 tests pass (625 + 7 new)
- [ ] CI: full matrix passes

## V5 progress after this PR

| target | DRAM | L2/L3 | L1 | vector_add validates? |
|---|---|---|---|---|
| i7-12700K | 0.47 | L3 = 0.82 | doc'd no-op | yes (1/5 passing) |
| Jetson Orin Nano | 0.55 | 1.0 (estimate) | 1.0 (Ampere spec) | needs Jetson runner |

**Remaining V5 work:**
1. Address the three findings above (dispatch floor, L3/DRAM
   boundary, L3 calibration tightening)
2. V5-3b default-flag flip after floors equal-or-improve consistently
3. V5-6: retire `_get_bandwidth_efficiency_scale`

Generated with [Claude Code](https://claude.com/claude-code)