### PR TITLE
feat(estimation,hardware): per-op tier calibration -- V5-3b flag-flip prerequisite

### DIFF
--- a/src/graphs/estimation/reuse_models.py
+++ b/src/graphs/estimation/reuse_models.py
@@ -185,6 +185,22 @@ class MatmulReuseModel:
 
     op_kind = "matmul"
 
+    # Below this min(M, N) threshold the optimal-square tile collapses
+    # to the small dimension (e.g. for B=2 linear, tile = (2, 2)) and
+    # the bytes_loaded reload-count formula explodes -- A is reloaded
+    # ceil(N / 2) = N/2 times. Real BLAS uses a different blocking
+    # strategy for skinny shapes (K-blocking with the full output
+    # tile), which this branch models: pick (M, N) as the tile so
+    # bytes_loaded equals operand_footprint with no reload inflation.
+    #
+    # Threshold of 16 was chosen because: (a) above 16 the square tile
+    # is genuinely useful (residency stays cache-friendly even with
+    # reload reuse); (b) below 16 the inflation factor is large
+    # (>20x for B=2, ~6x for B=8) and the no-reuse model is empirically
+    # closer to reality for these shapes on i7. See V5 follow-up
+    # PR description for the calibration data driving this threshold.
+    _SKINNY_THRESHOLD = 16
+
     def residency_window(
         self,
         shape: Sequence[int],
@@ -201,6 +217,18 @@ class MatmulReuseModel:
                 f"tier_capacity_bytes must be positive: {tier_capacity_bytes}"
             )
         bpe = bytes_per_element(dtype)
+
+        # Skinny shape branch: when the smallest output dim is below
+        # the threshold, the square-tile model produces an
+        # inflated bytes_loaded that doesn't match BLAS reality.
+        # Use full-output tile (Mt = M, Nt = N) so bytes_loaded
+        # collapses to the one-pass / no-reload sum.
+        if min(M, N) < self._SKINNY_THRESHOLD:
+            return TileChoice(
+                tile_dims=(int(M), int(N)),
+                residency_bytes=int(round(3 * M * N * bpe)),
+            )
+
         t_max = min(M, N)
         t_raw = int(floor(sqrt(tier_capacity_bytes / (3 * bpe))))
         t = max(1, min(t_max, t_raw))

--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -1216,7 +1216,12 @@ class RooflineAnalyzer:
         if result is None:
             return None
 
-        bw = result.binding_tier.effective_bandwidth_bps
+        # Per-op effective BW (V5-3b flag-flip prerequisite): a single
+        # ``achievable_fraction`` per tier doesn't capture that matmul /
+        # linear achieve different effective BW than vector_add at the
+        # same tier (different access patterns -> different cache hit
+        # rates). The lookup falls back per-op -> per-tier -> 1.0.
+        bw = self._per_op_effective_bw(result.binding_tier, op_kind)
         if bw <= 0:
             return None
 
@@ -1244,6 +1249,7 @@ class RooflineAnalyzer:
             bytes_loaded=result.bytes_loaded,
             binding_tier=result.binding_tier,
             hierarchy=hierarchy,
+            binding_tier_bw=bw,
         )
         self._last_tier_bytes_loaded = result.bytes_loaded
         self._last_memory_explanation = MemoryExplanation(
@@ -1256,12 +1262,37 @@ class RooflineAnalyzer:
         )
         return memory_time
 
