### PR TITLE
feat(estimation,hardware): per-mapper compute efficiency override

### DIFF
--- a/docs/calibration/jetson-orin-nano-calibration-analysis.md
+++ b/docs/calibration/jetson-orin-nano-calibration-analysis.md
@@ -31,7 +31,15 @@ Improving the floor requires three model fixes (in priority order):
    is the regime classifier (compute model, item 3).*
 3. **Compute efficiency model refinement** -- 19 -side
    under-predictions where compute_time is too fast vs reality;
-   separate from the memory model.
+   separate from the memory model. *Addressed by the V5 follow-up
+   compute-derate PR; see
+   [`docs/v5/jetson-compute-efficiency-derate.md`](../v5/jetson-compute-efficiency-derate.md).
+   Per-mapper `compute_efficiency_overrides_by_op` field replaces the
+   AGX-tuned legacy curve for matmul (0.70) and linear (0.94) on
+   Orin Nano FP16. Latency-pass gains: matmul +8, linear +7-12.
+   V4 PASS still blocked by the sweep-file regime classifier
+   (44/48 matmul, 45/46 linear records have stale sweep regimes;
+   regenerating the sweep is a separate task).*
 
 Setting calibration fractions any differently won't close these
 gaps -- the underlying physics (or model assumptions) is what's off.

--- a/docs/v5/jetson-compute-efficiency-derate.md
+++ b/docs/v5/jetson-compute-efficiency-derate.md
@@ -146,7 +146,7 @@ linear scale ~0.85. But the V4 floor tests run on the LEGACY memory
 path (`RunnerConfig.use_tier_aware_memory` defaults to False), and on
 that path 0.85 regresses the energy-pass band:
 
-```
+```text
 LEGACY memory path, linear scale sweep:
    scale  lat-pass  energy-pass
    0.85   28        24      ← peak lat, energy fails (floor 27)

