### PR TITLE
fix(hardware): i7 L1 calibration = 0.02 -- resolves V4 vector_add N=16K floor

### DIFF
--- a/docs/calibration/i7-12700k-l1-calibration-analysis.md
+++ b/docs/calibration/i7-12700k-l1-calibration-analysis.md
@@ -83,10 +83,12 @@ calibrated correctly:
 | **16K** | **192 KB** | **2.74 us** | 2 us | **math wins** |
 
 For N=16K the math part exceeds the floor, and L1 fraction directly
-drives the prediction. With L1 = 0.020 the prediction lands at
-2.74 us vs measured 3.09 us (-9%, well inside the 30% LAUNCH band).
-With the previous default L1 = 1.0 the math part is 0.055 us,
-floor wins, prediction = 2 us (-35% off measured -- FAIL).
+drives the prediction. With the current L1 = 0.020 the prediction
+lands at 2.74 us vs measured 3.09 us (-9%, well inside the 30%
+LAUNCH band). For comparison, **before** this calibration was set
+(when L1 defaulted to 1.0 in the V5-1 / pre-PR-#110 era), the math
+part was 0.055 us, the floor won, prediction was 2 us, and the
+shape FAILED at -35% off measured.
 
 This is what the prior conclusion missed: while L1 calibration is
 structurally moot for matmul, it's load-bearing for vector_add

--- a/docs/calibration/i7-12700k-l1-calibration-analysis.md
+++ b/docs/calibration/i7-12700k-l1-calibration-analysis.md
@@ -1,22 +1,27 @@
 # i7-12700K L1 Calibration Analysis (V5-5 follow-up)
 
-**Status:** L1 `achievable_fraction` is intentionally **left unset**
-(default 1.0) on `create_i7_12700k_mapper` and
-`create_i7_12700k_large_mapper`. This document captures the analysis
-behind that decision so a future contributor doesn't think it's a
-forgotten todo.
+**Status:** L1 `achievable_fraction = 0.02` on
+`create_i7_12700k_mapper` and `create_i7_12700k_large_mapper`,
+matching the 2-point regression below.
+
+**Update history:**
+* PR #105: L1 left at default 1.0 with the rationale "dispatch
+  floor dominates for every L1-binding matmul shape" -- correct
+  for matmul but missed the vector_add medium-N regime.
+* PR (this one): L1 set to 0.02 because vector_add at N=16K (a
+  shape the V4 sweep validates) DOES exceed the 2 us op-aware
+  dispatch floor with the proper L1 fraction, making the
+  calibration value the binding constraint there.
 
 ## TL;DR
 
-For matmul on i7-12700K, the V5-3b tier-aware analyzer is
-**dispatch-floor-bound for every L1-binding shape**. The CPU dispatch
-floor (`5 us` in `RooflineAnalyzer._analyze_subgraph`) supersedes any
-L1-derived memory_time, regardless of `L1.achievable_fraction`.
-Setting L1 to 0.05 vs 1.0 produces identical predictions across all
-48 L1-binding matmul shapes the V4 sweep generates. So the
-calibration value is a no-op until either (a) the dispatch floor
-moves or (b) a workload arrives whose L1-bound memory_time can
-exceed 5 microseconds.
+The 2-point regression on dispatch-corrected L1-resident vector_add
+rows (N=256 and N=1024) yields **BW = 69 GB/s, dispatch = 1.79 us**.
+As a fraction of the L1 aggregate peak (3500 GB/s), that's
+**0.020**. Originally rejected as "structurally unobservable for
+matmul" -- which is true -- but vector_add medium-N (N=4K to 16K)
+sits in the regime where the L1 fraction directly drives the
+prediction and 0.020 lands V4 floor passes within tolerance.
 
 ## Why vector_add can't isolate L1 BW directly
 
@@ -60,22 +65,43 @@ Two issues with using this 69 GB/s as the L1 calibration anchor:
    Even a 50 ns increase on either point (~3% relative noise on
    1.84 us) would shift the BW estimate by 30%.
 
-## Why L1 calibration is moot on the analyzer side
+## Where L1 calibration matters: vector_add medium-N
+
+The dispatch floor argument (below) is correct for **matmul**:
+small matmul shapes have tiny C-tiles (clamped to min(M,N)) and
+correspondingly tiny `bytes_loaded`, so memory_time stays in
+tens-of-nanoseconds and the dispatch floor wins regardless of L1
+fraction. But **vector_add at medium N** (4K-16K elements) has
+working set 48-192 KB, all of which streams through L1, giving
+memory_time on the order of microseconds when L1 fraction is
+calibrated correctly:
+
+| N | WS | math at L1=0.020 (= 70 GB/s) | floor (vector_add 2us) | binding |
+|---|---|---|---|---|
+| 1024 | 12 KB | 0.17 us | 2 us | floor |
+| 4096 | 48 KB | 0.69 us | 2 us | floor |
+| **16K** | **192 KB** | **2.74 us** | 2 us | **math wins** |
+
+For N=16K the math part exceeds the floor, and L1 fraction directly
+drives the prediction. With L1 = 0.020 the prediction lands at
+2.74 us vs measured 3.09 us (-9%, well inside the 30% LAUNCH band).
+With the previous default L1 = 1.0 the math part is 0.055 us,
+floor wins, prediction = 2 us (-35% off measured -- FAIL).
+
+This is what the prior conclusion missed: while L1 calibration is
+structurally moot for matmul, it's load-bearing for vector_add
+medium-N. Setting L1 = 0.020 is harmless for matmul (floor still
+wins there) but materially improves vector_add V4 floors (3/5 ->
+4/5 pass under tier-aware on i7).
+
+## Why L1 calibration was originally judged moot (matmul-only argument)
 
 Even if we settled on a defensible L1 value, it wouldn't change any
-predictions. The CPU dispatch floor in
-`graphs/estimation/roofline.py::_analyze_subgraph`:
-
-```python
-if self.resource_model.hardware_type.name == 'CPU':
-    actual_latency = max(actual_latency, 5e-6)
-```
-
-This 5 us floor came from #69's analysis: real PyTorch / nn.Module
-calls have ~5 us of dispatch + parameter access + bias-add overhead
-per forward call, regardless of kernel size. For L1-binding shapes,
-the tier-aware memory_time is in tens of nanoseconds — the floor is
-two orders of magnitude larger.
+**matmul** predictions. The op-aware CPU dispatch floor in
+`graphs/estimation/roofline.py::_analyze_subgraph` is 6 us for
+matmul. For L1-binding matmul shapes, the tier-aware memory_time
+is in tens of nanoseconds -- the floor is two orders of magnitude
+larger.
 
 Sweep across the V4 matmul shape range (M, K, N <= 128, the
 launch_bound regime that generates L1-binding shapes):

--- a/docs/calibration/i7-12700k-l1-calibration-analysis.md
+++ b/docs/calibration/i7-12700k-l1-calibration-analysis.md
@@ -125,34 +125,34 @@ for s in shapes:
 ```
 
 All 48 L1-binding shapes have memory_time in `[4.7 ns, 65.5 ns]`.
-The 5 us floor wins by 75x to 1000x. Setting
-`L1.achievable_fraction = 0.020` would change memory_time to
-`[235 ns, 3275 ns]` -- still all below the floor. **No prediction
-changes.**
+The 6 us matmul dispatch floor wins by 90x to 1300x. Setting
+`L1.achievable_fraction = 0.020` changes memory_time to
+`[235 ns, 3275 ns]` -- still all below the matmul floor. **For
+matmul, no prediction changes.** The vector_add medium-N regime
+above is the new reason L1 = 0.020 is set anyway.
 
-## When this needs to be revisited
+## When this needs to be revisited (further)
 
-The L1 calibration becomes load-bearing when ANY of the following
-land:
+L1 calibration is now set, but several open questions remain:
 
-1. **The dispatch floor drops or becomes shape-dependent.** If a
-   future change tightens the floor below ~50 ns for some shape
-   class, L1-binding predictions could become memory-time-dominated
-   and `L1.achievable_fraction` starts mattering.
+1. **A multi-threaded vector_add benchmark.** Single-thread data
+   underestimates aggregate L1 BW. A multi-thread benchmark would
+   let us measure the aggregate utilization directly and might
+   shift the calibration significantly.
 
-2. **A multi-threaded vector_add benchmark gets captured.** Running
-   the V5-2b workload across all 16 cores would let us measure the
-   aggregate L1 BW directly. The natural place is to extend the V4
-   capture path with a `--threads` knob.
-
-3. **The MemoryTier model gains thread-count awareness.** A more
+2. **The MemoryTier model gains thread-count awareness.** A more
    honest model would have `effective_bandwidth_bps(thread_count)`
-   that interpolates between single-thread (`peak / num_units`) and
-   aggregate (`peak`). Then the existing single-thread vector_add
-   data calibrates the single-thread end of that curve.
+   that interpolates between single-thread (`peak / num_units`)
+   and aggregate (`peak`). Then the existing single-thread
+   vector_add data calibrates the single-thread end of that curve
+   without forcing a single low fraction across all workloads.
 
-Until then, L1 stays absent from
-`tier_achievable_fractions` on the i7 mappers, defaulting to 1.0.
-The decision is locked by `tests/hardware/test_tier_achievable_fractions.py::test_i7_12700k_l1_uncalibrated`
-and the analytical claim above by
-`tests/hardware/test_i7_l1_calibration_is_dispatch_floor_dominated.py`.
+3. **The dispatch floor architecture changes.** If a future change
+   tightens or removes the floor, more shape classes become
+   memory-time-dominated and the L1 = 0.02 value may start
+   affecting matmul/linear too.
+
+The L1 = 0.02 value is locked by
+`tests/hardware/test_tier_achievable_fractions.py::test_i7_12700k_l1_calibration`
+and the matmul-specific dispatch-floor argument (which still holds)
+by `tests/hardware/test_i7_l1_calibration_is_dispatch_floor_dominated.py`.

--- a/src/graphs/hardware/mappers/cpu.py
+++ b/src/graphs/hardware/mappers/cpu.py
@@ -965,7 +965,7 @@ def create_i7_12700k_mapper() -> CPUMapper:
         # 75x-1000x smaller than the CPU dispatch floor, so any L1
         # achievable_fraction value is a no-op for predictions today.
         # See docs/calibration/i7-12700k-l1-calibration-analysis.md.
-        tier_achievable_fractions={"L2": 0.22, "L3": 0.84, "DRAM": 0.47},
+        tier_achievable_fractions={"L1": 0.02, "L2": 0.22, "L3": 0.84, "DRAM": 0.47},
     )
 
     return CPUMapper(model)
@@ -1197,7 +1197,7 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
         # 75x-1000x smaller than the CPU dispatch floor, so any L1
         # achievable_fraction value is a no-op for predictions today.
         # See docs/calibration/i7-12700k-l1-calibration-analysis.md.
-        tier_achievable_fractions={"L2": 0.22, "L3": 0.84, "DRAM": 0.47},
+        tier_achievable_fractions={"L1": 0.02, "L2": 0.22, "L3": 0.84, "DRAM": 0.47},
     )
 
     return CPUMapper(model)

--- a/src/graphs/hardware/mappers/cpu.py
+++ b/src/graphs/hardware/mappers/cpu.py
@@ -936,35 +936,24 @@ def create_i7_12700k_mapper() -> CPUMapper:
             "consumer-continuous": thermal_profile,
         },
         default_thermal_profile="consumer-continuous",
-        # V5-5 calibration: DRAM achievable_fraction derived from the
-        # vector_add baseline at validation/model_v4/results/baselines/
-        # i7_12700k_vector_add.csv. Plateau rows (N=16M, 67M, 268M;
-        # working set 192 MB to 3 GB, all well past the 25 MB LLC):
-        # measured 35.2 / 34.7 / 36.7 GB/s, median ~35 GB/s. Peak DDR5
-        # is 75 GB/s, so achievable_fraction = 35 / 75 = 0.47. Used by
-        # the V5-3b tier-aware roofline path when opt-in (or after the
-        # V5-5 follow-up flips the default). L1 / L3 entries stay
-        # absent (default 1.0) until matmul-anchored calibration.
-        # V5-5 + follow-up calibration:
-        #   DRAM = 0.47 (i7_12700k_vector_add.csv plateau, peak 75 GB/s)
-        #   L3   = 0.84 (i7_12700k_vector_add.csv 2-point fit on
-        #                dispatch-corrected L3-bound rows N=65K and
-        #                N=1M: 167.6 GB/s and 166.7 GB/s respectively
-        #                vs L3 peak 200 GB/s -> mean 0.836, rounded
-        #                to 0.84. The N=262K shape shows non-physical
-        #                fraction 1.71x peak -- per-core L2 hits the
-        #                i7 mapper doesn't currently model -- and is
-        #                rejected from the regression. See
-        #                docs/calibration/i7-12700k-l3-calibration-analysis.md
-        #                for the full derivation + the structural
-        #                limit (no L3 value can fix N=262K's V4 floor
-        #                failure; needs model refinement, not
-        #                calibration).
-        # L1 stays intentionally absent (default 1.0). The tier-aware
-        # memory_time for every L1-binding matmul shape on i7 is
-        # 75x-1000x smaller than the CPU dispatch floor, so any L1
-        # achievable_fraction value is a no-op for predictions today.
-        # See docs/calibration/i7-12700k-l1-calibration-analysis.md.
+        # V5-5 + follow-up calibration values, all from
+        # validation/model_v4/results/baselines/i7_12700k_vector_add.csv
+        # (dispatch-corrected via the L1 regression's 1.79 us constant).
+        # Per-tier docs at docs/calibration/i7-12700k-{l1,l2,l3}-calibration-analysis.md.
+        #
+        #   L1   = 0.020  2-point regression (N=256, N=1024); aggregate
+        #                 peak 3500 GB/s -> 70 GB/s effective. Matters for
+        #                 vector_add medium-N (N=4K-16K); no-op for matmul
+        #                 (dispatch floor 6 us dominates there).
+        #   L2   = 0.22   Per-core L2 (private, exclusive). vector_add at
+        #                 N=262K (3 MB WS); aggregate peak 1.5 TB/s ->
+        #                 326 GB/s effective single-thread.
+        #   L3   = 0.84   2-point regression on N=65K + N=1M (clean
+        #                 L3-resident; the N=262K outlier was 1.71x peak
+        #                 indicating per-core L2 hits and was rejected).
+        #                 Peak 200 GB/s -> 168 GB/s effective.
+        #   DRAM = 0.47   Plateau median across N=16M/67M/268M rows.
+        #                 Peak DDR5 75 GB/s -> 35 GB/s effective.
         tier_achievable_fractions={"L1": 0.02, "L2": 0.22, "L3": 0.84, "DRAM": 0.47},
     )
 
@@ -1173,30 +1162,10 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
             "consumer-continuous-large": thermal_profile,
         },
         default_thermal_profile="consumer-continuous-large",
-        # V5-5: same physical DDR5 subsystem as create_i7_12700k_mapper(),
-        # so the calibrated DRAM achievable_fraction applies identically.
-        # See the tiny-model variant for derivation (median 35 GB/s
-        # plateau on N=16M/67M/268M vector_add baseline; peak 75 GB/s).
-        # V5-5 + follow-up calibration:
-        #   DRAM = 0.47 (i7_12700k_vector_add.csv plateau, peak 75 GB/s)
-        #   L3   = 0.84 (i7_12700k_vector_add.csv 2-point fit on
-        #                dispatch-corrected L3-bound rows N=65K and
-        #                N=1M: 167.6 GB/s and 166.7 GB/s respectively
-        #                vs L3 peak 200 GB/s -> mean 0.836, rounded
-        #                to 0.84. The N=262K shape shows non-physical
-        #                fraction 1.71x peak -- per-core L2 hits the
-        #                i7 mapper doesn't currently model -- and is
-        #                rejected from the regression. See
-        #                docs/calibration/i7-12700k-l3-calibration-analysis.md
-        #                for the full derivation + the structural
-        #                limit (no L3 value can fix N=262K's V4 floor
-        #                failure; needs model refinement, not
-        #                calibration).
-        # L1 stays intentionally absent (default 1.0). The tier-aware
-        # memory_time for every L1-binding matmul shape on i7 is
-        # 75x-1000x smaller than the CPU dispatch floor, so any L1
-        # achievable_fraction value is a no-op for predictions today.
-        # See docs/calibration/i7-12700k-l1-calibration-analysis.md.
+        # Same physical hardware as create_i7_12700k_mapper(), so the
+        # calibration values apply identically. See the tiny-model
+        # variant above for the full per-tier rationale + per-tier
+        # docs at docs/calibration/i7-12700k-{l1,l2,l3}-calibration-analysis.md.
         tier_achievable_fractions={"L1": 0.02, "L2": 0.22, "L3": 0.84, "DRAM": 0.47},
     )
 

--- a/tests/hardware/test_tier_achievable_fractions.py
+++ b/tests/hardware/test_tier_achievable_fractions.py
@@ -164,14 +164,23 @@ def test_i7_12700k_l3_calibration():
     assert l3.effective_bandwidth_bps == pytest.approx(200e9 * 0.84)
 
 
-def test_i7_12700k_l1_uncalibrated():
-    """V5-5 follow-up still leaves L1 absent (default 1.0). Pure
-    L1-BW calibration would need a sub-microsecond benchmark that
-    isolates L1 BW from dispatch overhead, which the V5-2b
-    vector_add baseline doesn't provide cleanly."""
+def test_i7_12700k_l1_calibration():
+    """V5 follow-up: i7 ``L1.achievable_fraction = 0.020`` from the
+    2-point regression on N=256 and N=1024 vector_add baseline rows
+    (BW = 69 GB/s after dispatch correction; aggregate L1 peak is
+    3500 GB/s, so 69/3500 = 0.020). Originally judged a no-op (PR
+    #105) because dispatch floor dominates for matmul L1-binding
+    shapes -- which is true -- but vector_add at medium N (4K-16K)
+    has WS in the 48-192 KB range where the math part exceeds the
+    2 us op-aware dispatch floor and L1 fraction drives the
+    prediction. Setting 0.020 lands V4 vector_add N=16K within the
+    30% LAUNCH band."""
     hw = create_i7_12700k_mapper().resource_model
+    assert hw.tier_achievable_fractions.get("L1") == 0.02
     l1 = next(t for t in hw.memory_hierarchy if t.name == "L1")
-    assert l1.achievable_fraction == 1.0
+    assert l1.achievable_fraction == 0.02
+    # Verify the effective BW lands at the regression value (69 GB/s)
+    assert l1.effective_bandwidth_bps == pytest.approx(3500e9 * 0.02)
 
 
 def test_i7_12700k_large_mapper_inherits_dram_calibration():


### PR DESCRIPTION
## Summary

Sets `L1.achievable_fraction = 0.02` on the i7 mappers, the
**2-point regression value PR #105 derived but didn't apply**.
PR #105's "no-op" rationale was correct for matmul but missed
the vector_add medium-N regime where L1 fraction directly drives
predictions.

**V4 vector_add floor on i7: 3/5 -> 4/5 pass under tier-aware.**

## Why this PR exists (correcting #105's incomplete conclusion)

PR #105 concluded that L1 calibration is structurally a no-op
because "the dispatch floor dominates for every L1-binding shape".
That was correct for matmul (tile clamping produces tiny
`bytes_loaded`, so memory_time stays in nanoseconds). It missed
that vector_add at N=16K has a 192 KB working set that streams
through L1 at multi-microsecond memory_time when the L1 fraction
is calibrated correctly.

The regime split:

| N | WS | math at L1=1.0 | math at L1=0.02 | bound by |
|---|---|---|---|---|
| 1024 | 12 KB | 0.003 us | 0.17 us | floor (2 us) |
| 4096 | 48 KB | 0.014 us | 0.69 us | floor |
| **16K** | **192 KB** | 0.055 us | **2.74 us** | **math wins** |

For N=16K specifically, math at L1=0.02 (= 70 GB/s effective)
exceeds the 2 us vector_add op-aware floor, and the L1 fraction
becomes the binding constraint. The 0.02 value matches the
2-point regression PR #105 derived (BW = 69 GB/s, dispatch =
1.79 us, fraction = 69/3500 = 0.020).

## V4 floor impact

i7 vector_add validation, `--use-tier-aware-memory`:

| shape | pre-PR (L1=1.0) | post-PR (L1=0.02) |
|---|---|---|
| N=1024 | PASS (+1%) | PASS (+1%) (floor wins both) |
| **N=16K** | **FAIL (-35%)** | **PASS (-9%)** |
| N=262K | PASS (-13%) | PASS (-13%) (binds L2, unchanged) |
| N=4M | FAIL (+140%) | FAIL (+140%) (DRAM cliff, unchanged) |
| N=67M | PASS (-1%) | PASS (-1%) (DRAM, unchanged) |

**`pass_latency: 3/5 -> 4/5`**.

matmul (43/60 fail) and linear (35/60 default-off, 43/60
tier-aware) are unchanged: their dispatch floors (6 us / 9 us)
still dominate for L1-binding shapes, so L1 = 0.02 is invisible
there. PR #105's matmul-specific conclusion remains true.

## Documentation

`docs/calibration/i7-12700k-l1-calibration-analysis.md` updated
with:
- Explicit regime split (where L1 calibration matters vs doesn't)
- Math showing N=16K crosses the floor threshold
- Update history (#105 -> this PR)

## Tests

- `test_i7_12700k_l1_calibration` replaces `_l1_uncalibrated`,
  asserting L1 = 0.020 + effective BW = 70 GB/s
- `test_i7_l1_calibration_is_dispatch_floor_dominated` regression
  gate (the matmul-specific claim) still passes -- its claim was
  always matmul-specific and remains true

## Test plan

- [x] V4 vector_add tier-aware: 3/5 -> 4/5 pass
- [x] V4 matmul (default-off + tier-aware): unchanged
- [x] V4 linear (default-off + tier-aware): unchanged
- [x] 640 tests pass total (unchanged count; one test renamed)
- [ ] CI: full matrix passes

## Calibration coverage matrix (post-PR)

| target | DRAM | L3 | L2 | L1 |
|---|---|---|---|---|
| **i7-12700K** | **0.47** | **0.84** | **0.22** | **0.02** (this PR) |
| Jetson Orin Nano | 0.55 | 1.0 (default) | 1.0 (default) | 1.0 (default) |

## Remaining V4 floor failures

Only N=4M (L3/DRAM boundary cliff) remains. That's a separate
model design issue (binary tier classification at the boundary;
50 MB just past 25 MB LLC over-attributes to DRAM). Resolution
needs weighted-tier or smaller-transition-zone model -- not a
calibration value.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated i7-12700K L1 cache calibration analysis and performance expectations for vector operations.

* **Bug Fixes**
  * Improved i7-12700K L1 cache performance calibration for more accurate predictions on vector workloads at medium working set sizes (4K–16K).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->