-    @staticmethod
+    def _per_op_effective_bw(self, tier: "MemoryTier", op_kind: str) -> float:
+        """V5-3b flag-flip prerequisite: per-op effective BW lookup.
+
+        Returns ``tier.peak_bandwidth_bps * fraction``, where fraction
+        falls back through:
+          1. ``tier_achievable_fractions_by_op[op_kind][tier.name]``
+             -- per-op override
+          2. ``tier_achievable_fractions[tier.name]`` -- per-tier
+             default (the V5-5 calibrated value)
+          3. ``1.0`` -- ideal
+
+        Per-op overrides are a workload-specific calibration knob:
+        matmul / linear achieve different effective BW than
+        vector_add at the same tier because of structured access
+        patterns. The single-fraction-per-tier model can't capture
+        this, so the per-op override sits on top.
+        """
+        op_dict = self.resource_model.tier_achievable_fractions_by_op.get(op_kind, {})
+        if tier.name in op_dict:
+            fraction = op_dict[tier.name]
+        else:
+            fraction = self.resource_model.tier_achievable_fractions.get(tier.name, 1.0)
+        return tier.peak_bandwidth_bps * fraction
+
     def _memory_time_with_boundary_overlap(
+        self,
         op_kind: str,
         bytes_loaded: int,
         binding_tier: "MemoryTier",
         hierarchy: list,
+        binding_tier_bw: float,
     ) -> float:
         """V5-followup boundary cliff model: when a vector_add op
         binds at DRAM but its operand size is comparable to the
@@ -1291,9 +1322,10 @@ class RooflineAnalyzer:
         N=4M vector_add case lands at +20% (PASS) vs +140% (FAIL)
         under the previous binary model.
         """
-        bw = binding_tier.effective_bandwidth_bps
-        # Default behavior (current): pure binding-tier streaming.
-        default_time = bytes_loaded / bw
+        # Default behavior (current): pure binding-tier streaming
+        # using the caller-provided ``binding_tier_bw`` (which is
+        # already the per-op effective BW from _per_op_effective_bw).
+        default_time = bytes_loaded / binding_tier_bw
 
         # Scope: vector_add only. The matmul / linear bytes_loaded
         # calculation encodes reuse via tile-streaming reload counts;
@@ -1316,7 +1348,9 @@ class RooflineAnalyzer:
             return default_time
         last_cache = cache_tiers[-1]
         cache_cap = last_cache.total_capacity_bytes
-        cache_bw = last_cache.effective_bandwidth_bps
+        # Per-op cache BW (vector_add gets the per-tier default,
+        # which is the V5-5 calibrated value for that tier).
+        cache_bw = self._per_op_effective_bw(last_cache, op_kind)
         if cache_cap <= 0 or cache_bw <= 0:
             return default_time
 
@@ -1325,7 +1359,7 @@ class RooflineAnalyzer:
         cache_fill_bytes = min(bytes_loaded, cache_cap)
         dram_stream_bytes = max(0, bytes_loaded - cache_cap)
         cache_fill_time = cache_fill_bytes / cache_bw
-        dram_stream_time = dram_stream_bytes / bw
+        dram_stream_time = dram_stream_bytes / binding_tier_bw
         return max(cache_fill_time, dram_stream_time)
 
     @staticmethod

--- a/src/graphs/hardware/mappers/cpu.py
+++ b/src/graphs/hardware/mappers/cpu.py
@@ -955,6 +955,24 @@ def create_i7_12700k_mapper() -> CPUMapper:
         #   DRAM = 0.47   Plateau median across N=16M/67M/268M rows.
         #                 Peak DDR5 75 GB/s -> 35 GB/s effective.
         tier_achievable_fractions={"L1": 0.02, "L2": 0.22, "L3": 0.84, "DRAM": 0.47},
+        # Per-op overrides: vector_add (the V5-2b baseline workload)
+        # gets the per-tier defaults above. Matmul / linear achieve
+        # different effective BW because of structured access
+        # patterns (cache hits the V5-3a reuse model can't capture
+        # via a single tier-fraction). Empirical fit from V4 sweep
+        # measurements:
+        #   matmul/linear @ L2: 0.10 -- vs 0.22 for vector_add. Multi-
+        #     thread BLAS doesn't realize the same per-core L2 BW that
+        #     single-thread torch.add does at the same WS range.
+        #   matmul/linear @ DRAM: 0.85 -- close to scalar
+        #     bw_efficiency_scale's value because matmul has reuse
+        #     (effective DRAM streaming exceeds vector_add's 0.47
+        #     plateau when the kernel hits caches mid-stream).
+        # See PR description for the per-shape derivation.
+        tier_achievable_fractions_by_op={
+            "matmul": {"L2": 0.10, "DRAM": 0.85},
+            "linear": {"L2": 0.10, "DRAM": 0.85},
+        },
     )
 
     return CPUMapper(model)
