### PR TITLE
feat(estimation): L3/DRAM boundary cliff -- OVERLAP physics for vector_add

### DIFF
--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -1220,7 +1220,31 @@ class RooflineAnalyzer:
         if bw <= 0:
             return None
 
-        memory_time = result.bytes_loaded / bw
+        # V5 follow-up: L3/DRAM boundary cliff resolution for
+        # vector_add. When the operand overflows the outermost cache
+        # but is comparable to it (e.g., 50 MB vs 25 MB LLC), the
+        # measured BW lands between cache and DRAM. The binary tier
+        # picker says "binding = DRAM" with full DRAM-calibrated BW
+        # (35 GB/s on i7), but reality shows ~84 GB/s for those
+        # boundary shapes -- partial cache hits the model misses.
+        #
+        # OVERLAP physical model: cache warmup (filling LLC with the
+        # first cap bytes) and DRAM streaming (remaining bytes) happen
+        # in parallel via prefetch + memory-controller overlap, not
+        # sequentially. memory_time = max(cache_fill_time,
+        # dram_stream_time).
+        #
+        # Scope: vector_add specifically (zero-reuse model where
+        # bytes_loaded == operand_footprint). For matmul / linear the
+        # bytes_loaded calculation already encodes reuse via the
+        # per-op model; the OVERLAP physics differ when data is
+        # tile-streamed with reuse, so we don't apply it there.
+        memory_time = self._memory_time_with_boundary_overlap(
+            op_kind=op_kind,
+            bytes_loaded=result.bytes_loaded,
+            binding_tier=result.binding_tier,
+            hierarchy=hierarchy,
+        )
         self._last_tier_bytes_loaded = result.bytes_loaded
         self._last_memory_explanation = MemoryExplanation(
             binding_tier_name=result.binding_tier.name,
@@ -1231,6 +1255,78 @@ class RooflineAnalyzer:
             effective_bandwidth_bps=float(bw),
         )
         return memory_time
+
+    @staticmethod
+    def _memory_time_with_boundary_overlap(
+        op_kind: str,
+        bytes_loaded: int,
+        binding_tier: "MemoryTier",
+        hierarchy: list,
+    ) -> float:
+        """V5-followup boundary cliff model: when a vector_add op
+        binds at DRAM but its operand size is comparable to the
+        outermost cache, blend cache fill time with DRAM stream
+        time via the OVERLAP physics:
+
+            memory_time = max(cache_fill_time, dram_stream_time)
+
+        where:
+            cache_fill_time = min(bytes_loaded, last_cache.cap)
+                              / last_cache.effective_bandwidth_bps
+            dram_stream_time = max(0, bytes_loaded - last_cache.cap)
+                              / dram.effective_bandwidth_bps
+
+        For shapes far past LLC (overflow >> cap), the dram_stream_time
+        dominates and the model collapses to the current binary
+        behavior (memory_time = bytes_loaded / dram_eff_bw, with the
+        cache_fill_time contributing only the first ~149 us of L3
+        warmup -- negligible at multi-millisecond DRAM streaming).
+
+        For shapes well inside LLC, the picker doesn't bind at DRAM
+        in the first place, so this code path doesn't fire.
+
+        For the boundary regime (1x-4x past LLC), the cache_fill_time
+        is non-negligible relative to dram_stream_time, and OVERLAP
+        gives a more accurate prediction than pure-DRAM-stream. The
+        N=4M vector_add case lands at +20% (PASS) vs +140% (FAIL)
+        under the previous binary model.
+        """
+        bw = binding_tier.effective_bandwidth_bps
+        # Default behavior (current): pure binding-tier streaming.
+        default_time = bytes_loaded / bw
+
+        # Scope: vector_add only. The matmul / linear bytes_loaded
+        # calculation encodes reuse via tile-streaming reload counts;
+        # the OVERLAP physics (cache fills then concurrent DRAM
+        # stream) doesn't apply when the data has structured reuse.
+        if op_kind != "vector_add":
+            return default_time
+
+        # Predicate: only at the outermost-tier boundary (binding == DRAM).
+        # For binding at L1 / L2 / L3 the picker has already routed
+        # correctly and OVERLAP would be a model-confusion.
+        if binding_tier.name != "DRAM":
+            return default_time
+
+        # Find the last cache tier (innermost-out, the tier just
+        # before DRAM). If there isn't one (DRAM-only hierarchy),
+        # OVERLAP is moot.
+        cache_tiers = [t for t in hierarchy if t.name != "DRAM"]
+        if not cache_tiers:
+            return default_time
+        last_cache = cache_tiers[-1]
+        cache_cap = last_cache.total_capacity_bytes
+        cache_bw = last_cache.effective_bandwidth_bps
+        if cache_cap <= 0 or cache_bw <= 0:
+            return default_time
+
+        # OVERLAP physics: cache warmup time + DRAM streaming time,
+        # parallelized.
+        cache_fill_bytes = min(bytes_loaded, cache_cap)
+        dram_stream_bytes = max(0, bytes_loaded - cache_cap)
+        cache_fill_time = cache_fill_bytes / cache_bw
+        dram_stream_time = dram_stream_bytes / bw
+        return max(cache_fill_time, dram_stream_time)
 
     @staticmethod
     def _extract_matmul_shape(sg: SubgraphDescriptor) -> Optional[tuple]:

