### PR TITLE
fix(precision): consolidate Precision enum to a single canonical class

### DIFF
--- a/src/graphs/benchmarks/schema.py
+++ b/src/graphs/benchmarks/schema.py
@@ -66,16 +66,9 @@ class LayerTag(Enum):
     COMPOSITE = "composite"
 
 
-class Precision(Enum):
-    """Supported numerical precisions"""
-    FP64 = "fp64"
-    FP32 = "fp32"
-    TF32 = "tf32"
-    FP16 = "fp16"
-    BF16 = "bf16"
-    FP8 = "fp8"
-    INT8 = "int8"
-    INT4 = "int4"
+# Re-export the canonical Precision enum (issue #59) so benchmark
+# specs share one class identity with the hardware catalog.
+from graphs.hardware.resource_model import Precision  # noqa: E402,F401
 
 
 class DeviceType(Enum):

--- a/src/graphs/calibration/precision_detector.py
+++ b/src/graphs/calibration/precision_detector.py
@@ -9,26 +9,7 @@ import numpy as np
 import sys
 from typing import List, Tuple, Optional
 
-
-# Import Precision enum from resource_model
-try:
-    from ..resource_model import Precision
-except ImportError:
-    # Fallback: define locally if import fails
-    from enum import Enum
-    class Precision(Enum):
-        FP64 = "fp64"
-        FP32 = "fp32"
-        TF32 = "tf32"  # NVIDIA TensorFloat-32, Tensor Cores only
-        FP16 = "fp16"
-        BF16 = "bf16"
-        FP8_E4M3 = "fp8_e4m3"
-        FP8_E5M2 = "fp8_e5m2"
-        INT64 = "int64"
-        INT32 = "int32"
-        INT16 = "int16"
-        INT8 = "int8"
-        INT4 = "int4"
+from graphs.hardware.resource_model import Precision
 
 
 def test_numpy_precision(precision: Precision, numpy_dtype) -> Tuple[bool, Optional[str]]:

--- a/src/graphs/estimation/workload_characterization.py
+++ b/src/graphs/estimation/workload_characterization.py
@@ -14,20 +14,11 @@ This separation enables accurate hardware mapping and energy modeling.
 
 from dataclasses import dataclass, field
 from typing import Optional, Dict, Any
-from enum import Enum
 
-
-class Precision(Enum):
-    """Numerical precision types"""
-    FP64 = "fp64"
-    FP32 = "fp32"
-    FP16 = "fp16"
-    BF16 = "bf16"
-    INT32 = "int32"
-    INT16 = "int16"
-    INT8 = "int8"
-    INT4 = "int4"
-    MIXED = "mixed"  # Mixed precision
+# Re-export the canonical Precision enum so module-boundary lookups
+# (e.g. mcp/server.py -> hardware/mappers/* precision_profiles dicts)
+# operate on the same class object. Issue #59.
+from graphs.hardware.resource_model import Precision  # noqa: F401
 
 
 @dataclass

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -1268,8 +1268,27 @@ class HardwareResourceModel:
     # THEORETICAL to INTERPOLATED or CALIBRATED.
     field_provenance: Dict[str, EstimationConfidence] = field(default_factory=dict)
 
-    def _unsupported_precision_error(self, precision: Precision) -> ValueError:
+    def _unsupported_precision_error(self, precision: "Precision") -> ValueError:
         supported = sorted(p.name.lower() for p in self.precision_profiles)