@@ -1167,6 +1185,10 @@ def create_i7_12700k_large_mapper() -> CPUMapper:
         # variant above for the full per-tier rationale + per-tier
         # docs at docs/calibration/i7-12700k-{l1,l2,l3}-calibration-analysis.md.
         tier_achievable_fractions={"L1": 0.02, "L2": 0.22, "L3": 0.84, "DRAM": 0.47},
+        tier_achievable_fractions_by_op={
+            "matmul": {"L2": 0.10, "DRAM": 0.85},
+            "linear": {"L2": 0.10, "DRAM": 0.85},
+        },
     )
 
     return CPUMapper(model)

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -1109,6 +1109,27 @@ class HardwareResourceModel:
     # functions, not here.
     tier_achievable_fractions: Dict[str, float] = field(default_factory=dict)
 
+    # V5-3b flag-flip prerequisite: per-op overrides for the tier-aware
+    # achievable fraction. The single-fraction-per-tier model captured
+    # by ``tier_achievable_fractions`` above doesn't reflect that
+    # matmul / linear achieve a different effective BW than vector_add
+    # at the same tier (matmul has structured access patterns that
+    # benefit from cache hits; vector_add is zero-reuse). For shapes
+    # that bind the same tier under both ops, the right BW is
+    # genuinely different.
+    #
+    # Nested mapping: ``{op_kind: {tier_name: fraction}}``. Lookup
+    # falls back to ``tier_achievable_fractions[tier_name]`` if the
+    # (op, tier) pair isn't present, then to 1.0.
+    #
+    # Example (i7-12700K post the V5-3b-flip-prerequisite PR):
+    #   {"matmul":     {"L2": 0.10, "DRAM": 0.85},
+    #    "linear":     {"L2": 0.10, "DRAM": 0.85}}
+    # vector_add stays on the per-tier values (L2 = 0.22, DRAM = 0.47).
+    tier_achievable_fractions_by_op: Dict[str, Dict[str, float]] = field(
+        default_factory=dict
+    )
+
     # M5 Layer 5: cache-coherence protocol class.
     # ``"snoopy_mesi"`` -- snoopy MESI / MOESI on shared bus or
     # ring (CPU multi-core, single-socket).

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -1130,6 +1130,36 @@ class HardwareResourceModel:
         default_factory=dict
     )
 
+    def __post_init__(self) -> None:
+        """Validate calibration-fraction invariants.
+
+        ``tier_achievable_fractions`` flows through ``MemoryTier``
+        (which validates each value in ``__post_init__``), so values
+        out of [0, 1] would surface there at hierarchy-construction
+        time. ``tier_achievable_fractions_by_op`` is looked up
+        directly by the analyzer at runtime and bypasses that
+        validation, so it could silently produce nonsense BW math.
+        Validate both up-front so calibration mistakes surface at
+        mapper construction, not as confusing analyzer drift.
+
+        ``tier_achievable_fractions`` is also revalidated here for
+        defense-in-depth (the MemoryTier check runs only when
+        ``memory_hierarchy`` is read; some callers may want the
+        invariant enforced earlier)."""
+        for tier_name, fraction in self.tier_achievable_fractions.items():
+            if not (0.0 <= fraction <= 1.0):
+                raise ValueError(
+                    f"tier_achievable_fractions[{tier_name!r}] = {fraction} "
+                    f"must be in [0.0, 1.0]"
+                )
+        for op_kind, by_tier in self.tier_achievable_fractions_by_op.items():
+            for tier_name, fraction in by_tier.items():
+                if not (0.0 <= fraction <= 1.0):
+                    raise ValueError(
+                        f"tier_achievable_fractions_by_op[{op_kind!r}]"
+                        f"[{tier_name!r}] = {fraction} must be in [0.0, 1.0]"
+                    )
+
     # M5 Layer 5: cache-coherence protocol class.
     # ``"snoopy_mesi"`` -- snoopy MESI / MOESI on shared bus or
     # ring (CPU multi-core, single-socket).

--- a/tests/analysis/test_reuse_models.py
+++ b/tests/analysis/test_reuse_models.py
@@ -152,13 +152,39 @@ def test_matmul_optimal_square_for_l2_sized_capacity():
     assert tile.residency_bytes <= tier
 
 