--- a/docs/v5/jetson-compute-efficiency-derate.md
+++ b/docs/v5/jetson-compute-efficiency-derate.md
@@ -1,0 +1,201 @@
+# V5 Follow-up: Jetson Compute Efficiency Derate
+
+## Context
+
+The V5 follow-up Jetson Orin Nano calibration analysis (PR #115) flagged
+"compute efficiency model refinement" as one of three model gaps blocking
+V4 floor improvement. This PR closes that gap for matmul / linear at FP16
+on Jetson Orin Nano via a new per-mapper calibration field.
+
+## What was wrong
+
+`RooflineAnalyzer._get_compute_efficiency_scale` is a single 240-line
+function that returns a multiplicative scale applied to `peak_flops`:
+
+```python
+effective_peak_flops = self.peak_flops * compute_efficiency_scale
+compute_time = sg.flops / effective_peak_flops
+```
+
+The function was calibrated on **Jetson Orin AGX (50W, FP32, conv2d-heavy
+workloads with cuDNN+TF32)**. For large matmul (>5 GFLOPS) it returns
+**1.4-1.5** -- meaning the model predicts compute throughput **1.4-1.5x
+above peak**. This makes sense on AGX where:
+
+* `peak_flops = peak_ops_per_sec` is the SPEC peak (no efficiency
+  baked in)
+* cuDNN secretly upgrades FP32 to TF32, achieving ~5x of FP32 spec
+  on large convs
+* The scale > 1 compensates for the spec-vs-effective gap
+
+But Jetson Orin Nano works differently:
+
+* `peak_ops_per_sec = 8 SMs * 1024 ops/clock * 1.02 GHz = 8.36 TFLOPS`
+* `efficiency_factor = 0.85` (cuBLAS Tensor Core matmul fraction)
+* `peak_flops = 8.36 * 0.85 = 7.10 TFLOPS` -- already the ACHIEVABLE peak
+
+Multiplying 7.10 TFLOPS by the AGX-tuned 1.48 scale yields a predicted
+compute throughput of **10.5 TFLOPS** -- 25% above the theoretical
+spec peak, and **2.4x above the cuBLAS-achievable peak**.
+
+## Per-shape data
+
+Probe of `peak_flops`, `compute_efficiency_scale`, and measured
+efficiency across the 20 large-matmul shapes from the Jetson Orin
+Nano V4 baseline (`jetson_orin_nano_8gb_matmul.csv`):
+
+| shape | flops (G) | cm_scale | pred compute_t (ms) | meas (ms) | meas eff |
+|---|---|---|---|---|---|
+| (96, 12288, 6144) | 14.50 | 1.477 | 1.382 | 3.11 | 0.656 |
+| (192, 6144, 6144) | 14.50 | 1.477 | 1.382 | 2.98 | 0.685 |
+| (1536, 3072, 1536) | 14.50 | 1.477 | 1.382 | 3.65 | 0.559 |
+| (3072, 192, 12288) | 14.50 | 1.477 | 1.382 | 2.96 | 0.689 |
+| (6144, 96, 12288) | 14.50 | 1.477 | 1.382 | 5.72 | 0.357 |
+| (6144, 6144, 192) | 14.50 | 1.477 | 1.382 | 2.89 | 0.706 |
+| (12288, 96, 6144) | 14.50 | 1.477 | 1.382 | 5.66 | 0.361 |
+| (12288, 3072, 192) | 14.50 | 1.477 | 1.382 | 2.65 | 0.770 |
+| (64, 8192, 16384) | 17.18 | 1.489 | 1.624 | 5.60 | 0.432 |
+| (64, 16384, 8192) | 17.18 | 1.489 | 1.624 | 4.89 | 0.495 |
+| (128, 4096, 16384) | 17.18 | 1.489 | 1.624 | 4.46 | 0.542 |
+| (128, 8192, 8192) | 17.18 | 1.489 | 1.624 | 3.35 | 0.722 |
+| (128, 16384, 4096) | 17.18 | 1.489 | 1.624 | 2.89 | 0.837 |
+| (256, 2048, 16384) | 17.18 | 1.489 | 1.624 | 3.33 | 0.726 |
+| (256, 4096, 8192) | 17.18 | 1.489 | 1.624 | 4.44 | 0.545 |
+| (256, 8192, 4096) | 17.18 | 1.489 | 1.624 | 2.70 | 0.896 |
+| (256, 16384, 2048) | 17.18 | 1.489 | 1.624 | 3.78 | 0.640 |
+| (2048, 256, 16384) | 17.18 | 1.489 | 1.624 | 3.32 | 0.729 |
+| (2048, 2048, 2048) | 17.18 | 1.489 | 1.624 | 4.64 | 0.521 |
+| (2048, 16384, 256) | 17.18 | 1.489 | 1.624 | 3.64 | 0.665 |
+
+`meas_eff` = `flops / (meas_ms * 1e-3 * 7.10 TFLOPS)`. Range:
+0.36-0.90, median 0.66, mean 0.62.
+
+The model says scale = 1.48 (compute is 48% FASTER than achievable
+peak); reality says scale ≈ 0.62 (compute is 62% of achievable peak).
+The model is **2.4x too optimistic**.
+
+## What changed
+
+### New field on `HardwareResourceModel`
+
+```python
+compute_efficiency_overrides_by_op: Dict[str, Dict[str, float]] = field(
+    default_factory=dict
+)
+# Outer key: precision name ("fp16", "fp32", ...)
+# Inner key: op kind ("matmul", "linear", "vector_add")
+# Value: scale to use instead of _get_compute_efficiency_scale (range (0, 2.0])
+```
+
+### New helper on `RooflineAnalyzer`
+
+```python
+def _get_compute_efficiency_override(self, sg) -> Optional[float]:
+    """Look up the per-(precision, op_kind) override; return None to fall
+    through to the legacy curve."""
+```
+
+Called at the top of `_get_compute_efficiency_scale`. When the override
+fires, the legacy 240-line curve is bypassed entirely.
+
+### Calibrated values for Jetson Orin Nano FP16
+
+```python
+compute_efficiency_overrides_by_op={
+    "fp16": {"matmul": 0.70, "linear": 0.94},
+}
+```
+
+V4-baseline-fit; the choice is constrained by the legacy memory path's
+energy-band test floor (`test_jetson_orin_nano_linear_pass_energy_floor`
+requires >= 27/46 energy passes).
+
+## V4 floor impact
+
+| metric | path | baseline | this PR | delta |
+|---|---|---|---|---|
+| jetson matmul lat-pass | tier-aware | 22 | 30 | **+8** |
+| jetson matmul lat-pass | legacy | 18 | 26 | **+8** |
+| jetson matmul egy-pass | tier-aware | 29 | 29 | 0 |
+| jetson matmul egy-pass | legacy | 24 | 24 | 0 |
+| jetson linear lat-pass | tier-aware | 18 | 30 | **+12** |
+| jetson linear lat-pass | legacy | 18 | 25 | **+7** |
+| jetson linear egy-pass | tier-aware | 29 | 30 | +1 |
+| jetson linear egy-pass | legacy | 29 | 28 | -1 (above 27 floor) |
+| i7 matmul (all) | both | unchanged | unchanged | 0 |
+| i7 linear (all) | both | unchanged | unchanged | 0 |
+| jetson vector_add | both | unchanged | unchanged | 0 |
+
+## V4 PASS counts: still unchanged for Jetson
+
+`pass_regime AND pass_latency` is the V4 PASS gate. Jetson is bottlenecked
+by `pass_regime` because the **sweep file's pre-computed regime
+classifications** (in `regimes_validation_*.json`'s `regime_per_hw`) come
+from an older model and disagree with the measured regime on most shapes
+(only 4/48 matmul shapes and 1/46 linear shapes have correct sweep-side
+regimes). The compute model can't lift PASS while the sweep classifier
+is the gate.
+
+This is a separate task: regenerate the sweep regime classifications
+with the V5 model. Tracked but out of scope for this PR.
+
+## Why the linear scale is 0.94 not 0.85
+
+Pure latency-pass maximization on the tier-aware memory path picks
+linear scale ~0.85. But the V4 floor tests run on the LEGACY memory
+path (`RunnerConfig.use_tier_aware_memory` defaults to False), and on
+that path 0.85 regresses the energy-pass band:
+
+```
+LEGACY memory path, linear scale sweep:
+   scale  lat-pass  energy-pass
+   0.85   28        24      ← peak lat, energy fails (floor 27)
+   0.88   28        25      ← still fails
+   0.93   25        27      ← matches floor exactly
+   0.94   25        28      ← +1 headroom; ships here
+   1.00   22        28
+```
+
+Reason: on legacy, predicted memory-time is wider, so compute_time
+matters less. Lowering compute scale grows predicted latency more
+than it should, which inflates predicted `static_energy = avg_power *
+latency` past the actual silicon energy.
+
+When `RunnerConfig.use_tier_aware_memory` is set to the production
+default (True), the optimal point shifts -- 0.85-0.88 becomes
+Pareto-optimal again with energy-pass holding above 27. The right
+follow-up is to align `RunnerConfig` defaults with the V5-3b
+production default; then re-tune linear toward 0.85. For now, 0.94
+is the safe Pareto value that respects the existing test floors.
+
+## i7 unaffected
+
+i7 mappers don't carry `compute_efficiency_overrides_by_op` (empty
+dict default), so the override helper returns None and the legacy
+curve fires unchanged. Verified: i7 matmul / linear V4 floors are
+byte-identical before and after this PR.
+
+## What this does NOT fix
+
+* **Sweep regime classifier** -- 44/48 Jetson matmul shapes have wrong
+  regime predictions baked into the sweep JSON. The compute fix lifts
+  predicted regime classification accuracy on the analyzer side, but
+  V4 PASS still gates on sweep-side regime.
+* **Per-shape compute efficiency** -- a single scalar fits a 0.36-0.90
+  measured-efficiency range. Per-shape variance (related to Tensor
+  Core utilization patterns: aspect ratio, alignment, K size) is
+  still uncaptured. A future per-shape model (analog of the
+  aspect-ratio skinny detection in PR #117) could close more of the
+  remaining gap.
+* **Other Jetson SKUs** -- AGX 64GB and NX 16GB do not yet have
+  V4 baselines, so their override values are absent. Set them as
+  baselines land.
+
+## Cross-link
+
+* PR #115 -- analysis that flagged compute model derate as Category 3
+* PR #116 -- Category 1 (GPU dispatch overhead bridge)
+* PR #117 -- Category 2 (aspect-ratio skinny matmul detection)
+* `src/graphs/hardware/resource_model.py` -- `compute_efficiency_overrides_by_op`
+* `src/graphs/estimation/roofline.py` -- `_get_compute_efficiency_override`
+* `docs/calibration/jetson-orin-nano-calibration-analysis.md`

--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -741,6 +741,43 @@ class RooflineAnalyzer:
             memory_explanation=self._last_memory_explanation,
         )
 
+    def _get_compute_efficiency_override(
+        self, sg: SubgraphDescriptor
+    ) -> Optional[float]:
+        """V5 follow-up: per-precision per-op compute scale override.
+
+        Returns the calibrated scalar from
+        ``resource_model.compute_efficiency_overrides_by_op[precision_str]
+        [op_kind]`` if the mapper has supplied one for the analyzer's
+        precision and the subgraph's op kind. Returns None to fall
+        through to the legacy ``_get_compute_efficiency_scale`` curve.
+
+        ``op_kind`` is mapped from ``OperationType`` to the same
+        string used by ``ReuseModel.op_kind`` (``"matmul"``,
+        ``"linear"``, ``"vector_add"``). Subgraphs with multiple
+        ops or unknown ops fall through to the legacy path.
+        """
+        from graphs.core.structures import OperationType
+
+        overrides = self.resource_model.compute_efficiency_overrides_by_op
+        if not overrides:
+            return None
+        prec_overrides = overrides.get(self.precision.value)
+        if not prec_overrides:
+            return None
+        op_types = getattr(sg, "operation_types", None)
+        if not op_types or len(op_types) != 1:
+            return None
+        op_to_kind = {
+            OperationType.MATMUL: "matmul",
+            OperationType.LINEAR: "linear",
+            OperationType.ELEMENTWISE: "vector_add",
+        }
+        op_kind = op_to_kind.get(op_types[0])
+        if op_kind is None:
+            return None
+        return prec_overrides.get(op_kind)
+
     def _get_compute_efficiency_scale(self, sg: SubgraphDescriptor) -> float:
         """
         Compute efficiency scaling factor based on operation type and granularity.
@@ -785,6 +822,16 @@ class RooflineAnalyzer:
 
         if flops <= 0:
             return 1.0  # No compute, efficiency doesn't matter
+
+        # V5 follow-up: per-precision per-op override path. When the
+        # mapper has supplied a calibrated scalar for this
+        # (precision, op_kind), bypass the legacy curve below entirely
+        # -- the override is what we trust. See
+        # ``HardwareResourceModel.compute_efficiency_overrides_by_op``
+        # docstring for the rationale.
+        override = self._get_compute_efficiency_override(sg)
+        if override is not None:
+            return override
 
         # Check for depthwise convolution (severely inefficient on GPUs)
         # CALIBRATION (Jetson Orin AGX, 50W, FP32):

--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -756,6 +756,15 @@ class RooflineAnalyzer:
         string used by ``ReuseModel.op_kind`` (``"matmul"``,
         ``"linear"``, ``"vector_add"``). Subgraphs with multiple
         ops or unknown ops fall through to the legacy path.
+
+        For ``OperationType.ELEMENTWISE``, the ``"vector_add"``
+        override only fires when the subgraph also matches the strict
+        vector-add layout (3 tensors, 1-D, ``c[i] = a[i] + b[i]``);
+        otherwise the override would also apply to ReLU / sigmoid /
+        other elementwise ops that share ELEMENTWISE but have
+        different compute-efficiency physics. ``_extract_vector_add_shape``
+        is the existing strict predicate (also used by
+        ``_try_tier_aware_memory_time``).
         """
         from graphs.core.structures import OperationType
 
@@ -768,13 +777,18 @@ class RooflineAnalyzer:
         op_types = getattr(sg, "operation_types", None)
         if not op_types or len(op_types) != 1:
             return None
-        op_to_kind = {
-            OperationType.MATMUL: "matmul",
-            OperationType.LINEAR: "linear",
-            OperationType.ELEMENTWISE: "vector_add",
-        }
-        op_kind = op_to_kind.get(op_types[0])
-        if op_kind is None:
+        op_type = op_types[0]
+        if op_type == OperationType.MATMUL:
+            op_kind = "matmul"
+        elif op_type == OperationType.LINEAR:
+            op_kind = "linear"
+        elif op_type == OperationType.ELEMENTWISE:
+            # Strict vector_add gate -- ReLU / sigmoid also map to
+            # ELEMENTWISE but should NOT pick up a vector_add override.
+            if self._extract_vector_add_shape(sg) is None:
+                return None
+            op_kind = "vector_add"
+        else:
             return None
         return prec_overrides.get(op_kind)
 

--- a/src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py
+++ b/src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py
@@ -452,4 +452,54 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
         # tier-aware roofline path when opt-in. L1 / L2 entries stay
         # absent (default 1.0) until matmul-anchored calibration.
         tier_achievable_fractions={"DRAM": 0.55},
+        # V5 follow-up: per-op compute efficiency overrides for matmul
+        # / linear at fp16. Derived from V4 baseline measurements at
+        # validation/model_v4/results/baselines/jetson_orin_nano_8gb_{matmul,linear}.csv.
+        #
+        # The shared ``_get_compute_efficiency_scale`` curve was tuned
+        # for AGX-style "spec peak" interpretations and returns scale
+        # ~1.5 for large matmul, but Orin Nano's
+        # ``peak_ops_per_sec = 7.1 TFLOPS`` is ALREADY the achievable
+        # peak (cuBLAS Tensor Core 0.85 efficiency baked in via
+        # ``efficiency_factor`` on the FP16 perf characteristics).
+        # Multiplying that by 1.5 over-predicts compute throughput by
+        # 2.4x and forces shapes that actually run alu_bound to look
+        # dram_bound in the model.
+        #
+        # V4-baseline-fit sweep at the 15W default (Orin Nano Super
+        # 1.02 GHz). Two memory paths matter (legacy via
+        # ``_get_bandwidth_efficiency_scale`` and tier-aware via
+        # V5-3b); the values below are Pareto-optimal across both:
+        #
+        # * matmul: 0.70 maximizes latency-pass count.
+        #     - tier-aware: lat 22 -> 30 (+8), energy unchanged at 29
+        #     - legacy:     lat 18 -> 26 (+8), energy unchanged at 24
+        #
+        # * linear: 0.94 respects the legacy-path energy floor while
+        #   still gaining latency-pass on both paths. The peak
+        #   latency-pass point is around 0.85-0.88 but those values
+        #   regress the legacy-path energy band (predicted latency
+        #   grows -> static_energy = avg_power * latency grows
+        #   faster than the actual silicon energy). Sweep results
+        #   on the LEGACY memory path (which the V4 floor tests
+        #   currently use):
+        #     scale  lat-pass  energy-pass
+        #     0.85   28        24      ← peak lat, energy fails (floor 27)
+        #     0.88   28        25      ← still fails energy floor
+        #     0.90   27        25
+        #     0.93   25        27      ← matches floor
+        #     0.94   25        28      ← ships here, +1 headroom
+        #     1.00   22        28
+        #     1.40   18        29      ← legacy curve baseline
+        #   On the TIER-AWARE path 0.94 gives lat 30 (vs baseline 18).
+        #   The energy floor is enforced by
+        #   tests/validation_model_v4/test_v4_against_baseline.py
+        #   ::test_jetson_orin_nano_linear_pass_energy_floor (>=27).
+        #
+        # vector_add gets no override (its compute path is dominated
+        # by memory; the legacy curve already returns ~1.0 for
+        # elementwise ops).
+        compute_efficiency_overrides_by_op={
+            "fp16": {"matmul": 0.70, "linear": 0.94},
+        },
     )

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -1152,6 +1152,39 @@ class HardwareResourceModel:
         default_factory=dict
     )
 
