### PR TITLE
feat(estimation): op-aware CPU dispatch floor with first-principles documentation

### DIFF
--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -663,17 +663,22 @@ class RooflineAnalyzer:
         overhead = self._estimate_overhead(sg)
         actual_latency = bottleneck_time + overhead
 
-        # CPU dispatch floor (#69): real PyTorch / nn.Module call has ~5us
-        # of Python dispatch + parameter access + bias-add overhead per
-        # forward call. The roofline math doesn't model this, so very small
-        # ops (B=1 linear, tiny matmul) under-predict. Apply as a floor
-        # rather than additive overhead so it only kicks in when the kernel
-        # is too small to dominate -- avoids over-correcting medium ops
-        # where the overhead is amortized by real kernel time.
-        # V4 baseline shows the floor empirically: smallest measured shape
-        # (1,128,128 linear, 33K flops) lands at 5.20us wall-clock.
+        # CPU dispatch floor: PyTorch's per-op runtime overhead that the
+        # roofline math doesn't capture. Apply as a floor rather than
+        # additive overhead so it only kicks in for ops too small for
+        # the kernel time to dominate -- avoids over-correcting medium
+        # ops where the overhead amortizes naturally.
+        #
+        # Op-aware: see _get_cpu_dispatch_floor for the first-principles
+        # decomposition (base ATen dispatch + BLAS thread launch +
+        # stride/layout normalization + parameter access + bias add).
+        # Empirical floors on i7-12700K (#69 set 5 us across the board;
+        # this PR splits per op based on smallest-shape measurements):
+        #   vector_add: 2 us  (base ATen dispatch only)
+        #   matmul:     6 us  (+ BLAS thread launch, stride norm)
+        #   linear:     9 us  (+ parameter access, bias epilogue)
         if self.resource_model.hardware_type.name == "CPU":
-            actual_latency = max(actual_latency, 5e-6)
+            actual_latency = max(actual_latency, self._get_cpu_dispatch_floor(sg))
 
         # Arithmetic intensity
         ai = sg.flops / total_bytes if total_bytes > 0 else 0.0
@@ -1038,6 +1043,93 @@ class RooflineAnalyzer:
         # TPU/KPU: handled by _get_discrete_resource_correction
         # Other hardware: no operation-size efficiency scaling
         return 1.0