+        # Dual-enum diagnostic (issue #59): if the requested precision
+        # has the same value as one of the catalog members but is from a
+        # different Enum class, the dict lookup silently misses. Surface
+        # the class identity so the bug is obvious instead of
+        # self-contradicting.
+        catalog_cls = type(next(iter(self.precision_profiles))) if self.precision_profiles else None
+        if (
+            catalog_cls is not None
+            and not isinstance(precision, catalog_cls)
+            and any(p.value == precision.value for p in self.precision_profiles)
+        ):
+            req_cls = type(precision)
+            return ValueError(
+                f"{self.name}: precision {precision.name.lower()} came from "
+                f"{req_cls.__module__}.{req_cls.__name__} but the catalog "
+                f"keys are {catalog_cls.__module__}.{catalog_cls.__name__}; "
+                f"the value matches but the Enum classes differ. "
+                f"Import Precision from graphs.hardware.resource_model."
+            )
         return ValueError(
             f"{self.name} does not support {precision.name.lower()} -- "
             f"supported precisions are: {', '.join(supported) if supported else '(none)'}"

--- a/src/graphs/mcp/server.py
+++ b/src/graphs/mcp/server.py
@@ -51,7 +51,9 @@ def _get_registry():
 
 def _precision_enum(name: str):
     """Convert a precision string like 'fp16' to the Precision enum value."""
-    from graphs.estimation.workload_characterization import Precision
+    # Use the canonical Precision so dict lookups against
+    # HardwareResourceModel.precision_profiles succeed (issue #59).
+    from graphs.hardware.resource_model import Precision
 
     mapping = {p.value: p for p in Precision}
     key = name.lower()

--- a/src/graphs/reporting/baseline_alu_energy.py
+++ b/src/graphs/reporting/baseline_alu_energy.py
@@ -50,6 +50,12 @@ from typing import Dict
 from graphs.core.confidence import ConfidenceLevel, EstimationConfidence
 from graphs.hardware.technology_profile import TechnologyProfile
 
+# Re-export the canonical Precision enum (issue #59). The baseline
+# model only treats FP32/FP16/INT8, but it must use the same enum
+# class as the hardware catalog so that callers passing the canonical
+# member find their entry in this module's scaling dict.
+from graphs.hardware.resource_model import Precision  # noqa: F401
+
 
 # --------------------------------------------------------------------
 # Op kinds, precisions
@@ -59,12 +65,6 @@ class OpKind(Enum):
     FADD = "FADD"   # 2-source floating add
     FMUL = "FMUL"   # 2-source floating multiply
     FMA  = "FMA"    # 3-source fused multiply-add (1 FMA = 2 FLOPS)
-
-
-class Precision(Enum):
-    FP32 = "fp32"
-    FP16 = "fp16"
-    INT8 = "int8"
 
 
 # Sources per op kind (for FF read count in baseline).
@@ -208,6 +208,12 @@ def _alu_energies_pj(
     using the Horowitz ratios; precision narrows the ALU width.
     """
     base_fma_fp32 = profile.base_alu_energy_pj  # canonical fp32 FMA
+    if precision not in _PRECISION_ALU_SCALE:
+        supported = sorted(p.name for p in _PRECISION_ALU_SCALE)
+        raise ValueError(
+            f"baseline_alu_energy only models {', '.join(supported)}; "
+            f"got {precision.name}"
+        )
     prec_scale = _PRECISION_ALU_SCALE[precision]
 
     if op_kind is OpKind.FADD:

--- a/tests/reporting/test_baseline_alu_energy.py
+++ b/tests/reporting/test_baseline_alu_energy.py
@@ -27,7 +27,10 @@ from graphs.reporting.baseline_alu_energy import (
 
 
 _ALL_OPS = list(OpKind)
-_ALL_PRECS = list(Precision)
+# The baseline ALU model documents three precisions (FP32, FP16, INT8).
+# Precision is now the canonical 14-member enum, so enumerate the
+# supported subset explicitly rather than `list(Precision)`.
+_ALL_PRECS = [Precision.FP32, Precision.FP16, Precision.INT8]
 
 
 class TestStructure:

--- a/tests/reporting/test_gpu_simt_energy.py
+++ b/tests/reporting/test_gpu_simt_energy.py
@@ -32,7 +32,10 @@ from graphs.reporting.gpu_simt_energy import (
 
 
 _ALL_OPS = list(OpKind)
-_ALL_PRECS = list(Precision)
+# gpu_simt_energy is built on baseline_alu_energy, which only models
+# FP32 / FP16 / INT8. Precision is now the canonical 14-member enum,
+# so enumerate the supported subset explicitly. Issue #59.
+_ALL_PRECS = [Precision.FP32, Precision.FP16, Precision.INT8]
 
 
 class TestPipelineStructure:

--- a/tests/test_precision_enum_identity.py
+++ b/tests/test_precision_enum_identity.py
@@ -1,0 +1,88 @@
+"""Regression tests for issue #59.
+
+The graphs repo previously had five independent ``class Precision(Enum)``
+declarations, two of which sat on the MCP analyze hot path:
+
+    mcp/server.py             -> workload_characterization.Precision
+    hardware/mappers/kpu_t64  -> hardware.resource_model.Precision
+
+Because Python enums compare by class identity, ``precision in
+self.precision_profiles`` returned False even when both enums had a
+member with value ``"int8"``. The analyzer then raised a
+self-contradicting "does not support int8 -- supported precisions are:
+... int8 ..." error.
+
+The fix: pick ``graphs.hardware.resource_model.Precision`` as the canonical
+enum and have every other module re-export it. These tests pin that
+contract so the dual-enum bug cannot regress.
+"""
+from graphs.hardware.resource_model import Precision as CanonicalPrecision
+
+
+def test_workload_characterization_precision_is_canonical():
+    from graphs.estimation.workload_characterization import Precision as P
+    assert P is CanonicalPrecision
+
+
+def test_baseline_alu_energy_precision_is_canonical():
+    from graphs.reporting.baseline_alu_energy import Precision as P
+    assert P is CanonicalPrecision
+
+
+def test_benchmarks_schema_precision_is_canonical():
+    from graphs.benchmarks.schema import Precision as P
+    assert P is CanonicalPrecision
+
+
+def test_calibration_precision_detector_precision_is_canonical():
+    from graphs.calibration.precision_detector import Precision as P
+    assert P is CanonicalPrecision
+
+
+def test_mcp_precision_enum_returns_canonical():
+    """The MCP boundary helper must yield the canonical class so that
+    `precision in mapper.precision_profiles` works for KPU-T64 and every
+    other catalog mapper."""
+    from graphs.mcp.server import _precision_enum
+    assert type(_precision_enum("int8")) is CanonicalPrecision
+    assert _precision_enum("int8") is CanonicalPrecision.INT8
+
+
+def test_mcp_int8_keys_kpu_t64_precision_profile():
+    """Issue #59 repro at the data-structure level: bridging 'int8' through
+    the MCP boundary must produce a key the KPU-T64 catalog accepts."""
+    from graphs.mcp.server import _precision_enum
+    from graphs.hardware.models.accelerators.kpu_t64 import (
+        kpu_t64_resource_model,
+    )
+
+    model = kpu_t64_resource_model()
+    precision = _precision_enum("int8")
+    assert precision in model.precision_profiles
+    # And the analyzer-facing accessor returns a profile, not a ValueError.
+    profile = model.get_precision_profile(precision)
+    assert profile.precision is CanonicalPrecision.INT8
+
+
+def test_dual_enum_diagnostic_names_modules():
+    """When a caller passes a same-valued member from a foreign Enum
+    class, the catalog should explain the class mismatch rather than
+    emit the self-contradicting "does not support X -- supported: ... X"
+    message that motivated issue #59."""
+    from enum import Enum
+    from graphs.hardware.models.accelerators.kpu_t64 import (
+        kpu_t64_resource_model,
+    )
+
+    class Precision(Enum):  # foreign, same values
+        INT8 = "int8"
+
+    model = kpu_t64_resource_model()
+    try:
+        model.get_precision_profile(Precision.INT8)
+    except ValueError as e:
+        msg = str(e)
+        assert "Enum classes differ" in msg
+        assert "graphs.hardware.resource_model" in msg
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError for dual-enum mismatch")


### PR DESCRIPTION
## Summary
- Six `class Precision(Enum)` declarations existed; two were on the MCP analyze hot path. Dict lookup `precision in self.precision_profiles` returned False because the enum classes differed by identity, blocking every `mcp analyze` / `mcp compare` call after #57.
- Promote `graphs.hardware.resource_model.Precision` to canonical and re-export it from the four other modules so all module boundaries share one class object.
- Improve `_unsupported_precision_error` to detect dual-enum collisions and emit a diagnostic that names both modules instead of repeating the rejected precision back as "supported".

## Changes
- `src/graphs/hardware/resource_model.py` — canonical Precision; expanded `_unsupported_precision_error` with a dual-enum branch.
- `src/graphs/calibration/precision_detector.py` — fixed broken `..resource_model` relative import (the module lives at `..hardware.resource_model`); removed the dead fallback fork.
- `src/graphs/estimation/workload_characterization.py` — dropped local enum (unused `MIXED` member had no callers).
- `src/graphs/reporting/baseline_alu_energy.py` — dropped local enum; added explicit `ValueError` at the 3-precision scaling dict.
- `src/graphs/benchmarks/schema.py` — dropped local enum (strict subset of canonical).
- `src/graphs/mcp/server.py` — `_precision_enum` now bridges through canonical Precision directly.
- `tests/test_precision_enum_identity.py` (new) — identity assertions across all five modules + KPU-T64 INT8 lookup repro + dual-enum diagnostic test.
- `tests/reporting/test_baseline_alu_energy.py`, `tests/reporting/test_gpu_simt_energy.py` — narrowed `_ALL_PRECS = list(Precision)` to the documented FP32/FP16/INT8 subset (canonical enum exposes 14 members, but these two energy models only treat three).

## Test Results
| Suite | Result |
|---|---|
| `tests/test_precision_enum_identity.py` (new) | 7 passed |
| `tests/reporting/test_baseline_alu_energy.py` | 25 passed |
| `tests/reporting/test_gpu_simt_energy.py` | 30 passed |
| Full `pytest tests/` | 2118 passed, 15 skipped, 5 xfailed |

All four repro commands from the issue now succeed:
- `branes mcp analyze vit_b_16 kpu-t64 -p int8`
- `branes mcp analyze vit_b_16 kpu-t64 -p fp16`
- `branes mcp analyze vit_b_16 jetson-orin-nano-8gb -p int8 --thermal 15W`
- `branes mcp compare vit_b_16 kpu-t64 jetson-orin-nano-8gb -p int8`

The compare invocation produces a side-by-side KPU-T64 vs Jetson Orin Nano table for ViT-B/16 INT8 — the workflow that was completely blocked.

## Test plan
- [x] CI passes
- [x] Reviewer sanity-checks the dual-enum diagnostic message wording
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #59

Generated with [Claude Code](https://claude.com/claude-code)