### PR TITLE
feat(estimation,hardware): GPU dispatch overhead -- bridge mapper to analyzer

### DIFF
--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -687,6 +687,20 @@ class RooflineAnalyzer:
         #   linear:     9 us  (+ parameter access, bias epilogue)
         if self.resource_model.hardware_type.name == "CPU":
             actual_latency = max(actual_latency, self._get_cpu_dispatch_floor(sg))
+        # V5 follow-up: GPU dispatch floor was investigated but NOT
+        # applied here. The V4 Jetson measurer reports kernel time
+        # via cudaEvent which inconsistently includes / excludes the
+        # CUDA launch overhead -- some L1-binding matmul shapes
+        # measure 14-32 us (launch excluded) while others measure
+        # 113-173 us (launch included). A hard floor matching the
+        # launch-included cohort over-predicts the launch-excluded
+        # cohort, regressing V4 floors net. The op-aware
+        # _get_gpu_dispatch_floor helper is implemented for future
+        # use; the additive _estimate_overhead bump (from 5 us to
+        # the mapper's kernel_launch_overhead_ns) handles the
+        # launch-included cohort without breaking the other.
+        # See docs/calibration/jetson-orin-nano-calibration-analysis.md
+        # for the full V4 measurer-artifact analysis.
 
         # Arithmetic intensity
         ai = sg.flops / total_bytes if total_bytes > 0 else 0.0
@@ -1138,6 +1152,64 @@ class RooflineAnalyzer:
         return self._CPU_DISPATCH_FLOOR_SECONDS.get(
             op_name, self._CPU_DISPATCH_FLOOR_DEFAULT_SECONDS
         )
+
+    # ------------------------------------------------------------------
+    # GPU dispatch floor (V5 follow-up; analog of CPU dispatch floor).
+    # ------------------------------------------------------------------
+
+    # Op -> multiplier on the hardware's base kernel_launch_overhead.
+    # Different ops have different per-launch overhead because:
+    #
+    #   * vector_add: 1 simple CUDA kernel ("torch.add" -> ATen ->
+    #     cudaLaunchKernel). Multiplier 1.0 (same as base).
+    #   * matmul: cuBLAS dispatch -- backend selection + GEMM kernel
+    #     launch. ~1.5x base based on Jetson Orin Nano measurements
+    #     (vector_add 113 us vs matmul 119 us at smallest shape ->
+    #     not 1.5x exactly, but cuBLAS adds setup overhead beyond
+    #     bare cudaLaunchKernel).
+    #   * linear: matmul + bias add -- typically two separate kernel
+    #     launches OR one fused kernel with extra setup. Empirical
+    #     ~2x base (Jetson Orin Nano linear 169 us vs matmul 119 us).
+    #
+    # Empirical anchors (Jetson Orin Nano fp16 baseline, smallest L1-
+    # binding shapes where compute + memory are negligible):
+    #   vector_add  N=256:        113 us  / 80 us base ->  1.41x
+    #   matmul      (64, 64, 64): 126 us  / 80 us base ->  1.58x
+    #   linear      (1, 128, 256):173 us  / 80 us base ->  2.16x
+    #
+    # Round to clean multipliers (1.4 / 1.6 / 2.1) so the model is
+    # explicit about which op gets how much extra dispatch.
+    _GPU_DISPATCH_FLOOR_MULT: dict = {
+        "ELEMENTWISE": 1.4,
+        "MATMUL": 1.6,
+        "LINEAR": 2.1,
+    }
+    _GPU_DISPATCH_FLOOR_DEFAULT_MULT: float = 1.0  # bare CUDA launch
+
+    def _get_gpu_dispatch_floor(self, sg: SubgraphDescriptor) -> float:
+        """Op-aware GPU dispatch floor in seconds.
+
+        Floor = ``mapper.kernel_launch_overhead_ns * 1e-9 *
+        op_multiplier``. Falls back to a 5 us floor if the mapper
+        hasn't populated ``kernel_launch_overhead_ns`` (the legacy
+        constant; preserves pre-V5 behavior for un-augmented mappers).
+
+        Relative to the analyzer's ``_estimate_overhead`` (which adds
+        the base overhead to every prediction additively), this floor
+        catches the case where compute + memory time are themselves
+        below the dispatch overhead -- common for L1-binding shapes
+        on edge GPUs. Op multiplier picks up the per-launch cost
+        differences (cuBLAS setup for matmul, bias-add for linear).
+        """
+        klo_ns = self.resource_model.kernel_launch_overhead_ns
+        if klo_ns is None or klo_ns <= 0:
+            return 5e-6  # legacy fallback
+        base = klo_ns * 1e-9
+        op_name = sg.operation_type.name if sg.operation_type else None
+        mult = self._GPU_DISPATCH_FLOOR_MULT.get(
+            op_name, self._GPU_DISPATCH_FLOOR_DEFAULT_MULT
+        )
+        return base * mult
 
     # ------------------------------------------------------------------
     # V5-3b: tier-aware memory_time path (opt-in; gated by
@@ -1747,8 +1819,16 @@ class RooflineAnalyzer:
         kernel launch overhead rather than actual compute/memory time.
         """
         if self.resource_model.hardware_type.name == "GPU":
-            # Base kernel launch overhead
-            base_overhead = 5e-6  # 5 microseconds
+            # V5 follow-up: pull base from
+            # ``HardwareResourceModel.kernel_launch_overhead_ns``
+            # when populated (Jetson edge = 80 us per arXiv:2508.08430,
+            # datacenter = 10 us). Falls back to the legacy 5 us when
+            # the mapper hasn't set the field.
+            klo_ns = self.resource_model.kernel_launch_overhead_ns
+            if klo_ns is not None and klo_ns > 0:
+                base_overhead = klo_ns * 1e-9
+            else:
+                base_overhead = 5e-6  # 5 microseconds (legacy fallback)
 
             # Check operation patterns for additional overhead
             fusion_pattern = (

--- a/src/graphs/hardware/mappers/gpu.py
+++ b/src/graphs/hardware/mappers/gpu.py
@@ -59,7 +59,7 @@ class GPUMapper(HardwareMapper):
         self,
         resource_model: HardwareResourceModel,
         thermal_profile: str = None,
-        calibration=None  # Type: Optional[GPUCalibration]
+        calibration=None,  # Type: Optional[GPUCalibration]
     ):
         """
         Initialize GPU mapper.