--- a/tests/analysis/test_roofline_tier_aware.py
+++ b/tests/analysis/test_roofline_tier_aware.py
@@ -457,6 +457,110 @@ def test_opt_in_falls_back_for_elementwise_with_mismatched_shapes():
     assert on.memory_explanation is None
 
 
+# ---------------------------------------------------------------------------
+# Boundary-cliff OVERLAP model (V5 follow-up: resolves N=4M floor failure)
+# ---------------------------------------------------------------------------
+
+
+def test_vector_add_dram_binding_uses_overlap_model_at_boundary():
+    """V5 follow-up: when vector_add binds DRAM with operand size
+    comparable to the outermost cache (boundary regime), use the
+    OVERLAP physics:
+      memory_time = max(cache_fill_time, dram_stream_time)
+    instead of pure DRAM streaming. The boundary case (N=4M on
+    i7, WS=50 MB just past the 25 MB LLC) showed +140% over-
+    prediction with binary tier picking; OVERLAP brings it to
+    +15% (passes 25% DRAM band)."""
+    N = 4 * 1024 * 1024
+    sg = _vector_add_subgraph(N)
+    hw = create_i7_12700k_mapper().resource_model
+    desc = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )._analyze_subgraph(sg)
+
+    bytes_loaded = 3 * N * 4  # 50 MB
+    # Pure DRAM (binary, what we'd get without OVERLAP):
+    dram_eff_bw = next(
+        t.effective_bandwidth_bps for t in hw.memory_hierarchy if t.name == "DRAM"
+    )
+    pure_dram_time = bytes_loaded / dram_eff_bw
+
+    # OVERLAP-corrected memory_time must be SHORTER than pure DRAM
+    # (cache hits help) but LONGER than zero. The exact value depends
+    # on L3 capacity + BW; we assert the corridor.
+    assert desc.memory_time < pure_dram_time, (
+        f"OVERLAP didn't kick in: memory_time={desc.memory_time*1e6:.1f}us "
+        f">= pure_dram={pure_dram_time*1e6:.1f}us. The L3 cache fill "
+        f"component should be reducing the prediction."
+    )
+    # Sanity floor: prediction can't be smaller than the DRAM stream
+    # for the overflow bytes alone (50 MB - 25 MB = 25 MB at DRAM BW).
+    overflow_dram_time = (bytes_loaded - 25 * 1024 * 1024) / dram_eff_bw
+    assert desc.memory_time >= overflow_dram_time * 0.95, (
+        f"OVERLAP under-counted DRAM stream time: got "
+        f"{desc.memory_time*1e6:.1f}us vs floor "
+        f"{overflow_dram_time*1e6:.1f}us"
+    )
+
+
+def test_vector_add_deeply_dram_bound_falls_back_to_pure_dram():
+    """For shapes vastly past LLC (e.g., N=67M, WS=768 MB on i7's
+    25 MB LLC), the cache_fill_time component is negligible and
+    OVERLAP collapses to pure DRAM streaming. The prediction
+    should be dominated by dram_stream_time."""
+    N = 67 * 1024 * 1024
+    sg = _vector_add_subgraph(N)
+    hw = create_i7_12700k_mapper().resource_model
+    desc = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )._analyze_subgraph(sg)
+
+    bytes_loaded = 3 * N * 4
+    dram_eff_bw = next(
+        t.effective_bandwidth_bps for t in hw.memory_hierarchy if t.name == "DRAM"
+    )
+    pure_dram_time = bytes_loaded / dram_eff_bw
+
+    # OVERLAP and pure-DRAM should match within 5% for deeply
+    # DRAM-bound shapes (the L3 fill time of ~149us is negligible
+    # vs the multi-millisecond DRAM stream).
+    rel = abs(desc.memory_time - pure_dram_time) / pure_dram_time
+    assert rel < 0.05, (
+        f"OVERLAP perturbed deeply-DRAM-bound prediction by "
+        f"{rel*100:.0f}% (threshold 5%); something's wrong with "
+        f"the cache_fill_time vs dram_stream_time max() collapse."
+    )
+
+
+def test_overlap_does_not_apply_to_matmul_dram_binding():
+    """The OVERLAP scope is vector_add only. Matmul / linear use
+    the per-op reuse model's bytes_loaded which already encodes
+    tile-streaming reload counts; OVERLAP physics (cache fill +
+    concurrent DRAM stream) doesn't apply there. This test pins
+    that scope so matmul predictions don't inadvertently get
+    OVERLAP-discounted."""
+    sg = _matmul_subgraph(4096, 4096, 4096)  # 192 MB operand, DRAM-bound
+    hw = create_i7_12700k_mapper().resource_model
+    desc = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )._analyze_subgraph(sg)
+
+    # bytes_loaded for matmul includes tile-streaming reloads; the
+    # raw division by binding-tier BW should give the same answer
+    # whether OVERLAP fires or not (because OVERLAP doesn't fire
+    # for matmul).
+    me = desc.memory_explanation
+    assert me is not None
+    assert me.binding_tier_name == "DRAM"
+    pure_dram_time = me.bytes_loaded / me.effective_bandwidth_bps
+    # memory_time must equal pure DRAM for matmul (no OVERLAP)
+    assert desc.memory_time == pytest.approx(pure_dram_time, rel=1e-9), (
+        f"matmul DRAM-binding got OVERLAP-modified memory_time "
+        f"({desc.memory_time*1e6:.1f}us vs pure-DRAM "
+        f"{pure_dram_time*1e6:.1f}us); the scope predicate is wrong."
+    )
+
+
 def test_memory_explanation_format_summary_renders_breakdown():
     """LatencyDescriptor.format_summary should include a 'Memory binding'
     line when memory_explanation is set, so the breakdown surfaces in


### PR DESCRIPTION
## Summary

Resolves the **V4 vector_add N=4M floor failure** (the last
remaining vector_add fail on i7). Working sets 1x-4x past LLC
capacity show empirical BW between cache and DRAM (e.g.,
84 GB/s at 50 MB on i7 vs 35 GB/s DRAM peak), but the binary
tier picker said "binding = DRAM" with full DRAM-calibrated BW
-- producing +140% over-prediction.

**V4 vector_add: 4/5 -> 5/5 PASS under tier-aware on i7.**

## Physical model

Modern CPUs prefetch and overlap cache + DRAM access. For a
working set that spans cache and DRAM:

```
cache_fill_time  = min(bytes_loaded, cache_cap) / cache_eff_bw
dram_stream_time = max(0, bytes_loaded - cache_cap) / dram_eff_bw
memory_time      = max(cache_fill_time, dram_stream_time)
```

The max() (not +) collapse reflects that the memory controller
fills the cache concurrently with serving DRAM reads to the
consumer; the two streams operate in parallel.

### Three regime behaviors

| WS vs cache_cap | OVERLAP behavior | rationale |
|---|---|---|
| WS < cache_cap | doesn't fire | picker doesn't bind DRAM |
| WS in [1x, ~4x] cache_cap | meaningful blend | boundary regime |
| WS >> cache_cap | collapses to pure DRAM | cache_fill_time ~ 149us is noise vs multi-ms DRAM stream |

## Why other models lost

| model | N=4M | N=16M | N=67M | net delta |
|---|---|---|---|---|
| Sequential cache + DRAM (`cache_time + dram_time`) | +45% (FAIL) | -9% | -8% | none |
| Linear BW interpolation by overflow fraction | -17% PASS | **-32% (FAIL, was PASS)** | n/a | breaks N=16M |
| **OVERLAP `max(cache_time, dram_time)`** | **+15% PASS** | -12% PASS | -5% PASS | **+1 PASS, no regressions** |

## Scope

**Vector_add only.** The bytes_loaded calculation in the V5-3a
matmul / linear reuse models already encodes tile-streaming
reload counts; the OVERLAP physics (cache fills then concurrent
DRAM stream) doesn't apply when the data has structured reuse.
Matmul / linear predictions are unchanged.

The scope predicate is locked by
`test_overlap_does_not_apply_to_matmul_dram_binding`.

## Empirical fit (i7 vector_add, --use-tier-aware-memory)

| shape | binary (pre-PR) | OVERLAP (this PR) | measured |
|---|---|---|---|
| N=1M | -5% PASS | -5% PASS | no overflow |
| **N=4M** | **+140% FAIL** | **+15% PASS** | 596 us |
| N=16M | -1% PASS | -12% PASS | 5417 us |
| N=67M | -1% PASS | -5% PASS | 23179 us |

## Test plan

- [x] **3 new tests**:
  - `test_vector_add_dram_binding_uses_overlap_model_at_boundary` --
    boundary shapes' memory_time is strictly less than pure-DRAM
    streaming and at least the overflow bytes at DRAM rate
  - `test_vector_add_deeply_dram_bound_falls_back_to_pure_dram` --
    deeply DRAM-bound predictions match pure-DRAM within 5%
  - `test_overlap_does_not_apply_to_matmul_dram_binding` -- scope
    pin: matmul predictions equal pure-DRAM, no OVERLAP discount
- [x] V4 vector_add tier-aware: 4/5 -> **5/5 pass**
- [x] V4 matmul / linear: unchanged (default-off + tier-aware)
- [x] V4 default-off byte-identical (regression guarded by existing
  `test_default_off_produces_identical_memory_time_to_pre_v5_3b`)
- [x] Total: 643 tests pass (640 + 3)
- [ ] CI: full matrix passes

## V5 status after this PR

| target | DRAM | L3 | L2 | L1 | V4 vector_add floor |
|---|---|---|---|---|---|
| **i7-12700K** | 0.47 | 0.84 | 0.22 | 0.02 | **5/5 PASS** ✓ |

## Remaining V5 follow-ups

- **V5-3b default-flag flip** -- gated on equal-or-improved floors
  across all ops. Vector_add now perfect (5/5). Matmul / linear
  still have variance under tier-aware -- needs per-op or
  thread-count-aware calibration.
- **V5-6** -- retire `_get_bandwidth_efficiency_scale`

Generated with [Claude Code](https://claude.com/claude-code)