+
+    # ------------------------------------------------------------------
+    # CPU dispatch floor (op-aware; #69 set a single 5 us floor, this
+    # PR splits per op based on first-principles dispatch decomposition
+    # validated against the V4 i7-12700K baseline).
+    # ------------------------------------------------------------------
+
+    # Op -> dispatch floor (seconds), keyed by OperationType. The first-
+    # principles model breaks dispatch into stackable components; each
+    # op pays for the components that actually execute on its path.
+    #
+    # ## What is "dispatch" on a CPU?
+    #
+    # Unlike a GPU "kernel launch" (a discrete cudaLaunchKernel call
+    # that the device queues), a CPU "dispatch" is the chain of
+    # software work that PyTorch performs before any FLOPs execute:
+    # Python frame entry, ATen dispatcher key resolution, output
+    # tensor allocation, kernel invocation. None of these are physical
+    # constraints -- a CPU can context-switch in nanoseconds, take an
+    # ISR, return from an RPC -- but they ARE the unavoidable runtime
+    # cost of routing a Python-level tensor op through the framework.
+    # The roofline math ignores all of this (it's pure compute / BW
+    # arithmetic), so we floor the prediction at the empirical
+    # smallest-shape latency.
+    #
+    # ## Per-component cost (first-principles, validated on i7 + Python 3.10 / PyTorch 2.x):
+    #
+    # 1. Base ATen dispatch (~2 us)        - all ops
+    #    Python frame entry + arg parsing (~300-500 ns), ATen
+    #    dispatcher key resolution + boxing (~100-300 ns), output
+    #    tensor allocation `at::empty` (~500 ns - 1 us), kernel
+    #    invocation overhead (~200-500 ns).
+    #
+    # 2. BLAS thread launch (+2-4 us)      - matmul, linear (any GEMM)
+    #    Once we route to oneMKL `cblas_sgemm`, the BLAS implementation
+    #    forks worker threads via OpenMP / TBB to parallelize the GEMM.
+    #    For tiny matrices the thread launch cost can EXCEED the actual
+    #    compute time; this is the dominant non-base contribution to
+    #    matmul/linear floor on x86.
+    #
+    # 3. Stride/layout normalization (+0.5-1 us) - matmul, linear
+    #    Inputs may need contiguity / transpose for the BLAS backend
+    #    (`is_contiguous` checks, optional copy via `at::empty +
+    #    at::contiguous`). Vector add doesn't need this -- it's
+    #    elementwise on identical-shape tensors.
+    #
+    # 4. nn.Module parameter access (+0.5-1 us) - linear, conv2d (parametric layers)
+    #    `self.weight`, `self.bias` go through `nn.Module.__getattr__`
+    #    overrides + `_parameters` OrderedDict lookups. Vector add and
+    #    raw matmul take no parameters; this cost only hits parametric
+    #    layers.
+    #
+    # 5. Bias epilogue (+0.5-2 us) - linear (and any addmm/fused-bias path)
+    #    After `x @ W.T`, the bias add is either fused (`at::addmm`) or
+    #    a separate dispatch hop (`at::add`). Either way, an additional
+    #    chunk of dispatch + tiny memory traffic.
+    #
+    # ## Summary by op (i7-12700K, fp32, smallest measured shape):
+    #
+    #   vector_add: components 1 only         -> ~2 us empirical (1.84-1.97 us)
+    #   matmul:     components 1+2+3          -> ~6 us empirical (6.2-6.8 us)
+    #   linear:     components 1+2+3+4+5      -> ~9 us empirical (8.8-9.1 us)
+    #
+    # Pre-PR: a single 5 us floor over-predicted vector_add at small N
+    # by ~150% and under-predicted linear at small shapes by ~40%.
+    _CPU_DISPATCH_FLOOR_SECONDS: dict = {
+        # ELEMENTWISE covers vector_add, ReLU, sigmoid, etc. They share
+        # the simplest dispatch path (no BLAS, no params, no bias).
+        "ELEMENTWISE": 2e-6,
+        "MATMUL": 6e-6,
+        "LINEAR": 9e-6,
+    }
+    _CPU_DISPATCH_FLOOR_DEFAULT_SECONDS: float = 5e-6
+
+    def _get_cpu_dispatch_floor(self, sg: SubgraphDescriptor) -> float:
+        """Op-aware CPU dispatch floor in seconds.
+
+        Looks up the floor by ``sg.operation_type`` against
+        ``_CPU_DISPATCH_FLOOR_SECONDS``. Unknown / fused / unset op
+        types fall back to ``_CPU_DISPATCH_FLOOR_DEFAULT_SECONDS``
+        (the legacy 5 us value), so this change is conservative for
+        any op kind not explicitly covered.
+        """
+        op_name = sg.operation_type.name if sg.operation_type else None
+        return self._CPU_DISPATCH_FLOOR_SECONDS.get(
+            op_name, self._CPU_DISPATCH_FLOOR_DEFAULT_SECONDS
+        )
 
     # ------------------------------------------------------------------
     # V5-3b: tier-aware memory_time path (opt-in; gated by

--- a/tests/analysis/test_roofline_cpu_dispatch_floor.py
+++ b/tests/analysis/test_roofline_cpu_dispatch_floor.py
@@ -1,23 +1,47 @@
-"""Regression tests for the CPU dispatch-overhead floor (issue #69).
+"""Regression tests for the op-aware CPU dispatch-overhead floor.
 