@@ -74,7 +74,9 @@ class GPUMapper(HardwareMapper):
 
         # Validate this is a GPU model
         if resource_model.hardware_type.value != "gpu":
-            raise ValueError(f"GPUMapper requires GPU resource model, got {resource_model.hardware_type}")
+            raise ValueError(
+                f"GPUMapper requires GPU resource model, got {resource_model.hardware_type}"
+            )
 
         # Calibration data for size-dependent efficiency
         self.calibration = calibration
@@ -84,10 +86,24 @@ class GPUMapper(HardwareMapper):
         # Edge devices (Jetson, etc.) have higher software stack overhead
         self._is_edge_device = self._detect_edge_device()
 
+        # V5 follow-up: surface the kernel-launch overhead on the
+        # resource_model so RooflineAnalyzer can pick it up in
+        # _estimate_overhead and _get_gpu_dispatch_floor. Only set if
+        # the mapper hasn't already populated the field explicitly --
+        # callers that want a custom value (e.g. a future per-Jetson-
+        # power-mode override) take precedence.
+        if resource_model.kernel_launch_overhead_ns is None:
+            klo_seconds = (
+                self.KERNEL_LAUNCH_OVERHEAD_EDGE
+                if self._is_edge_device
+                else self.KERNEL_LAUNCH_OVERHEAD_DATACENTER
+            )
+            resource_model.kernel_launch_overhead_ns = klo_seconds * 1e9
+
     def _detect_edge_device(self) -> bool:
         """Detect if this is an edge device (higher dispatch overhead)."""
         name = self.resource_model.name.lower()
-        edge_indicators = ['jetson', 'orin', 'xavier', 'tegra', 'nano', 'edge']
+        edge_indicators = ["jetson", "orin", "xavier", "tegra", "nano", "edge"]
         return any(ind in name for ind in edge_indicators)
 
     @property
@@ -122,7 +138,7 @@ class GPUMapper(HardwareMapper):
         pattern = subgraph.fusion_pattern.lower() if subgraph.fusion_pattern else ""
 
         # Get arithmetic intensity for memory-bound detection
-        ai = getattr(subgraph, 'arithmetic_intensity', 0.0)
+        ai = getattr(subgraph, "arithmetic_intensity", 0.0)
 
         # Check for specific patterns
         if "conv2d" in pattern or "conv" in pattern:
@@ -134,15 +150,33 @@ class GPUMapper(HardwareMapper):
                 return "conv2d_batchnorm"
             else:
                 return "conv2d"
-        elif "linear" in pattern or "matmul" in pattern or "mm" in pattern or "gemm" in pattern:
+        elif (
+            "linear" in pattern
+            or "matmul" in pattern
+            or "mm" in pattern
+            or "gemm" in pattern
+        ):
             return "matmul"
-        elif any(act in pattern for act in ["relu", "gelu", "softmax", "sigmoid", "tanh", "silu", "hardswish"]):
+        elif any(
+            act in pattern
+            for act in [
+                "relu",
+                "gelu",
+                "softmax",
+                "sigmoid",
+                "tanh",
+                "silu",
+                "hardswish",
+            ]
+        ):
             return "activation"
         elif "add" in pattern or "mul" in pattern:
             return "unfused"
 
         # Fallback: check node names
-        node_names = " ".join(subgraph.node_names).lower() if subgraph.node_names else ""
+        node_names = (
+            " ".join(subgraph.node_names).lower() if subgraph.node_names else ""
+        )
         if "conv" in node_names:
             # Check AI for memory-bound detection
             if ai > 0 and ai < self.MEMORY_BOUND_AI_THRESHOLD:
@@ -174,7 +208,11 @@ class GPUMapper(HardwareMapper):
             return self.default_efficiency
 
         op_type = self._classify_operation(subgraph)
-        flops = subgraph.total_flops if subgraph.total_flops > 0 else subgraph.total_macs * 2
+        flops = (
+            subgraph.total_flops
+            if subgraph.total_flops > 0
+            else subgraph.total_macs * 2
+        )
 
         return self.calibration.get_efficiency(op_type, flops, self.default_efficiency)
 
@@ -183,7 +221,7 @@ class GPUMapper(HardwareMapper):
         subgraph: FusedSubgraph,
         execution_stage: int,
         concurrent_subgraphs: int,