+    # V5 follow-up: per-precision per-op compute efficiency override.
+    # Replaces ``RooflineAnalyzer._get_compute_efficiency_scale``'s
+    # large hand-tuned curve for matmul / linear when set. Maps
+    # precision name (``"fp16"``, ``"fp32"``, etc. -- the
+    # ``Precision.value`` string, not the enum) to a per-op-kind
+    # mapping of fixed scale values.
+    #
+    # Key insight: ``peak_flops`` interpretation varies across
+    # mappers. On Jetson Orin Nano the ``peak_ops_per_sec`` already
+    # bakes in cuBLAS Tensor Core efficiency (e.g. 0.85), making it
+    # an "achievable" peak; on Jetson Orin AGX the value is closer to
+    # the spec peak (TF32 / cuDNN can boost effective throughput past
+    # it). The shared ``_get_compute_efficiency_scale`` function was
+    # calibrated for AGX-style spec peaks and returns scales > 1 for
+    # large matmul, which over-predicts compute throughput on
+    # achievable-peak mappers by 2x+.
+    #
+    # When this override is set for the analyzer's
+    # (precision, op_kind), the legacy curve is bypassed entirely.
+    # ``op_kind`` is the same string as ``ReuseModel.op_kind``
+    # (``"matmul"``, ``"linear"``, ``"vector_add"``).
+    #
+    # Example (Jetson Orin Nano FP16, V4 baseline-calibrated):
+    #   {"fp16": {"matmul": 0.70, "linear": 0.85}}
+    #
+    # The values must be in (0, 2.0]; the same range as the legacy
+    # curve to avoid surprising regressions when a mapper carries
+    # the override but the analyzer falls into a non-overridden op
+    # kind.
+    compute_efficiency_overrides_by_op: Dict[str, Dict[str, float]] = field(
+        default_factory=dict
+    )
+
     def __post_init__(self) -> None:
         """Validate calibration-fraction invariants.
 
@@ -1180,6 +1213,13 @@ class HardwareResourceModel:
                     raise ValueError(
                         f"tier_achievable_fractions_by_op[{op_kind!r}]"
                         f"[{tier_name!r}] = {fraction} must be in [0.0, 1.0]"
+                    )
+        for prec_name, by_op in self.compute_efficiency_overrides_by_op.items():
+            for op_kind, scale in by_op.items():
+                if not (0.0 < scale <= 2.0):
+                    raise ValueError(
+                        f"compute_efficiency_overrides_by_op[{prec_name!r}]"
+                        f"[{op_kind!r}] = {scale} must be in (0.0, 2.0]"
                     )
 
     # M5 Layer 5: cache-coherence protocol class.

--- a/tests/analysis/test_compute_efficiency_override.py
+++ b/tests/analysis/test_compute_efficiency_override.py
@@ -1,0 +1,257 @@
+"""V5 follow-up: pin the per-precision per-op compute efficiency override path.
+
+Background: Jetson Orin Nano's ``peak_ops_per_sec`` is the achievable
+peak (cuBLAS Tensor Core 0.85 efficiency baked in via
+``efficiency_factor``), but the shared
+``RooflineAnalyzer._get_compute_efficiency_scale`` curve was calibrated
+for AGX-style spec peaks and returns scale ~1.5 for large matmul. The
+mismatch over-predicted Orin Nano compute throughput by 2.4x. This PR
+adds a per-mapper override:
+
+  * ``HardwareResourceModel.compute_efficiency_overrides_by_op`` --
+    nested dict ``{precision_name: {op_kind: scale}}``.
+  * When set for the analyzer's ``(precision, op_kind)`` pair, the
+    legacy curve is bypassed entirely.
+  * When absent or non-matching, legacy curve fires unchanged.
+
+Tests:
+  * Override fires for matched (precision, op_kind); returns the
+    calibrated scalar
+  * Mismatched precision -> falls through to legacy
+  * Mismatched op kind -> falls through to legacy
+  * Multi-op subgraph -> falls through (override is single-op only)
+  * Empty overrides dict -> legacy curve (existing behavior)
+  * Out-of-range scale rejected at __post_init__
+  * Jetson Orin Nano mapper carries the calibrated values
+"""
+
+import pytest
+
+from graphs.core.structures import (
+    OperationType,
+    SubgraphDescriptor,
+    create_tensor_descriptor,
+)
+from graphs.estimation.roofline import RooflineAnalyzer
+from graphs.hardware.mappers.gpu import (
+    create_h100_sxm5_80gb_mapper,
+    create_jetson_orin_nano_8gb_mapper,
+)
+from graphs.hardware.resource_model import Precision
+
+
+def _make_matmul_subgraph(M: int = 128, K: int = 8192, N: int = 8192) -> SubgraphDescriptor:
+    a = create_tensor_descriptor((M, K), "float16")
+    b = create_tensor_descriptor((K, N), "float16")
+    c = create_tensor_descriptor((M, N), "float16")
+    return SubgraphDescriptor(
+        subgraph_id=1,
+        node_ids=["mm"],
+        node_names=["mm"],
+        operation_types=[OperationType.MATMUL],
+        fusion_pattern="MatMul",
+        total_flops=2 * M * K * N,
+        total_macs=M * K * N,
+        total_input_bytes=2 * M * K + 2 * K * N,
+        total_output_bytes=2 * M * N,
+        total_weight_bytes=0,
+        input_tensors=[a, b],
+        output_tensors=[c],
+        weight_tensors=[],
+    )
+
+
+def _make_linear_subgraph(B: int = 16, IN: int = 4096, OUT: int = 4096) -> SubgraphDescriptor:
+    x = create_tensor_descriptor((B, IN), "float16")
+    w = create_tensor_descriptor((OUT, IN), "float16")
+    y = create_tensor_descriptor((B, OUT), "float16")
+    return SubgraphDescriptor(
+        subgraph_id=2,
+        node_ids=["lin"],
+        node_names=["lin"],
+        operation_types=[OperationType.LINEAR],
+        fusion_pattern="Linear",
+        total_flops=2 * B * IN * OUT,
+        total_macs=B * IN * OUT,
+        total_input_bytes=2 * B * IN,
+        total_output_bytes=2 * B * OUT,
+        total_weight_bytes=2 * OUT * IN,
+        input_tensors=[x],
+        output_tensors=[y],
+        weight_tensors=[w],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Override fires for matched (precision, op_kind)
+# ---------------------------------------------------------------------------
+
+
+def test_orin_nano_fp16_matmul_override_fires():
+    """Jetson Orin Nano FP16 matmul should bypass the legacy curve and
+    return the calibrated 0.70 scalar."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+    sg = _make_matmul_subgraph()
+    scale = analyzer._get_compute_efficiency_scale(sg)
+    assert scale == pytest.approx(0.70), (
+        f"Expected calibrated 0.70 for FP16 matmul on Orin Nano, got {scale}"
+    )
+
+
+def test_orin_nano_fp16_linear_override_fires():
+    """Jetson Orin Nano FP16 linear should bypass the legacy curve and
+    return the calibrated 0.94 scalar (Pareto-optimal point that
+    respects the legacy-path energy-pass floor; see
+    jetson_orin_nano_8gb.py docstring)."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+    sg = _make_linear_subgraph()
+    scale = analyzer._get_compute_efficiency_scale(sg)
+    assert scale == pytest.approx(0.94), (
+        f"Expected calibrated 0.94 for FP16 linear on Orin Nano, got {scale}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Override path skips when precision / op kind doesn't match
+# ---------------------------------------------------------------------------
+
+
+def test_orin_nano_fp32_matmul_falls_through_to_legacy():
+    """FP32 isn't in the override dict, so legacy curve fires.
+    Smoke test: result should NOT be the FP16 0.70 calibrated value."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP32)
+    sg = _make_matmul_subgraph()
+    scale = analyzer._get_compute_efficiency_scale(sg)
+    assert scale != 0.70  # legacy curve, not the FP16 override
+
+
+def test_h100_no_override_uses_legacy():
+    """H100 mapper has no compute_efficiency_overrides_by_op set; the
+    legacy curve must fire (returns the AGX-tuned scale, not None)."""
+    hw = create_h100_sxm5_80gb_mapper().resource_model
+    assert hw.compute_efficiency_overrides_by_op == {}
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+    sg = _make_matmul_subgraph()
+    scale = analyzer._get_compute_efficiency_scale(sg)
+    # Legacy curve for >5G matmul on GPU returns 1.40 -> 1.50 range.
+    assert 1.0 <= scale <= 2.0
+
+
+# ---------------------------------------------------------------------------
+# Override helper: the lookup primitive
+# ---------------------------------------------------------------------------
+
+
+def test_override_helper_returns_none_when_dict_empty():
+    """``_get_compute_efficiency_override`` returns None when the
+    resource model has no overrides set, so the caller falls through."""
+    hw = create_h100_sxm5_80gb_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+    sg = _make_matmul_subgraph()
+    assert analyzer._get_compute_efficiency_override(sg) is None
+
+
+def test_override_helper_returns_none_for_multi_op_subgraph():
+    """Multi-op subgraphs (fused conv+bn+relu, etc.) bypass the
+    single-op override and fall through to the legacy curve (which
+    handles fusion patterns)."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+    sg = _make_matmul_subgraph()
+    # Force multi-op
+    sg.operation_types = [OperationType.MATMUL, OperationType.ELEMENTWISE]
+    assert analyzer._get_compute_efficiency_override(sg) is None
+
+
+def test_override_helper_returns_none_for_unmapped_op_kind():
+    """Op kinds outside {matmul, linear, vector_add} fall through
+    (e.g. CONV2D, REDUCE)."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    # Add a fictional CONV2D override that the helper won't see
+    hw.compute_efficiency_overrides_by_op = {"fp16": {"matmul": 0.70}}
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+    sg = _make_matmul_subgraph()
+    sg.operation_types = [OperationType.CONV2D]
+    assert analyzer._get_compute_efficiency_override(sg) is None
+
+
+# ---------------------------------------------------------------------------
+# Validation: __post_init__ rejects out-of-range scales
+# ---------------------------------------------------------------------------
+
+
+def test_resource_model_rejects_negative_compute_scale():
+    """``compute_efficiency_overrides_by_op`` values must be in (0, 2.0]."""
+    from graphs.hardware.models.edge.jetson_orin_nano_8gb import (
+        jetson_orin_nano_8gb_resource_model,
+    )
+
+    with pytest.raises(ValueError, match=r"compute_efficiency_overrides_by_op"):
+        rm = jetson_orin_nano_8gb_resource_model()
+        rm.compute_efficiency_overrides_by_op = {"fp16": {"matmul": -0.1}}
+        rm.__post_init__()  # re-validate after mutation
+
+
+def test_resource_model_rejects_zero_compute_scale():
+    """Zero is excluded -- the open lower bound prevents
+    division-by-zero downstream when the scale becomes the divisor
+    in compute_time = flops / (peak_flops * scale)."""
+    from graphs.hardware.models.edge.jetson_orin_nano_8gb import (
+        jetson_orin_nano_8gb_resource_model,
+    )
+
+    with pytest.raises(ValueError, match=r"compute_efficiency_overrides_by_op"):
+        rm = jetson_orin_nano_8gb_resource_model()
+        rm.compute_efficiency_overrides_by_op = {"fp16": {"matmul": 0.0}}
+        rm.__post_init__()
+
+
+def test_resource_model_rejects_excessive_compute_scale():
+    """Above 2.0 the override would let predicted compute exceed
+    twice the achievable peak -- almost certainly a calibration bug
+    rather than a legitimate value."""
+    from graphs.hardware.models.edge.jetson_orin_nano_8gb import (
+        jetson_orin_nano_8gb_resource_model,
+    )
+
+    with pytest.raises(ValueError, match=r"compute_efficiency_overrides_by_op"):
+        rm = jetson_orin_nano_8gb_resource_model()
+        rm.compute_efficiency_overrides_by_op = {"fp16": {"matmul": 5.0}}
+        rm.__post_init__()
+
+
+def test_resource_model_accepts_valid_compute_scale():
+    """Sanity: the calibrated 0.70 / 0.85 values pass validation."""
+    from graphs.hardware.models.edge.jetson_orin_nano_8gb import (
+        jetson_orin_nano_8gb_resource_model,
+    )
+
+    rm = jetson_orin_nano_8gb_resource_model()
+    # No exception
+    assert rm.compute_efficiency_overrides_by_op == {
+        "fp16": {"matmul": 0.70, "linear": 0.94}
+    }
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: analyzer compute_time uses the override
+# ---------------------------------------------------------------------------
+
+
+def test_analyzer_compute_time_reflects_override():
+    """compute_time = flops / (peak_flops * scale). On Orin Nano FP16
+    matmul with scale = 0.70, predicted compute_time should equal
+    flops / (peak_flops * 0.70). This is the integration-level check
+    that the override actually flows through to ``_analyze_subgraph``."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+    sg = _make_matmul_subgraph(M=128, K=8192, N=8192)  # ~17.2 GFLOPS
+    flops = sg.flops
+    expected_compute_time = flops / (analyzer.peak_flops * 0.70)
+    actual_scale = analyzer._get_compute_efficiency_scale(sg)
+    assert actual_scale == pytest.approx(0.70)
+    actual_compute_time = flops / (analyzer.peak_flops * actual_scale)
+    assert actual_compute_time == pytest.approx(expected_compute_time, rel=1e-9)

--- a/tests/analysis/test_compute_efficiency_override.py
+++ b/tests/analysis/test_compute_efficiency_override.py
@@ -178,6 +178,74 @@ def test_override_helper_returns_none_for_unmapped_op_kind():
     assert analyzer._get_compute_efficiency_override(sg) is None
 
 
+def test_override_helper_skips_non_strict_elementwise():
+    """ELEMENTWISE op kinds that aren't strict vector_add (e.g. ReLU
+    with one input + one output, or 2-D shapes) must NOT pick up a
+    ``vector_add`` override. The strict gate is the same predicate
+    ``_try_tier_aware_memory_time`` uses for the V5-3a vector_add
+    reuse model."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    # Register a hypothetical vector_add override -- without the
+    # strict gate, ReLU would silently inherit it.
+    hw.compute_efficiency_overrides_by_op = {
+        "fp16": {"vector_add": 0.55},
+    }
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+
+    # Build a 1-input ReLU-style elementwise subgraph (2 tensors, not
+    # 3 -- vector_add needs ``a + b -> c``).
+    x = create_tensor_descriptor((1024,), "float16")
+    y = create_tensor_descriptor((1024,), "float16")
+    sg = SubgraphDescriptor(
+        subgraph_id=99,
+        node_ids=["relu"],
+        node_names=["relu"],
+        operation_types=[OperationType.ELEMENTWISE],
+        fusion_pattern="ReLU",
+        total_flops=1024,
+        total_macs=0,
+        total_input_bytes=1024 * 2,
+        total_output_bytes=1024 * 2,
+        total_weight_bytes=0,
+        input_tensors=[x],  # 1 input -- not vector_add
+        output_tensors=[y],
+        weight_tensors=[],
+    )
+    assert analyzer._get_compute_efficiency_override(sg) is None, (
+        "ReLU (1 input) must not inherit a vector_add override"
+    )
+
+
+def test_override_helper_fires_for_strict_vector_add():
+    """The positive case: a 3-tensor 1-D vector_add layout DOES pick
+    up the override."""
+    hw = create_jetson_orin_nano_8gb_mapper().resource_model
+    hw.compute_efficiency_overrides_by_op = {
+        "fp16": {"vector_add": 0.55},
+    }
+    analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
+
+    a = create_tensor_descriptor((1024,), "float16")
+    b = create_tensor_descriptor((1024,), "float16")
+    c = create_tensor_descriptor((1024,), "float16")
+    sg = SubgraphDescriptor(
+        subgraph_id=100,
+        node_ids=["va"],
+        node_names=["va"],
+        operation_types=[OperationType.ELEMENTWISE],
+        fusion_pattern="Add",
+        total_flops=1024,
+        total_macs=0,
+        total_input_bytes=2 * 1024 * 2,
+        total_output_bytes=1024 * 2,
+        total_weight_bytes=0,
+        input_tensors=[a, b],
+        output_tensors=[c],
+        weight_tensors=[],
+    )
+    assert analyzer._get_compute_efficiency_override(sg) == pytest.approx(0.55)
+
+
 # ---------------------------------------------------------------------------
 # Validation: __post_init__ rejects out-of-range scales
 # ---------------------------------------------------------------------------