-def test_matmul_tile_clamped_to_min_dim():
-    """If sqrt-formula gives a tile > min(M, N), clamp to min(M, N).
-    Shape (4, 65536, 4) fp32, capacity huge: t_raw is enormous, clamped to 4."""
+def test_matmul_skinny_dim_uses_skinny_branch_not_clamp():
+    """Shape (4, 65536, 4) has min(M, N) = 4 < SKINNY_THRESHOLD,
+    so the skinny branch fires (full-output tile = (4, 4)) BEFORE
+    the clamp logic would. The result is the same tile_dims (4, 4)
+    but via a different code path. Pinned separately so a future
+    change that disables the skinny branch flips the right test
+    rather than silently passing this one for the wrong reason."""
     model = MatmulReuseModel()
     tile = model.residency_window((4, 65536, 4), "fp32", tier_capacity_bytes=10**10)
     assert tile.tile_dims == (4, 4)
+    # Skinny branch residency = 3 * M * N * bpe (full output tile)
     assert tile.residency_bytes == 3 * 4 * 4 * 4
+
+
+def test_matmul_non_skinny_clamped_to_min_dim():
+    """Coverage for the OPTIMAL-SQUARE CLAMP path (non-skinny):
+    if sqrt-formula gives a tile > min(M, N), clamp to min(M, N).
+    Use min(M, N) = 64 which is well above the 16 threshold so the
+    skinny branch doesn't fire, then huge capacity to force the
+    raw t to exceed 64.
+
+    Pre per-op-calibration PR: this test was test_matmul_tile_clamped_to_min_dim
+    using shape (4, 65536, 4), which inadvertently took the skinny
+    branch when that landed. CodeRabbit flagged the silent coverage
+    gap; this test restores explicit coverage for the clamp logic."""
+    model = MatmulReuseModel()
+    tile = model.residency_window(
+        (64, 65536, 64), "fp32", tier_capacity_bytes=10**10
+    )
+    # min(M, N) = 64 >= SKINNY_THRESHOLD (16) -> skinny branch skipped
+    # t_raw from sqrt(1e10 / 12) >> 64 -> clamped to 64
+    assert tile.tile_dims == (64, 64)
+    assert tile.residency_bytes == 3 * 64 * 64 * 4
 
 
 def test_matmul_tile_clamped_to_at_least_one():

--- a/tests/analysis/test_reuse_models.py
+++ b/tests/analysis/test_reuse_models.py
@@ -218,6 +218,56 @@ def test_matmul_bytes_loaded_singleton_tile_equals_no_reuse():
     assert actual == expected
 
 