-        precision: Precision = Precision.FP32
+        precision: Precision = Precision.FP32,
     ) -> HardwareAllocation:
         """
         Map a single fused subgraph to GPU SMs.
@@ -220,17 +258,25 @@ class GPUMapper(HardwareMapper):
 
         # Calculate occupancy (warps actually used / max warps possible)
         max_warps_possible = sms_allocated * warps_per_sm
-        occupancy = min(1.0, warps_required / max_warps_possible) if max_warps_possible > 0 else 0.0
+        occupancy = (
+            min(1.0, warps_required / max_warps_possible)
+            if max_warps_possible > 0
+            else 0.0
+        )
 
         # Calculate utilization (SMs used / total SMs available)
         utilization = sms_allocated / self.resource_model.compute_units
 
         # Calculate latency using roofline model
-        ops = subgraph.total_flops if subgraph.total_flops > 0 else subgraph.total_macs * 2
+        ops = (
+            subgraph.total_flops
+            if subgraph.total_flops > 0
+            else subgraph.total_macs * 2
+        )
         bytes_transferred = (
-            subgraph.total_input_bytes +
-            subgraph.total_output_bytes +
-            subgraph.total_weight_bytes
+            subgraph.total_input_bytes
+            + subgraph.total_output_bytes
+            + subgraph.total_weight_bytes
         )
 
         compute_time, memory_time, bottleneck = self._calculate_latency(
@@ -238,7 +284,7 @@ class GPUMapper(HardwareMapper):
             bytes_transferred=bytes_transferred,
             allocated_units=sms_allocated,
             occupancy=occupancy,
-            precision=precision
+            precision=precision,
         )
 
         estimated_latency = max(compute_time, memory_time)
@@ -264,14 +310,16 @@ class GPUMapper(HardwareMapper):
                 # Use calibrated latency (it already includes all inefficiencies)
                 estimated_latency = calibrated_latency
                 # Preserve bottleneck classification from base model
-                compute_time = calibrated_latency if compute_time > memory_time else compute_time
-                memory_time = calibrated_latency if memory_time >= compute_time else memory_time
+                compute_time = (
+                    calibrated_latency if compute_time > memory_time else compute_time
+                )
+                memory_time = (
+                    calibrated_latency if memory_time >= compute_time else memory_time
+                )
 
         # Calculate energy
         compute_energy, memory_energy = self._calculate_energy(
-            ops=ops,
-            bytes_transferred=bytes_transferred,
-            precision=precision
+            ops=ops, bytes_transferred=bytes_transferred, precision=precision
         )
         total_energy = compute_energy + memory_energy
 
@@ -300,9 +348,7 @@ class GPUMapper(HardwareMapper):
         )
 
     def should_use_sequential_execution(
-        self,
-        fusion_report: FusionReport,
-        batch_size: int
+        self, fusion_report: FusionReport, batch_size: int
     ) -> bool:
         """
         Determine if we should model sequential kernel execution.
@@ -330,12 +376,9 @@ class GPUMapper(HardwareMapper):
         # Threshold: If average subgraph has < 200M FLOPs, use sequential mode
         # This catches ResNet-18/50, MobileNet, and other small inference workloads
         # Each kernel can't efficiently saturate many SMs at this scale
-        return (batch_size < 8 and avg_flops_per_subgraph < 200e6)
+        return batch_size < 8 and avg_flops_per_subgraph < 200e6
 
-    def determine_sm_allocation(
-        self,
-        subgraph: FusedSubgraph
-    ) -> int:
+    def determine_sm_allocation(self, subgraph: FusedSubgraph) -> int:
         """
         Determine how many SMs to allocate for a subgraph in sequential mode.
 
@@ -371,7 +414,7 @@ class GPUMapper(HardwareMapper):
         warps_required = math.ceil(output_elements / warp_size)
 
         # Convert to SMs (assume 48 warps/SM for Ampere)
-        warps_per_sm = getattr(self.resource_model, 'warps_per_unit', 48)
+        warps_per_sm = getattr(self.resource_model, "warps_per_unit", 48)
         sms_needed = math.ceil(warps_required / warps_per_sm)
 
         # Cap at total available SMs
@@ -382,9 +425,7 @@ class GPUMapper(HardwareMapper):
         return max(1, sms_allocated)
 
     def compute_sequential_latency(
-        self,
-        fusion_report: FusionReport,
-        precision: Precision
+        self, fusion_report: FusionReport, precision: Precision
     ) -> Tuple[float, List[HardwareAllocation]]:
         """
         Compute latency assuming sequential kernel execution.
@@ -412,14 +453,18 @@ class GPUMapper(HardwareMapper):
             sms_allocated = self.determine_sm_allocation(sg)
 
             # Compute per-SM throughput using microarchitecture parameters
-            if (self.resource_model.cuda_cores_per_sm is not None and
-                self.resource_model.sm_sustained_clock_hz is not None and
-                self.resource_model.ops_per_clock_per_core is not None):
+            if (
+                self.resource_model.cuda_cores_per_sm is not None
+                and self.resource_model.sm_sustained_clock_hz is not None
+                and self.resource_model.ops_per_clock_per_core is not None
+            ):
                 # Use microarchitecture model: CUDA cores × ops/clock × frequency
                 # This is more accurate than dividing peak performance by SM count
-                sm_flops = (self.resource_model.cuda_cores_per_sm *
-                            self.resource_model.ops_per_clock_per_core *
-                            self.resource_model.sm_sustained_clock_hz)
+                sm_flops = (
+                    self.resource_model.cuda_cores_per_sm
+                    * self.resource_model.ops_per_clock_per_core
+                    * self.resource_model.sm_sustained_clock_hz
+                )
             else:
                 # Fallback to precision profile (for older models without microarch data)
                 peak_flops = self.resource_model.get_peak_ops(precision)
@@ -432,18 +477,21 @@ class GPUMapper(HardwareMapper):
             # Roofline model on allocated SMs
             ops = sg.total_flops if sg.total_flops > 0 else sg.total_macs * 2
             bytes_transferred = (
-                sg.total_input_bytes +
-                sg.total_output_bytes +
-                sg.total_weight_bytes
+                sg.total_input_bytes + sg.total_output_bytes + sg.total_weight_bytes
             )
 
             compute_time = ops / (sm_flops * sms_allocated)
-            memory_time = bytes_transferred / peak_bandwidth  # Bandwidth is shared, not per-SM!
+            memory_time = (
+                bytes_transferred / peak_bandwidth
+            )  # Bandwidth is shared, not per-SM!
 
             # Bottleneck is the limiting factor
             kernel_time = max(compute_time, memory_time)
-            bottleneck = (BottleneckType.COMPUTE_BOUND if compute_time > memory_time
-                         else BottleneckType.BANDWIDTH_BOUND)
+            bottleneck = (
+                BottleneckType.COMPUTE_BOUND
+                if compute_time > memory_time
+                else BottleneckType.BANDWIDTH_BOUND
+            )
 
             # Apply size-dependent calibration: use calibrated efficiency directly
             if self.calibration is not None and ops > 0:
@@ -464,7 +512,7 @@ class GPUMapper(HardwareMapper):
             # capture dispatch effects for small ops (very low efficiency = high latency).
             # For tiny ops where calibration gives latency < dispatch, use dispatch time.
             # For uncalibrated execution, add dispatch overhead explicitly.