@@ -242,16 +310,34 @@ def test_resource_model_accepts_valid_compute_scale():
 
 
 def test_analyzer_compute_time_reflects_override():
-    """compute_time = flops / (peak_flops * scale). On Orin Nano FP16
-    matmul with scale = 0.70, predicted compute_time should equal
-    flops / (peak_flops * 0.70). This is the integration-level check
-    that the override actually flows through to ``_analyze_subgraph``."""
+    """End-to-end: ``_analyze_subgraph`` uses the override-derived scale.
+
+    The override is read inside ``_get_compute_efficiency_scale``, then
+    consumed by ``_analyze_subgraph`` via:
+        effective_peak_flops = self.peak_flops * compute_efficiency_scale
+        compute_time = flops / effective_peak_flops
+    On Orin Nano FP16 matmul with scale = 0.70, the actual ``compute_time``
+    on the returned ``LatencyDescriptor`` must equal
+    ``flops / (peak_flops * 0.70)``. This pins both the override path
+    AND the analyzer's consumption of the result, not just the helper
+    in isolation."""
     hw = create_jetson_orin_nano_8gb_mapper().resource_model
     analyzer = RooflineAnalyzer(hw, precision=Precision.FP16)
     sg = _make_matmul_subgraph(M=128, K=8192, N=8192)  # ~17.2 GFLOPS
     flops = sg.flops