+def test_matmul_skinny_shape_uses_full_output_tile():
+    """V5-3b flag-flip prerequisite: when min(M, N) < skinny threshold,
+    the optimal-square model collapses to the small dim and inflates
+    bytes_loaded by ceil(N/Mt) reloads. Real BLAS uses a different
+    blocking strategy for skinny shapes; the model now picks the full
+    output as the tile so bytes_loaded ~= operand_footprint with no
+    reload inflation."""
+    model = MatmulReuseModel()
+    # Skinny B (linear with B=2 batch): min(M, N) = 2 < 16 threshold
+    M, K, N = 2, 12288, 640
+    tile = model.residency_window((M, K, N), "fp32", tier_capacity_bytes=10**8)
+    assert tile.tile_dims == (
+        M,
+        N,
+    ), f"Skinny shape should use full-output tile (M, N), got {tile.tile_dims}"
+    # bytes_loaded with full-output tile collapses to one-pass:
+    # A loaded once, B loaded once, C read + written once. That's
+    # operand_footprint + one extra M*N for the C write (operand
+    # counts each tensor once; bytes_loaded counts C twice for
+    # read+write).
+    bytes_ld = model.bytes_loaded_from_binding((M, K, N), "fp32", tile)
+    operand = model.operand_footprint_bytes((M, K, N), "fp32")
+    expected = operand + M * N * 4  # one extra C write at fp32
+    assert bytes_ld == expected, (
+        f"Skinny matmul bytes_loaded ({bytes_ld}) should equal "
+        f"operand + C-write ({expected}); the full-output tile zeros "
+        f"out reload counts but C is still read + written."
+    )
+
+
+def test_matmul_non_skinny_still_uses_optimal_square_tile():
+    """Negative case: shapes with min(M, N) >= threshold use the
+    optimal-square tile heuristic as before (V5-3a behavior). The
+    skinny branch must not perturb the well-shaped majority."""
+    model = MatmulReuseModel()
+    # Non-skinny: min(M, N) = 1024, well above 16 threshold
+    tile = model.residency_window((1024, 1024, 1024), "fp32", tier_capacity_bytes=12288)
+    assert tile.tile_dims == (
+        32,
+        32,
+    ), f"Non-skinny shape should use optimal-square tile, got {tile.tile_dims}"
+
+
+def test_matmul_skinny_threshold_pinned_at_16():
+    """The skinny threshold is empirically tuned for i7 V4 floors;
+    moving it changes which shapes hit the no-reuse model. Pin it
+    so a future contributor doesn't quietly drift the value."""
+    assert MatmulReuseModel._SKINNY_THRESHOLD == 16
+
+
 def test_matmul_bytes_loaded_uses_ceil_for_non_dividing_tile():
     """When Mt or Nt doesn't divide M or N, the partial last column
     of C-tiles still triggers a full A-row reload (and partial last

--- a/tests/analysis/test_roofline_tier_aware.py
+++ b/tests/analysis/test_roofline_tier_aware.py
@@ -561,6 +561,38 @@ def test_overlap_does_not_apply_to_matmul_dram_binding():
     )
 
 
+def test_per_op_calibration_lookup_falls_back_correctly():
+    """V5-3b flag-flip prerequisite: the per-op effective BW lookup
+    falls back per-op -> per-tier -> 1.0. With i7's calibration
+    (matmul/linear @ DRAM = 0.85, vector_add @ DRAM defaults to
+    per-tier 0.47), matmul + vector_add at the same DRAM-bound shape
+    should produce different memory_time predictions."""
+    hw = create_i7_12700k_mapper().resource_model
+    analyzer_mm = RooflineAnalyzer(
+        hw, precision=Precision.FP32, use_tier_aware_memory=True
+    )
+    # Matmul DRAM -> uses per-op 0.85 -> peak 75 * 0.85 = 63.75 GB/s
+    matmul_dram = analyzer_mm._per_op_effective_bw(
+        next(t for t in hw.memory_hierarchy if t.name == "DRAM"),
+        "matmul",
+    )
+    assert matmul_dram == pytest.approx(75e9 * 0.85)
+
+    # Vector_add DRAM -> falls back to per-tier 0.47 -> 35.25 GB/s
+    vadd_dram = analyzer_mm._per_op_effective_bw(
+        next(t for t in hw.memory_hierarchy if t.name == "DRAM"),
+        "vector_add",
+    )
+    assert vadd_dram == pytest.approx(75e9 * 0.47)
+
+    # Unknown op -> falls back to per-tier
+    unknown_dram = analyzer_mm._per_op_effective_bw(
+        next(t for t in hw.memory_hierarchy if t.name == "DRAM"),
+        "conv2d",
+    )
+    assert unknown_dram == pytest.approx(75e9 * 0.47)
+
+
 def test_memory_explanation_format_summary_renders_breakdown():
     """LatencyDescriptor.format_summary should include a 'Memory binding'
     line when memory_explanation is set, so the breakdown surfaces in

--- a/tests/hardware/test_tier_achievable_fractions.py
+++ b/tests/hardware/test_tier_achievable_fractions.py
@@ -164,6 +164,31 @@ def test_i7_12700k_l3_calibration():
     assert l3.effective_bandwidth_bps == pytest.approx(200e9 * 0.84)
 
 