-            disable_overhead = getattr(self, 'disable_launch_overhead', False)
+            disable_overhead = getattr(self, "disable_launch_overhead", False)
             if disable_overhead:
                 kernel_latency = kernel_time
             elif self.calibration is not None:
@@ -475,9 +523,7 @@ class GPUMapper(HardwareMapper):
 
             # Calculate energy for this kernel
             compute_energy, memory_energy = self._calculate_energy(
-                ops=ops,
-                bytes_transferred=bytes_transferred,
-                precision=precision
+                ops=ops, bytes_transferred=bytes_transferred, precision=precision
             )
 
             # Utilization: fraction of allocated SMs actually used
@@ -510,9 +556,7 @@ class GPUMapper(HardwareMapper):
         return total_latency, allocations
 
     def compute_energy_with_idle_power(
-        self,
-        latency: float,
-        dynamic_energy: float
+        self, latency: float, dynamic_energy: float
     ) -> Tuple[float, float]:
         """
         Compute total energy including idle power consumption.
@@ -540,7 +584,9 @@ class GPUMapper(HardwareMapper):
         # Get TDP from thermal operating point if available
         tdp_watts = None
         if self.thermal_profile and self.resource_model.thermal_operating_points:
-            thermal_point = self.resource_model.thermal_operating_points.get(self.thermal_profile)
+            thermal_point = self.resource_model.thermal_operating_points.get(
+                self.thermal_profile
+            )
             if thermal_point:
                 tdp_watts = thermal_point.tdp_watts
 
@@ -568,7 +614,7 @@ class GPUMapper(HardwareMapper):
         fusion_report: FusionReport,
         execution_stages: List[List[int]],
         batch_size: int = 1,
-        precision: Precision = Precision.FP32
+        precision: Precision = Precision.FP32,
     ) -> GraphHardwareAllocation:
         """
         Map entire computation graph to GPU.
@@ -608,8 +654,12 @@ class GPUMapper(HardwareMapper):
 
             # Aggregate metrics
             total_subgraphs = len(subgraph_allocations)
-            average_sms_used = sum(a.compute_units_allocated for a in subgraph_allocations) / max(1, total_subgraphs)
-            peak_sms_used = max((a.compute_units_allocated for a in subgraph_allocations), default=0)
+            average_sms_used = sum(
+                a.compute_units_allocated for a in subgraph_allocations
+            ) / max(1, total_subgraphs)
+            peak_sms_used = max(
+                (a.compute_units_allocated for a in subgraph_allocations), default=0
+            )
             average_utilization = average_sms_used / self.resource_model.compute_units
             peak_utilization = peak_sms_used / self.resource_model.compute_units
 
@@ -625,13 +675,31 @@ class GPUMapper(HardwareMapper):
             naive_latency = total_ops / peak_ops_per_sec if peak_ops_per_sec > 0 else 0
 
             # Latency breakdown (each subgraph is its own stage in sequential mode)
-            latency_breakdown = {i: a.estimated_latency for i, a in enumerate(subgraph_allocations)}
+            latency_breakdown = {
+                i: a.estimated_latency for i, a in enumerate(subgraph_allocations)
+            }
 
             # Bottleneck counts
-            compute_bound_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.COMPUTE_BOUND)
-            memory_bound_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.MEMORY_BOUND)
-            bandwidth_bound_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.BANDWIDTH_BOUND)
-            balanced_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.BALANCED)
+            compute_bound_count = sum(
+                1
+                for a in subgraph_allocations
+                if a.bottleneck == BottleneckType.COMPUTE_BOUND
+            )
+            memory_bound_count = sum(
+                1
+                for a in subgraph_allocations
+                if a.bottleneck == BottleneckType.MEMORY_BOUND
+            )
+            bandwidth_bound_count = sum(
+                1
+                for a in subgraph_allocations
+                if a.bottleneck == BottleneckType.BANDWIDTH_BOUND
+            )
+            balanced_count = sum(
+                1
+                for a in subgraph_allocations
+                if a.bottleneck == BottleneckType.BALANCED
+            )
 
             return GraphHardwareAllocation(
                 model_name="Unknown",
@@ -649,7 +717,9 @@ class GPUMapper(HardwareMapper):
                 latency_breakdown=latency_breakdown,
                 total_energy=total_energy,
                 naive_latency=naive_latency,
-                latency_correction_factor=total_latency / naive_latency if naive_latency > 0 else 1.0,
+                latency_correction_factor=(
+                    total_latency / naive_latency if naive_latency > 0 else 1.0
+                ),
                 compute_bound_count=compute_bound_count,
                 memory_bound_count=memory_bound_count,
                 bandwidth_bound_count=bandwidth_bound_count,
@@ -680,6 +750,7 @@ class GPUMapper(HardwareMapper):
                 if subgraph.parallelism and batch_size > 1:
                     # Create scaled copy
                     import copy
+
                     subgraph = copy.copy(subgraph)
                     subgraph.parallelism = copy.copy(subgraph.parallelism)
                     subgraph.parallelism.batch *= batch_size
@@ -689,7 +760,7 @@ class GPUMapper(HardwareMapper):
                     subgraph=subgraph,
                     execution_stage=stage_id,
                     concurrent_subgraphs=concurrent_subgraphs,
-                    precision=precision
+                    precision=precision,
                 )
                 stage_allocations.append(allocation)
                 subgraph_allocations.append(allocation)
@@ -698,7 +769,9 @@ class GPUMapper(HardwareMapper):
             # - Total SMs = max across subgraphs (they share SMs)
             # - Latency = max latency (they run concurrently)
             if stage_allocations:
-                stage_sms_used = max(a.compute_units_allocated for a in stage_allocations)
+                stage_sms_used = max(
+                    a.compute_units_allocated for a in stage_allocations
+                )
                 stage_latency = max(a.estimated_latency for a in stage_allocations)
 
                 peak_sms_used = max(peak_sms_used, stage_sms_used)