-    expected_compute_time = flops / (analyzer.peak_flops * 0.70)
+
+    # Sanity: the helper returns the calibrated scale.
     actual_scale = analyzer._get_compute_efficiency_scale(sg)
     assert actual_scale == pytest.approx(0.70)
-    actual_compute_time = flops / (analyzer.peak_flops * actual_scale)
-    assert actual_compute_time == pytest.approx(expected_compute_time, rel=1e-9)
+
+    # Integration: the analyzer's _analyze_subgraph (which is what
+    # produces real predictions) must also pick up the override.
+    latency_desc = analyzer._analyze_subgraph(sg)
+    expected_compute_time = flops / (analyzer.peak_flops * 0.70)
+    assert latency_desc.compute_time == pytest.approx(
+        expected_compute_time, rel=1e-9
+    ), (
+        f"Analyzer compute_time {latency_desc.compute_time*1e3:.4f} ms "
+        f"does not match expected {expected_compute_time*1e3:.4f} ms; "
+        f"override may not flow through to _analyze_subgraph."
+    )


### PR DESCRIPTION
## Summary

Closes Category 3 from PR #115's Jetson Orin Nano calibration analysis: the **compute model under-derate**. Adds `HardwareResourceModel.compute_efficiency_overrides_by_op` -- a per-(precision, op_kind) calibration that bypasses the shared `_get_compute_efficiency_scale` curve when the mapper supplies one.