-Real PyTorch / nn.Module forward calls have a ~5us floor on CPU due to
-Python dispatch + parameter access + bias-add overhead. The roofline
-math doesn't model this, so very small ops (B=1 linear, tiny matmul)
-under-predict latency by 50-80%.
+History:
+* #69 introduced a single 5 us CPU dispatch floor based on the
+  smallest V4 linear measurement (1, 128, 128) fp32 = 5.20 us.
+* This file's V5 follow-up split the floor per op kind based on
+  the first-principles dispatch decomposition validated against
+  i7-12700K V4 baselines.
 
-The fix in #69 applies a 5us floor in RooflineAnalyzer._analyze_subgraph
-*after* the roofline math: ``actual_latency = max(predicted, 5us)`` for
-CPU. Implemented as a floor (not additive overhead) so it only kicks in
-when the kernel is too small to dominate, avoiding over-correction of
-medium ops where the overhead is amortized by real kernel time.
+What "dispatch" means on a CPU
+------------------------------
 
-Empirical anchor: V4 baseline measurement of (1,128,128) linear fp32
-on i7-12700K is 5.20us -- the wall-clock floor for any forward call.
+Unlike GPU kernel launch (a discrete cudaLaunchKernel that the
+device queues), CPU dispatch is the chain of software work
+PyTorch performs before any FLOPs execute: Python frame entry,
+ATen dispatcher key resolution, output tensor allocation, kernel
+invocation. None of these are physical constraints -- a CPU can
+context-switch in nanoseconds, take an ISR, return from an RPC --
+but they ARE the unavoidable runtime cost of routing a Python-level
+tensor op through the framework. The roofline math ignores all
+of this, so we floor the prediction at the empirical
+smallest-shape latency.
+
+Per-op decomposition (first-principles, validated on i7 fp32):
+
+  vector_add: ~2 us  (base ATen dispatch only)
+  matmul:     ~6 us  (+ BLAS thread launch, stride/layout norm)
+  linear:     ~9 us  (+ nn.Module parameter access, bias epilogue)
+
+See the ``_get_cpu_dispatch_floor`` docstring in
+``src/graphs/estimation/roofline.py`` for the full component
+breakdown.
 
 These tests lock in:
-1. CPU-typed hardware: floor is applied; predicted >= 5us
-2. GPU-typed hardware: NOT affected (GPU has its own kernel-launch overhead model)
-3. Floor only kicks in when the kernel is sub-floor; doesn't add to medium ops
+1. The single-floor-everywhere behavior is gone -- each op kind
+   gets its own floor.
+2. Smallest CPU op of each kind gets its own empirical floor
+   (2 / 6 / 9 us).
+3. GPU is unaffected (GPU has its own kernel-launch overhead model).
+4. Floor only kicks in when the kernel is sub-floor; doesn't add
+   to medium ops.
+5. Unknown / fused / unset op types fall back to the legacy 5 us
+   value so this PR is conservative for code paths it doesn't
+   directly cover.
 """
 
 import pytest
@@ -38,10 +62,10 @@ def _tiny_linear_subgraph() -> SubgraphDescriptor:
         node_names=["linear"],
         operation_types=[OperationType.LINEAR],
         fusion_pattern="linear",
-        total_flops=2 * 1 * 128 * 128,        # 32,768
+        total_flops=2 * 1 * 128 * 128,  # 32,768
         total_macs=1 * 128 * 128,
-        total_input_bytes=1 * 128 * 4,         # 512
-        total_output_bytes=1 * 128 * 4,        # 512
+        total_input_bytes=1 * 128 * 4,  # 512
+        total_output_bytes=1 * 128 * 4,  # 512
         total_weight_bytes=(128 * 128 + 128) * 4,  # 66,048
     )
 
@@ -74,9 +98,9 @@ def test_cpu_floor_applies_to_tiny_op():
     sg = _tiny_linear_subgraph()
     lat = analyzer._analyze_subgraph(sg)
     # The floor is 5us; any prediction below it gets raised.
-    assert lat.actual_latency >= 5e-6, (
-        f"CPU floor not applied: actual_latency={lat.actual_latency*1e6:.2f}us"
-    )
+    assert (
+        lat.actual_latency >= 5e-6
+    ), f"CPU floor not applied: actual_latency={lat.actual_latency*1e6:.2f}us"
 
 
 def test_cpu_floor_does_not_inflate_medium_op():
@@ -109,12 +133,14 @@ def test_gpu_does_not_get_cpu_floor():
     # Build a tiny op
     sg = SubgraphDescriptor(
         subgraph_id=0,
-        node_ids=["x"], node_names=["x"],
+        node_ids=["x"],
+        node_names=["x"],
         operation_types=[OperationType.LINEAR],
         fusion_pattern="linear",
-        total_flops=2 * 1 * 64 * 64,   # tiny
+        total_flops=2 * 1 * 64 * 64,  # tiny
         total_macs=1 * 64 * 64,
-        total_input_bytes=128, total_output_bytes=128,
+        total_input_bytes=128,
+        total_output_bytes=128,
         total_weight_bytes=(64 * 64 + 64) * 2,
     )
     lat = analyzer._analyze_subgraph(sg)
@@ -129,17 +155,140 @@ def test_gpu_does_not_get_cpu_floor():
 # ---------------------------------------------------------------------------
 
 
-def test_v4_anchor_shape_predicts_within_band_of_baseline():
-    """The V4 baseline shows (1,128,128) linear fp32 on i7 measured at
-    5.20us (the wall-clock floor). With the dispatch floor the prediction
-    should land within the LAUNCH 30% tolerance band of that measurement."""
+def test_v4_typical_small_linear_predicts_within_band_of_baseline():
+    """The V4 i7 linear baseline clusters at ~8.7-9.0 us for 7 of the
+    8 smallest shapes (e.g. 1x384x128 = 8.76 us, 1x640x128 = 8.78 us).
+    Only the very-smallest 1x128x128 (32K flops) is an outlier at 5.20
+    us -- so tiny that BLAS thread-launch overhead is fully amortized.
+
+    With the op-aware linear floor (9 us, the typical-cluster value),
+    the prediction lands within the LAUNCH 30% band of any
+    typical-cluster shape. The outlier 1x128x128 is over-predicted
+    (~73%) but is structurally below the model's resolution; it's a
+    documented limitation of the single-floor-per-op approach."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP32)
+    # Use 1x384x128 -- a typical-cluster shape, not the 1x128x128 outlier
+    sg = SubgraphDescriptor(
+        subgraph_id=0,
+        node_ids=["linear"],
+        node_names=["linear"],
+        operation_types=[OperationType.LINEAR],
+        fusion_pattern="linear",
+        total_flops=2 * 1 * 384 * 128,
+        total_macs=1 * 384 * 128,
+        total_input_bytes=1 * 384 * 4,
+        total_output_bytes=1 * 128 * 4,
+        total_weight_bytes=(384 * 128 + 128) * 4,
+    )
+    lat = analyzer._analyze_subgraph(sg)
+    measured_s = 8.76e-6  # i7 baseline: 1x384x128 fp32
+    rel_err = abs(lat.actual_latency - measured_s) / measured_s
+    assert rel_err <= 0.30, (
+        f"Predicted {lat.actual_latency*1e6:.2f}us is {rel_err*100:.0f}% "
+        f"off from typical-cluster baseline 8.76us (LAUNCH band: 30%)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Op-aware floor values
+# ---------------------------------------------------------------------------
+
+
+def _vector_add_subgraph(N: int) -> SubgraphDescriptor:
+    return SubgraphDescriptor(
+        subgraph_id=0,
+        node_ids=["va"],
+        node_names=["va"],
+        operation_types=[OperationType.ELEMENTWISE],
+        fusion_pattern="vector_add",
+        total_flops=N,
+        total_macs=0,
+        total_input_bytes=2 * N * 4,
+        total_output_bytes=N * 4,
+        total_weight_bytes=0,
+    )
+
+
+def _matmul_subgraph(M: int, K: int, N: int) -> SubgraphDescriptor:
+    return SubgraphDescriptor(
+        subgraph_id=0,
+        node_ids=["mm"],
+        node_names=["mm"],
+        operation_types=[OperationType.MATMUL],
+        fusion_pattern="matmul",
+        total_flops=2 * M * K * N,
+        total_macs=M * K * N,
+        total_input_bytes=(M * K + K * N) * 4,
+        total_output_bytes=M * N * 4,
+        total_weight_bytes=0,
+    )
+
+
+def test_vector_add_floor_is_2us():
+    """Empirical i7 floor for vector_add at smallest N (256, 1024) is
+    1.84-1.97 us. Op-aware floor sets vector_add to 2 us, the
+    base-ATen-dispatch component only (no BLAS, no parameter access,
+    no bias)."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP32)
+    sg = _vector_add_subgraph(1024)  # 12 KB working set; tiny
+    lat = analyzer._analyze_subgraph(sg)
+    # Floor binds for this tiny op; the math gives ~ns, floor wins.
+    assert lat.actual_latency == pytest.approx(2e-6, rel=1e-9), (
+        f"vector_add tiny op should hit 2us floor, got "
+        f"{lat.actual_latency*1e6:.2f}us"
+    )
+
+
+def test_matmul_floor_is_6us():
+    """Empirical i7 floor for matmul at smallest shapes (e.g. 64x64x96)
+    is 6.2-6.8 us. Op-aware floor sets matmul to 6 us, capturing
+    base ATen + BLAS thread launch + stride/layout normalization."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP32)
+    sg = _matmul_subgraph(8, 8, 8)  # 512 flops, way below floor
+    lat = analyzer._analyze_subgraph(sg)
+    assert lat.actual_latency == pytest.approx(6e-6, rel=1e-9), (
+        f"matmul tiny op should hit 6us floor, got " f"{lat.actual_latency*1e6:.2f}us"
+    )
+
+
+def test_linear_floor_is_9us():
+    """Empirical i7 floor for linear at typical-small shapes (cluster
+    of 7 of the 8 smallest) is 8.7-9.0 us. Op-aware floor sets linear
+    to 9 us, capturing the matmul stack + parameter access + bias
+    epilogue."""
     hw = create_i7_12700k_mapper().resource_model
     analyzer = RooflineAnalyzer(hw, precision=Precision.FP32)
     sg = _tiny_linear_subgraph()
     lat = analyzer._analyze_subgraph(sg)
-    measured_s = 5.20e-6
-    rel_err = abs(lat.actual_latency - measured_s) / measured_s
-    assert rel_err <= 0.30, (
-        f"Predicted {lat.actual_latency*1e6:.2f}us is {rel_err*100:.0f}% "
-        f"off from baseline 5.20us (LAUNCH band: 30%)"
+    assert lat.actual_latency == pytest.approx(9e-6, rel=1e-9), (
+        f"linear tiny op should hit 9us floor, got " f"{lat.actual_latency*1e6:.2f}us"
+    )
+
+
+def test_unknown_op_falls_back_to_default_floor():
+    """For op kinds not in the op-aware table (CONV2D, RELU, etc.),
+    fall back to the legacy 5 us default. Ensures this PR can't
+    silently break floor predictions for op kinds it didn't
+    explicitly model."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP32)
+    sg = SubgraphDescriptor(
+        subgraph_id=0,
+        node_ids=["c"],
+        node_names=["c"],
+        operation_types=[OperationType.CONV2D],
+        fusion_pattern="conv2d",
+        total_flops=100,  # tiny
+        total_macs=50,
+        total_input_bytes=400,
+        total_output_bytes=400,
+        total_weight_bytes=0,
+    )
+    lat = analyzer._analyze_subgraph(sg)
+    assert lat.actual_latency == pytest.approx(5e-6, rel=1e-9), (
+        f"CONV2D tiny op should fall back to 5us default floor, got "
+        f"{lat.actual_latency*1e6:.2f}us"
     )


### PR DESCRIPTION
## Summary

Splits the single 5 us CPU dispatch floor into per-op values based on
a first-principles decomposition of what \"dispatch\" actually does on
a CPU. Validated against i7-12700K V4 baselines.

**Net V4 floor improvement: +7 records pass that previously failed.**

## What \"dispatch\" means on a CPU

Unlike GPU kernel launch (a discrete `cudaLaunchKernel` that the
device queues), CPU dispatch is the chain of *software* work
PyTorch performs before any FLOPs execute: Python frame entry,
ATen dispatcher key resolution, output tensor allocation, kernel
invocation. None of these are physical constraints -- a CPU can
context-switch in nanoseconds, take an ISR, return from an RPC --
but they ARE the unavoidable runtime cost of routing a
Python-level tensor op through the framework. The roofline math
ignores all of this, so we floor the prediction at the empirical
smallest-shape latency.

## Per-component decomposition

(validated on i7-12700K + Python 3.10 / PyTorch 2.x)

| Component | Cost | Affects |
|---|---|---|
| Base ATen dispatch | ~2 us | All ops |
| BLAS thread launch (oneMKL OpenMP fork) | +2-4 us | matmul, linear |
| Stride/layout normalization | +0.5-1 us | matmul, linear |
| nn.Module parameter access | +0.5-1 us | linear, conv2d |
| Bias epilogue (`at::addmm` or separate `at::add`) | +0.5-2 us | linear |

## Op-aware floor values

| op | components | floor | empirical |
|---|---|---|---|
| **vector_add** | 1 only | **2 us** | 1.84-1.97 us |
| **matmul** | 1+2+3 | **6 us** | 6.2-6.8 us |
| **linear** | 1+2+3+4+5 | **9 us** | 8.8-9.1 us |
| (unknown/fused) | -- | 5 us | (legacy default) |

## V4 floor impact (i7-12700K, default-off)

| op | before | after | delta |
|---|---|---|---|
| matmul | 43/60 fail | 43/60 fail | unchanged (floor rarely binds, math gives > 5 us) |
| vector_add | 5/5 fail | 4/5 fail | -1 |
| **linear** | **41/60 fail** | **35/60 fail** | **-6** |

The 5 smallest linear shapes (the `1x384x128` cluster) all flip
FAIL → PASS: prediction moves from 5 us to 9 us, matching measured
8.8-9.1 us cleanly within the 30% LAUNCH band.

## Known limitation

The very-smallest `(1, 128, 128)` linear (32K flops, the original #69
anchor at 5.20 us) is now over-predicted by ~73% -- it's structurally
below the single-floor-per-op model's resolution. The typical-small
cluster (7 of 8 smallest shapes) takes priority. This is documented
in the updated `test_v4_typical_small_linear_predicts_within_band_of_baseline`.

## Test plan

- [x] **4 new tests** in `test_roofline_cpu_dispatch_floor.py`:
  - `test_vector_add_floor_is_2us`
  - `test_matmul_floor_is_6us`
  - `test_linear_floor_is_9us`
  - `test_unknown_op_falls_back_to_default_floor`
- [x] **1 updated test**: `test_v4_typical_small_linear_predicts_within_band_of_baseline`
  (replaces the old `(1,128,128)` outlier anchor)
- [x] V4 floor sweep: linear -6, vector_add -1, matmul unchanged
- [x] Total: 636 tests pass (632 + 4 new)
- [ ] CI: full matrix passes

## V5 progress after this PR

Three V5 follow-up findings remain (in order of expected impact):
1. ~~Op-aware CPU dispatch floor~~ ← shipped here
2. **L3/DRAM boundary cliff** for matmul shapes near LLC capacity
   (model design discussion: weighted-tier? cache-line-aware?)
3. **L3 calibration tightening** (needs new microbench data or
   matmul-anchored derivation)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CPU latency estimation now uses operation-type-specific dispatch overhead floors instead of a uniform default, delivering more accurate performance predictions for different computation types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->