@@ -710,7 +783,9 @@ class GPUMapper(HardwareMapper):
         # Calculate aggregate metrics
         total_subgraphs = len(subgraph_allocations)
         total_execution_stages = len(execution_stages)
-        average_sms_used = total_sms_used / total_sms_samples if total_sms_samples > 0 else 0
+        average_sms_used = (
+            total_sms_used / total_sms_samples if total_sms_samples > 0 else 0
+        )
 
         total_compute_units = self.resource_model.compute_units
         peak_utilization = peak_sms_used / total_compute_units
@@ -731,13 +806,29 @@ class GPUMapper(HardwareMapper):
         naive_latency = total_ops / peak_ops_per_sec if peak_ops_per_sec > 0 else 0
 
         # Correction factor
-        latency_correction_factor = total_latency / naive_latency if naive_latency > 0 else 1.0
+        latency_correction_factor = (
+            total_latency / naive_latency if naive_latency > 0 else 1.0
+        )
 
         # Bottleneck analysis
-        compute_bound_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.COMPUTE_BOUND)
-        memory_bound_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.MEMORY_BOUND)
-        bandwidth_bound_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.BANDWIDTH_BOUND)
-        balanced_count = sum(1 for a in subgraph_allocations if a.bottleneck == BottleneckType.BALANCED)
+        compute_bound_count = sum(
+            1
+            for a in subgraph_allocations
+            if a.bottleneck == BottleneckType.COMPUTE_BOUND
+        )
+        memory_bound_count = sum(
+            1
+            for a in subgraph_allocations
+            if a.bottleneck == BottleneckType.MEMORY_BOUND
+        )
+        bandwidth_bound_count = sum(
+            1
+            for a in subgraph_allocations
+            if a.bottleneck == BottleneckType.BANDWIDTH_BOUND
+        )
+        balanced_count = sum(
+            1 for a in subgraph_allocations if a.bottleneck == BottleneckType.BALANCED
+        )
 
         return GraphHardwareAllocation(
             model_name="Unknown",  # Will be set by caller
@@ -917,6 +1008,7 @@ def create_a100_sxm4_80gb_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for A100 SXM4 80GB
     """
     from ..models.datacenter.a100_sxm4_80gb import a100_sxm4_80gb_resource_model
+
     return GPUMapper(a100_sxm4_80gb_resource_model(), thermal_profile=thermal_profile)
 
 
@@ -955,6 +1047,7 @@ def create_v100_sxm3_32gb_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for V100 SXM2 32GB
     """
     from ..models.datacenter.v100_sxm3_32gb import v100_sxm3_32gb_resource_model
+
     return GPUMapper(v100_sxm3_32gb_resource_model(), thermal_profile=thermal_profile)
 
 
@@ -996,10 +1089,13 @@ def create_t4_pcie_16gb_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for T4 PCIe 16GB
     """
     from ..models.datacenter.t4_pcie_16gb import t4_pcie_16gb_resource_model
+
     return GPUMapper(t4_pcie_16gb_resource_model(), thermal_profile=thermal_profile)
 
 
-def create_jetson_orin_agx_64gb_mapper(thermal_profile: str = None, calibration=None) -> GPUMapper:
+def create_jetson_orin_agx_64gb_mapper(
+    thermal_profile: str = None, calibration=None
+) -> GPUMapper:
     """
     Create GPU mapper for NVIDIA Jetson Orin AGX 64GB (edge AI platform).
 
@@ -1026,10 +1122,14 @@ def create_jetson_orin_agx_64gb_mapper(thermal_profile: str = None, calibration=
         tech_profile=EDGE_8NM_LPDDR5
     )
 
-    return GPUMapper(resource_model, thermal_profile=thermal_profile, calibration=calibration)
+    return GPUMapper(
+        resource_model, thermal_profile=thermal_profile, calibration=calibration
+    )
 
 
-def create_jetson_orin_nano_8gb_mapper(thermal_profile: str = None, calibration=None) -> GPUMapper:
+def create_jetson_orin_nano_8gb_mapper(
+    thermal_profile: str = None, calibration=None
+) -> GPUMapper:
     """
     Create GPU mapper for NVIDIA Jetson Orin Nano 8GB (compact edge AI platform).
 
@@ -1044,10 +1144,17 @@ def create_jetson_orin_nano_8gb_mapper(thermal_profile: str = None, calibration=
         GPUMapper configured for Jetson Orin Nano 8GB
     """
     from ..models.edge.jetson_orin_nano_8gb import jetson_orin_nano_8gb_resource_model
-    return GPUMapper(jetson_orin_nano_8gb_resource_model(), thermal_profile=thermal_profile, calibration=calibration)
+
+    return GPUMapper(
+        jetson_orin_nano_8gb_resource_model(),
+        thermal_profile=thermal_profile,
+        calibration=calibration,
+    )
 
 
-def create_jetson_orin_nx_16gb_mapper(thermal_profile: str = None, calibration=None) -> GPUMapper:
+def create_jetson_orin_nx_16gb_mapper(
+    thermal_profile: str = None, calibration=None
+) -> GPUMapper:
     """
     Create GPU mapper for NVIDIA Jetson Orin NX 16GB (mid-range edge AI platform).
 
@@ -1071,7 +1178,12 @@ def create_jetson_orin_nx_16gb_mapper(thermal_profile: str = None, calibration=N
         GPUMapper configured for Jetson Orin NX 16GB
     """
     from ..models.edge.jetson_orin_nx_16gb import jetson_orin_nx_16gb_resource_model
-    return GPUMapper(jetson_orin_nx_16gb_resource_model(), thermal_profile=thermal_profile, calibration=calibration)
+
+    return GPUMapper(
+        jetson_orin_nx_16gb_resource_model(),
+        thermal_profile=thermal_profile,
+        calibration=calibration,
+    )
 
 
 def create_jetson_thor_128gb_mapper(thermal_profile: str = None) -> GPUMapper:
@@ -1088,12 +1200,16 @@ def create_jetson_thor_128gb_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for Jetson Thor 128GB
     """
     from ..models.automotive.jetson_thor_128gb import jetson_thor_128gb_resource_model
-    return GPUMapper(jetson_thor_128gb_resource_model(), thermal_profile=thermal_profile)
+
+    return GPUMapper(
+        jetson_thor_128gb_resource_model(), thermal_profile=thermal_profile
+    )
 
 
 # ============================================================================
 # ARM Mali GPU IP Mappers
 # ============================================================================
+
 
 def create_arm_mali_g78_mp20_mapper(thermal_profile: str = None) -> GPUMapper:
     """
@@ -1150,13 +1266,17 @@ def create_arm_mali_g78_mp20_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for ARM Mali-G78 MP20
     """
     from ..models.mobile.arm_mali_g78_mp20 import arm_mali_g78_mp20_resource_model
-    return GPUMapper(arm_mali_g78_mp20_resource_model(), thermal_profile=thermal_profile)
+
+    return GPUMapper(
+        arm_mali_g78_mp20_resource_model(), thermal_profile=thermal_profile
+    )
 
 
 # ============================================================================
 # DEPRECATED: Old mapper names (backward compatibility)
 # These will be removed in version X.Y+1.0 (6 months)
 # ============================================================================
+
 
 def create_h100_mapper(thermal_profile: str = None) -> GPUMapper:
     """
@@ -1175,11 +1295,12 @@ def create_h100_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for H100 PCIe 80GB
     """
     import warnings
+
     warnings.warn(
         "create_h100_mapper() is deprecated and will be removed in a future version. "
         "Use create_h100_pcie_80gb_mapper() instead for explicit form factor and memory size.",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
     return create_h100_pcie_80gb_mapper(thermal_profile)
 
@@ -1201,11 +1322,12 @@ def create_a100_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for A100 SXM4 80GB
     """
     import warnings
+
     warnings.warn(
         "create_a100_mapper() is deprecated and will be removed in a future version. "
         "Use create_a100_sxm4_80gb_mapper() instead for explicit form factor and memory size.",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
     return create_a100_sxm4_80gb_mapper(thermal_profile)
 
@@ -1227,11 +1349,12 @@ def create_v100_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for V100 SXM2 32GB
     """
     import warnings
+
     warnings.warn(
         "create_v100_mapper() is deprecated and will be removed in a future version. "
         "Use create_v100_sxm3_32gb_mapper() instead for explicit form factor and memory size.",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
     return create_v100_sxm3_32gb_mapper(thermal_profile)
 
@@ -1253,11 +1376,12 @@ def create_t4_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for T4 PCIe 16GB
     """
     import warnings
+
     warnings.warn(
         "create_t4_mapper() is deprecated and will be removed in a future version. "
         "Use create_t4_pcie_16gb_mapper() instead for explicit form factor and memory size.",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
     return create_t4_pcie_16gb_mapper(thermal_profile)
 
@@ -1279,11 +1403,12 @@ def create_jetson_orin_agx_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for Jetson Orin AGX 64GB
     """
     import warnings
+
     warnings.warn(
         "create_jetson_orin_agx_mapper() is deprecated and will be removed in a future version. "
         "Use create_jetson_orin_agx_64gb_mapper() instead for explicit memory size.",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
     return create_jetson_orin_agx_64gb_mapper(thermal_profile)
 
@@ -1305,11 +1430,12 @@ def create_jetson_orin_nano_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for Jetson Orin Nano 8GB
     """
     import warnings
+
     warnings.warn(
         "create_jetson_orin_nano_mapper() is deprecated and will be removed in a future version. "
         "Use create_jetson_orin_nano_8gb_mapper() instead for explicit memory size.",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
     return create_jetson_orin_nano_8gb_mapper(thermal_profile)
 
@@ -1331,10 +1457,11 @@ def create_jetson_thor_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for Jetson Thor 128GB
     """
     import warnings
+
     warnings.warn(
         "create_jetson_thor_mapper() is deprecated and will be removed in a future version. "
         "Use create_jetson_thor_128gb_mapper() instead for explicit memory size.",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
     return create_jetson_thor_128gb_mapper(thermal_profile)

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -1097,6 +1097,28 @@ class HardwareResourceModel:
     l3_access_latency_ns: Optional[float] = None
     dram_access_latency_ns: Optional[float] = None
 
+    # V5 follow-up: kernel-launch / dispatch overhead for the
+    # roofline analyzer's _estimate_overhead path. The GPUMapper
+    # subclass already tracks ``kernel_launch_overhead`` (10 us
+    # datacenter, 80 us edge), but RooflineAnalyzer only sees
+    # HardwareResourceModel and was using a hardcoded 5 us base.
+    # Surfacing the value here lets both the mapper and the analyzer
+    # read the same constant.
+    #
+    # Empirical anchors:
+    #   Datacenter NVIDIA (H100/A100/V100): ~10 us per
+    #     CUDA driver / Nsight Systems (NVIDIA blog).
+    #   Jetson Orin (Nano/AGX/NX): ~80 us per direct measurement
+    #     and arXiv:2508.08430 ("individual GPU kernel launches are
+    #     typically Kl = 20-100 us" on Orin Nano). The 80 us
+    #     value is the existing repo constant
+    #     KERNEL_LAUNCH_OVERHEAD_EDGE on GPUMapper.
+    #   CPU: not used (CPU has its own op-aware dispatch floor in
+    #     RooflineAnalyzer._get_cpu_dispatch_floor).
+    #
+    # None means "use the analyzer's hardware-type-default".
+    kernel_launch_overhead_ns: Optional[float] = None
+
     # V5-5: per-tier achievable_fraction overrides for the V5-3b
     # tier-aware roofline path. Maps tier name ("L1", "L2", "L3", "DRAM")
     # to the calibrated achievable BW fraction (peak * fraction =

--- a/tests/hardware/test_kernel_launch_overhead.py
+++ b/tests/hardware/test_kernel_launch_overhead.py
@@ -1,0 +1,153 @@
+"""V5 follow-up: pin the ``kernel_launch_overhead_ns`` plumbing.
+
+Background: the GPUMapper subclass tracks
+``KERNEL_LAUNCH_OVERHEAD_EDGE = 80e-6`` for Jetson and
+``KERNEL_LAUNCH_OVERHEAD_DATACENTER = 10e-6`` for desktop GPUs, but
+``RooflineAnalyzer._estimate_overhead`` was using a hardcoded 5 us
+base regardless of the device class. This caused L1-binding shapes
+on Jetson to under-predict by 100+ us (predict 5-13 us, measure
+113-173 us per arXiv:2508.08430 + V4 baselines).
+
+This PR surfaces ``kernel_launch_overhead_ns`` on
+``HardwareResourceModel`` and has GPUMapper write it during
+construction, so RooflineAnalyzer can read the same value the
+mapper already exposes.
+
+Tests:
+* GPUMapper construction sets the field correctly for edge / datacenter
+* Explicit override on the resource_model wins over the mapper default
+* RooflineAnalyzer's _estimate_overhead uses the new field for GPU
+* Field stays None / unused for CPU mappers
+"""
+
+import pytest
+
+from graphs.estimation.roofline import RooflineAnalyzer
+from graphs.hardware.mappers.cpu import create_i7_12700k_mapper
+from graphs.hardware.mappers.gpu import (
+    GPUMapper,
+    create_h100_sxm5_80gb_mapper,
+    create_jetson_orin_nano_8gb_mapper,
+)
+from graphs.hardware.resource_model import Precision
+
+
+def test_jetson_mapper_writes_edge_overhead_to_resource_model():
+    """Jetson Orin Nano (edge device) gets the 80 us EDGE constant
+    written to ``resource_model.kernel_launch_overhead_ns``."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    assert hw.kernel_launch_overhead_ns == pytest.approx(
+        GPUMapper.KERNEL_LAUNCH_OVERHEAD_EDGE * 1e9
+    )
+    assert hw.kernel_launch_overhead_ns == 80_000.0
+
+
+def test_h100_mapper_writes_datacenter_overhead_to_resource_model():
+    """H100 (datacenter, NOT edge) gets the 10 us DATACENTER
+    constant written to ``resource_model.kernel_launch_overhead_ns``."""
+    hw = create_h100_sxm5_80gb_mapper().resource_model
+    assert hw.kernel_launch_overhead_ns == pytest.approx(
+        GPUMapper.KERNEL_LAUNCH_OVERHEAD_DATACENTER * 1e9
+    )
+    assert hw.kernel_launch_overhead_ns == 10_000.0
+
+
+def test_cpu_mapper_does_not_touch_kernel_launch_overhead_ns():
+    """CPU mappers don't go through GPUMapper, so the field stays
+    None. (CPU has its own op-aware dispatch floor in
+    RooflineAnalyzer._get_cpu_dispatch_floor.)"""
+    hw = create_i7_12700k_mapper().resource_model
+    assert hw.kernel_launch_overhead_ns is None
+
+
+def test_explicit_override_on_resource_model_wins():
+    """If the mapper / caller has already set
+    ``kernel_launch_overhead_ns`` (e.g. for a future per-Jetson-
+    power-mode override), the GPUMapper construction respects it."""
+    from graphs.hardware.models.edge.jetson_orin_nano_8gb import (
+        jetson_orin_nano_8gb_resource_model,
+    )
+
+    rm = jetson_orin_nano_8gb_resource_model()
+    rm.kernel_launch_overhead_ns = 60_000.0  # 60 us, hypothetical custom value
+    GPUMapper(rm)  # construction; should NOT overwrite the explicit value
+    assert rm.kernel_launch_overhead_ns == 60_000.0
+
+
+def test_analyzer_picks_up_jetson_edge_overhead():
+    """RooflineAnalyzer._estimate_overhead reads the new field for
+    GPU. For a Jetson resource_model with 80 us
+    kernel_launch_overhead_ns, the base overhead in the GPU branch
+    is 80 us (vs the legacy 5 us)."""
+    from graphs.core.structures import (
+        OperationType,
+        SubgraphDescriptor,
+        create_tensor_descriptor,
+    )
+
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+    # Build a vector_add subgraph (no special op-type bumps in
+    # _estimate_overhead, so the base passes through cleanly).
+    a = create_tensor_descriptor((1024,), "float16")
+    b = create_tensor_descriptor((1024,), "float16")
+    c = create_tensor_descriptor((1024,), "float16")
+    sg = SubgraphDescriptor(
+        subgraph_id=1,
+        node_ids=["va"],
+        node_names=["va"],
+        operation_types=[OperationType.ELEMENTWISE],
+        fusion_pattern="Add",
+        total_flops=1024,
+        total_macs=0,
+        total_input_bytes=2 * 1024 * 2,
+        total_output_bytes=1024 * 2,
+        total_weight_bytes=0,
+        input_tensors=[a, b],
+        output_tensors=[c],
+        weight_tensors=[],
+    )
+    overhead = analyzer._estimate_overhead(sg)
+    # Should be at least the Jetson 80 us base (might be higher if
+    # an op-type bump fires; vanilla ELEMENTWISE shouldn't trigger
+    # any of the bumps in the function body).
+    assert overhead >= 80e-6, (
+        f"Expected at least 80 us base for Jetson, got " f"{overhead*1e6:.2f} us"
+    )
+
+
+def test_analyzer_picks_up_datacenter_overhead():
+    """H100 mapper has 10 us datacenter overhead; the analyzer's
+    GPU branch picks it up the same way as Jetson."""
+    from graphs.core.structures import (
+        OperationType,
+        SubgraphDescriptor,
+        create_tensor_descriptor,
+    )
+
+    hw = create_h100_sxm5_80gb_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+    a = create_tensor_descriptor((1024,), "float16")
+    b = create_tensor_descriptor((1024,), "float16")
+    c = create_tensor_descriptor((1024,), "float16")
+    sg = SubgraphDescriptor(
+        subgraph_id=2,
+        node_ids=["va"],
+        node_names=["va"],
+        operation_types=[OperationType.ELEMENTWISE],
+        fusion_pattern="Add",
+        total_flops=1024,
+        total_macs=0,
+        total_input_bytes=2 * 1024 * 2,
+        total_output_bytes=1024 * 2,
+        total_weight_bytes=0,
+        input_tensors=[a, b],
+        output_tensors=[c],
+        weight_tensors=[],
+    )
+    overhead = analyzer._estimate_overhead(sg)
+    assert overhead >= 10e-6, (
+        f"Expected at least 10 us base for H100, got " f"{overhead*1e6:.2f} us"
+    )
+    # And less than the Jetson 80 us (sanity)
+    assert overhead < 80e-6


### PR DESCRIPTION
## Summary

`GPUMapper` already tracks kernel-launch overhead as a class
constant (`KERNEL_LAUNCH_OVERHEAD_EDGE = 80 µs` for Jetson,
`KERNEL_LAUNCH_OVERHEAD_DATACENTER = 10 µs` for datacenter), but
`RooflineAnalyzer._estimate_overhead` was using a hardcoded **5 µs**
base regardless of device class. This caused L1-binding shapes on
Jetson Orin Nano to under-predict by 100+ µs.

This PR surfaces `kernel_launch_overhead_ns` on `HardwareResourceModel`
so the analyzer reads the same value the mapper already exposes.

## External validation of the 80 µs Jetson value

The user asked me to validate the ~100 µs Jetson kernel-launch claim
with external data. Findings:

| source | value | context |
|---|---|---|
| **[arXiv:2508.08430](https://arxiv.org/html/2508.08430v1)** (Profiling Concurrent Vision Inference on NVIDIA Jetson) | **20-100 µs** per individual kernel | Direct Orin Nano measurement |
| [NVIDIA Nsight Systems blog](https://developer.nvidia.com/blog/understanding-the-visualization-of-overhead-and-latency-in-nsight-systems/) | ~20 µs end-to-end | Desktop CUDA |
| [NVIDIA Forums: Jetson Xavier](https://forums.developer.nvidia.com/t/kernel-launch-time-in-nsight-system/139398) | 139 µs total launch-to-execute | Tegra software stack |
| [NVIDIA Forums: Orin AGX CUDA graph](https://forums.developer.nvidia.com/t/orin-cuda-graph-latency-is-too-long/309359) | ~20 µs direct, ~100 µs with nsys | Per-kernel amortized |
| Existing repo constant | 80 µs | "measured on Jetson" |

**The 80 µs edge value sits squarely in the published range.** It's
defensible as a representative single-kernel base, with caveats:
thermal-profile-dependent, lower under CUDA Graphs, higher for tiny
activation kernels (already handled by op-specific bumps in
`_estimate_overhead`).

## What ships

1. **`HardwareResourceModel.kernel_launch_overhead_ns`** (new field,
   `Optional[float]`, defaults to `None`)
2. **`GPUMapper.__init__`** writes its detected per-device-class
   value (10 µs datacenter / 80 µs edge) onto `resource_model`.
   Explicit overrides on the `resource_model` win.
3. **`RooflineAnalyzer._estimate_overhead`** reads the new field for
   the GPU branch's base overhead. Op-specific bumps (Hardswish,
   SE block, POINTWISE, DEPTHWISE, etc.) still apply on top.

## What was investigated but NOT shipped

A full op-aware GPU dispatch **floor** (analog of CPU `#108`) was
implemented as `_get_gpu_dispatch_floor` but **not applied in
`_analyze_subgraph`**. The V4 Jetson measurer reports kernel time
via cudaEvent which inconsistently includes/excludes the CUDA launch
overhead — some L1-binding matmul shapes measure 14-32 µs (launch
excluded) while others measure 113-173 µs (launch included). A hard
floor matching the launch-included cohort would over-predict the
launch-excluded cohort, regressing V4 floors net (matmul 22/48 →
7/48; linear 18/46 → 9/46 in initial test).

The additive `_estimate_overhead` bump alone is the responsible
change — raises small-kernel predictions toward the launch-included
cohort without breaking the launch-excluded ones. The op-aware
floor helper stays in the codebase for future use once the V4
measurer is fixed.

## V4 floor impact

| target | op | before | after | delta |
|---|---|---|---|---|
| Orin Nano | vector_add | 4/7 | **5/7** | **+1** |
| Orin Nano | matmul | 22/48 | 22/48 | 0 |
| Orin Nano | linear | 18/46 | 18/46 | 0 |
| i7-12700K | (all) | (unchanged) | (unchanged) | 0 |

CPU mappers don't touch `kernel_launch_overhead_ns`; CPU has its own
op-aware dispatch floor (`#108`).

## Test plan

- [x] **6 new tests** in `test_kernel_launch_overhead.py`:
  - Jetson mapper writes 80,000 ns to resource_model
  - H100 mapper writes 10,000 ns
  - CPU mapper leaves field None
  - Explicit resource_model override wins over mapper default
  - Analyzer picks up Jetson edge value (>=80 µs)
  - Analyzer picks up H100 datacenter value (>=10 µs, <80 µs)
- [x] V4 Orin Nano vector_add: 4/7 → **5/7** (+1)
- [x] V4 i7 unchanged (all three ops)
- [x] 662 tests pass (656 + 6)
- [ ] CI: full matrix passes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GPU kernel launch overhead is now configurable per hardware device and automatically incorporated into dispatch performance estimates.
  * Added precision specification support for GPU analysis workflows.
  * Enhanced operation classification with expanded pattern detection for improved accuracy.
  * Improved bottleneck tracking with more detailed latency breakdown reporting.

* **Tests**
  * Comprehensive test coverage for GPU dispatch overhead across different hardware platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->