## Why

The legacy 240-line `_get_compute_efficiency_scale` was tuned for **Jetson Orin AGX (50W, conv2d, cuDNN+TF32)** where `peak_flops` is the spec peak. For large matmul it returns scale ~1.48 to compensate for the spec-vs-effective gap.

But Jetson Orin Nano's `peak_flops = 7.10 TFLOPS` is **already the achievable peak** (cuBLAS Tensor Core 0.85 efficiency baked in via `efficiency_factor`). Multiplying that by 1.48 predicts compute throughput at 10.5 TFLOPS -- 25% above spec, **2.4x above measured cuBLAS achievable**. This forces matmul/linear shapes that actually run alu_bound to look dram_bound in the model.

Per-shape probe of the 20 large-matmul shapes shows the model is 2.4x too optimistic; measured efficiency range 0.36-0.90, median 0.66.

## What changed

```python
# HardwareResourceModel
compute_efficiency_overrides_by_op: Dict[str, Dict[str, float]]
# Outer key: precision name ("fp16", ...)
# Inner key: op kind ("matmul", "linear", "vector_add")
# Value: scale to use (range (0, 2.0])

# Jetson Orin Nano calibration
{"fp16": {"matmul": 0.70, "linear": 0.94}}
```

`_get_compute_efficiency_scale` checks the override first; falls through to the legacy curve when no override is registered.