+def test_i7_12700k_per_op_calibration():
+    """V5-3b flag-flip prerequisite: i7 has per-op DRAM and L2
+    overrides for matmul / linear. The single-fraction-per-tier
+    model couldn't capture that vector_add (zero-reuse) and matmul
+    (structured-reuse) achieve different effective BW at the same
+    tier; per-op overrides resolve this."""
+    hw = create_i7_12700k_mapper().resource_model
+    assert hw.tier_achievable_fractions_by_op == {
+        "matmul": {"L2": 0.10, "DRAM": 0.85},
+        "linear": {"L2": 0.10, "DRAM": 0.85},
+    }
+
+
+def test_per_op_calibration_falls_back_to_per_tier():
+    """vector_add isn't in the per-op overrides; its tier fractions
+    must come from the per-tier ``tier_achievable_fractions``
+    (V5-5 baseline values)."""
+    hw = create_i7_12700k_mapper().resource_model
+    # No vector_add entry in tier_achievable_fractions_by_op
+    assert "vector_add" not in hw.tier_achievable_fractions_by_op
+    # So vector_add picks up the per-tier values
+    assert hw.tier_achievable_fractions["L2"] == 0.22
+    assert hw.tier_achievable_fractions["DRAM"] == 0.47
+
+
 def test_i7_12700k_l1_calibration():
     """V5 follow-up: i7 ``L1.achievable_fraction = 0.020`` from the
     2-point regression on N=256 and N=1024 vector_add baseline rows

--- a/tests/hardware/test_tier_achievable_fractions.py
+++ b/tests/hardware/test_tier_achievable_fractions.py
@@ -99,13 +99,26 @@ def test_unset_tiers_default_to_one_when_other_tier_is_overridden():
 
 
 def test_invalid_fraction_raises_at_construction():
-    """MemoryTier validates achievable_fraction is in [0, 1] in
-    __post_init__. An override out of range must surface as a
-    construction-time ValueError, not a silent garbage value at
-    analysis time."""
-    hw = _bare_resource_model(tier_achievable_fractions={"DRAM": 1.5})
-    with pytest.raises(ValueError, match="achievable_fraction"):
-        _ = hw.memory_hierarchy
+    """HardwareResourceModel.__post_init__ rejects any
+    tier_achievable_fractions value out of [0, 1] up-front, so
+    calibration mistakes surface at mapper-construction time
+    rather than as confusing analyzer drift."""
+    with pytest.raises(ValueError, match="must be in \\[0.0, 1.0\\]"):
+        _bare_resource_model(tier_achievable_fractions={"DRAM": 1.5})
+
+
+def test_invalid_per_op_fraction_raises_at_construction():
+    """Per-op fractions get the same up-front validation as the
+    per-tier dict (they bypass MemoryTier's check because they're
+    looked up at analyzer runtime, not at hierarchy construction)."""
+    with pytest.raises(ValueError, match="must be in \\[0.0, 1.0\\]"):
+        _bare_resource_model(
+            tier_achievable_fractions_by_op={"matmul": {"DRAM": -0.1}}
+        )
+    with pytest.raises(ValueError, match="must be in \\[0.0, 1.0\\]"):
+        _bare_resource_model(
+            tier_achievable_fractions_by_op={"linear": {"L2": 1.5}}
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the **last blocker** for flipping the V5-3b
`use_tier_aware_memory` default to True. The single-fraction-per-tier
model couldn't capture that matmul / linear achieve different
effective BW than vector_add at the same tier (structured-reuse vs
zero-reuse access patterns); per-op overrides + a skinny-shape
detection in the matmul reuse model resolve the linear regression
that was -7 floors under tier-aware.

**V5-3b plan exit criterion ("matmul + linear V4 floor pass-rates
equal or improve") is now MET on i7-12700K.**

## V4 floor impact (i7, --use-tier-aware-memory)

| op | default-off | tier-aware (post-PR) | vs default |
|---|---|---|---|
| vector_add | 1/5 | **5/5** | **+4 (improve)** |
| matmul | 35/60 | 35/60 | **0 (equal)** |
| linear | 27/60 | **27/60** | **0 (equal)** |

The flag-flip is now a small follow-up PR.

## Three changes, all co-dependent

### 1. Schema: `tier_achievable_fractions_by_op`

```python
tier_achievable_fractions_by_op: Dict[str, Dict[str, float]] = {}
# e.g. {"matmul": {"L2": 0.10, "DRAM": 0.85}, "linear": {...}}
```

Lookup: per-op `(op, tier)` -> per-tier `(tier)` -> 1.0. Empty
default preserves V5-5 behavior; the new field is purely additive
for mappers that haven't calibrated per-op.

### 2. Roofline integration

- `RooflineAnalyzer._per_op_effective_bw(tier, op_kind)` -- helper
  encoding the fallback chain.
- `_try_tier_aware_memory_time` and `_memory_time_with_boundary_overlap`
  use it for both binding-tier and cache-tier BW lookups.

### 3. Skinny matmul reuse model

When `min(M, N) < 16`, `MatmulReuseModel.residency_window` returns
`tile = (M, N)` (full output) instead of the optimal-square C-tile.
This collapses `bytes_loaded` to one-pass semantics: A loaded once,
B loaded once, C read + written once -- matching real BLAS
behavior for skinny shapes which use K-blocking, not MN-blocking.

For `(2, 12288, 640)` linear pre-PR: tile = (2, 2), `bytes_loaded`
= 63 MB (~2x reload inflation). Post-PR: tile = (2, 640),
`bytes_loaded` = 31.5 MB (operand + 5 KB C write). With per-op DRAM
= 0.85: predicted 494 us, measured 432 us, +14% (passes 25% band).

## i7-12700K per-op calibration

```python
tier_achievable_fractions_by_op = {
    "matmul": {"L2": 0.10, "DRAM": 0.85},
    "linear": {"L2": 0.10, "DRAM": 0.85},
}
```

Empirical justification:
- **L2 = 0.10** (vs 0.22 for vector_add): multi-thread BLAS doesn't
  realize the same per-core L2 BW that single-thread `torch.add` does
- **DRAM = 0.85** (vs 0.47 for vector_add): matmul has structured
  reuse; effective DRAM streaming exceeds vector_add's zero-reuse
  plateau because mid-stream cache hits boost throughput

## What this PR doesn't fix

The 2 linear shapes `(8, 1536, 768)` and `(8, 3072, 384)` flipped
PASS->FAIL pre-PR but are **compute-bound**, not memory-bound. Pred
= compute_time = 51us, measured 80us. The L2 calibration change
doesn't move the prediction. Default-off "passed" them by accident
(memory over-prediction cancelling compute under-prediction); the
tier-aware path exposes the real compute efficiency model issue.

That's a separate model concern, deferred to future work.

## Test plan

- [x] **6 new tests**:
  - `test_matmul_skinny_shape_uses_full_output_tile`
  - `test_matmul_non_skinny_still_uses_optimal_square_tile`
  - `test_matmul_skinny_threshold_pinned_at_16`
  - `test_i7_12700k_per_op_calibration`
  - `test_per_op_calibration_falls_back_to_per_tier`
  - `test_per_op_calibration_lookup_falls_back_correctly`
- [x] V4 vector_add tier-aware: 5/5 PASS (held)
- [x] V4 matmul (default + tier): 35/60 PASS (equal)
- [x] V4 linear (default + tier): 27/60 PASS (**equal, was -7**)
- [x] V4 default-off byte-identical (no regressions outside tier-aware)
- [x] Total: 649 tests pass (643 + 6 new)
- [ ] CI: full matrix passes

## V5 progress after this PR

| follow-up | status |
|---|---|
| op-aware CPU dispatch floor | ✓ #108 |
| per-core L2 tier (i7) | ✓ #109 |
| L1 calibration (i7) | ✓ #110 |
| L3/DRAM boundary cliff (OVERLAP) | ✓ #111 |
| **Per-op calibration + skinny matmul** | **this PR** |
| **V5-3b default-flag flip** | **next, small PR** |
| V5-6 retire `_get_bandwidth_efficiency_scale` | gated on flag-flip |

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operation-specific memory tier calibration for enhanced performance analysis of matrix multiplication and linear operations.

* **Improvements**
  * Refined roofline bandwidth calculations with per-operation effective bandwidth lookups for more accurate performance modeling.
  * Improved handling of certain matrix multiplication shapes in performance estimations.
  * Enhanced CPU resource modeling with operation-specific cache efficiency tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->