## V4 floor impact

| metric | baseline | this PR | delta |
|---|---|---|---|
| jetson matmul lat-pass (tier-aware) | 22 | **30** | +8 |
| jetson matmul lat-pass (legacy) | 18 | **26** | +8 |
| jetson linear lat-pass (tier-aware) | 18 | **30** | +12 |
| jetson linear lat-pass (legacy) | 18 | **25** | +7 |
| i7 (all) | unchanged | unchanged | 0 |
| jetson vector_add | unchanged | unchanged | 0 |

## V4 PASS still 0 on Jetson

V4 PASS = `pass_regime AND pass_latency`. Jetson is gated by `pass_regime` because the **sweep file's pre-computed regime classifications** disagree with the measured regime on 44/48 matmul / 45/46 linear shapes. Regenerating the sweep with the V5 model is a separate task. This PR's lat-pass gain is the upstream signal for when that lands.

## Why linear = 0.94 not 0.85

Pure latency-pass on the tier-aware path picks 0.85, but V4 floor tests run on the LEGACY memory path (`RunnerConfig.use_tier_aware_memory` defaults False), and on that path 0.85 regresses energy-pass below the test floor (27):

```
LEGACY path linear sweep:
   0.85   lat=28  egy=24   ← peak lat, fails energy floor
   0.93   lat=25  egy=27   ← matches floor
   0.94   lat=25  egy=28   ← +1 headroom; ships here
   1.00   lat=22  egy=28
```

When `RunnerConfig` defaults catch up with V5-3b production (tier-aware), the optimal point shifts back to ~0.85. See `docs/v5/jetson-compute-efficiency-derate.md` for the per-shape calibration data and full sweep tables.

## Test plan

- [x] 12 new unit tests in `tests/analysis/test_compute_efficiency_override.py` (override fires / falls through / range validation / end-to-end compute_time)
- [x] Existing V4 baseline tests still green (energy floor 27 met)
- [x] Full suite: 2100 passed, 11 skipped, 5 xfailed
- [x] V4 floor parity verified for i7 + Jetson on matmul + linear + vector_add (i7 byte-identical)

## Cross-link

- Analysis: `docs/v5/jetson-compute-efficiency-derate.md` (new)
- Updated: `docs/calibration/jetson-orin-nano-calibration-analysis.md` (Category 3 marked addressed)
- PR #115 (analysis), #116 (Category 1 dispatch overhead), #117 (Category 2 aspect-ratio skinny)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced compute efficiency calibration for Jetson Orin Nano 8GB, improving latency prediction accuracy for compute-intensive operations.

* **Documentation**
  * Updated Jetson Orin Nano calibration analysis with detailed baseline verification.
  * Added documentation on compute efficiency refinements and their impact on prediction accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->