### PR TITLE
feat(hardware): PhysicalSpec foundation + CLI precision columns

### DIFF
--- a/cli/list_hardware_mappers.py
+++ b/cli/list_hardware_mappers.py
@@ -14,7 +14,7 @@ Usage:
 
 import json
 import argparse
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Optional
 from dataclasses import dataclass, asdict
 
 from graphs.hardware.resource_model import HardwareType, Precision
@@ -28,8 +28,13 @@ class HardwareMapperInfo:
     deployment: str  # Datacenter, Edge, Mobile, Automotive
     manufacturer: str
     compute_units: int
+    peak_flops_fp64: float  # GFLOPS
     peak_flops_fp32: float  # GFLOPS
-    peak_flops_int8: float  # GOPS
+    peak_flops_fp16: float  # GFLOPS
+    peak_flops_fp8: float   # GFLOPS
+    peak_flops_int32: float  # GOPS
+    peak_flops_int16: float  # GOPS
+    peak_flops_int8: float   # GOPS
     memory_bandwidth: float  # GB/s
     power_tdp: float  # Watts
     thermal_profiles: List[str]
@@ -52,6 +57,34 @@ def _safe_peak_gflops(mapper, precision: Precision) -> float:
         return mapper.resource_model.get_peak_ops(precision) / 1e9
     except ValueError:
         return 0.0
+
+
+_PRECISION_COLUMNS = (
+    ("peak_flops_fp64", Precision.FP64),
+    ("peak_flops_fp32", Precision.FP32),
+    ("peak_flops_fp16", Precision.FP16),
+    ("peak_flops_fp8", Precision.FP8),
+    ("peak_flops_int32", Precision.INT32),
+    ("peak_flops_int16", Precision.INT16),
+    ("peak_flops_int8", Precision.INT8),
+)
+
+
+def _populate_precisions(mapper) -> Dict[str, float]:
+    """Build the seven peak-throughput fields for ``HardwareMapperInfo`` in one shot.
+
+    Returns 0.0 for any precision the resource model does not natively list (see
+    ``_safe_peak_gflops``). The ``peak_flops_fp8`` column reports the max of the
+    generic FP8 enum and the two IEEE FP8 variants (E4M3 / E5M2), since most
+    resource models register the variants but not the generic enum.
+    """
+    out = {field: _safe_peak_gflops(mapper, prec) for field, prec in _PRECISION_COLUMNS}
+    out["peak_flops_fp8"] = max(
+        _safe_peak_gflops(mapper, Precision.FP8),
+        _safe_peak_gflops(mapper, Precision.FP8_E4M3),
+        _safe_peak_gflops(mapper, Precision.FP8_E5M2),
+    )
+    return out
 
 
 def _get_tdp_from_mapper(mapper) -> float:
@@ -111,8 +144,7 @@ def discover_cpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="Intel",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -129,8 +161,7 @@ def discover_cpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="Intel",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -147,8 +178,7 @@ def discover_cpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="Intel",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -165,8 +195,7 @@ def discover_cpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="AMD",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -183,8 +212,7 @@ def discover_cpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="AMD",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -201,8 +229,7 @@ def discover_cpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="AMD",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -219,8 +246,7 @@ def discover_cpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="Ampere",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -237,8 +263,7 @@ def discover_cpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="Ampere",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -255,8 +280,7 @@ def discover_cpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Desktop",
         manufacturer="Intel",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -273,8 +297,7 @@ def discover_cpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Edge",
         manufacturer="NVIDIA",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -311,8 +334,7 @@ def discover_gpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="NVIDIA",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -329,8 +351,7 @@ def discover_gpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="NVIDIA",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -347,8 +368,7 @@ def discover_gpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="NVIDIA",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -365,8 +385,7 @@ def discover_gpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="NVIDIA",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -383,8 +402,7 @@ def discover_gpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="NVIDIA",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -401,8 +419,7 @@ def discover_gpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="NVIDIA",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=mapper.resource_model.thermal_operating_points[mapper.resource_model.default_thermal_profile].tdp_watts,
         thermal_profiles=list(mapper.resource_model.thermal_operating_points.keys()),
@@ -419,8 +436,7 @@ def discover_gpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Edge",
         manufacturer="NVIDIA",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -437,8 +453,7 @@ def discover_gpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Edge",
         manufacturer="NVIDIA",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -455,8 +470,7 @@ def discover_gpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Automotive",
         manufacturer="NVIDIA",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -473,8 +487,7 @@ def discover_gpu_mappers() -> List[HardwareMapperInfo]:
         deployment="Mobile",
         manufacturer="ARM",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -503,8 +516,7 @@ def discover_dsp_mappers() -> List[HardwareMapperInfo]:
         deployment="Edge",
         manufacturer="Qualcomm",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -521,8 +533,7 @@ def discover_dsp_mappers() -> List[HardwareMapperInfo]:
         deployment="Automotive",
         manufacturer="Texas Instruments",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -562,8 +573,7 @@ def discover_accelerator_mappers() -> List[HardwareMapperInfo]:
         deployment="Datacenter",
         manufacturer="Google",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -580,8 +590,7 @@ def discover_accelerator_mappers() -> List[HardwareMapperInfo]:
         deployment="Edge",
         manufacturer="Google",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=0.0,  # INT8 only
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -598,8 +607,7 @@ def discover_accelerator_mappers() -> List[HardwareMapperInfo]:
         deployment="Embodied AI",
         manufacturer="Stillwater",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=0.0,  # INT8 primary
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -616,8 +624,7 @@ def discover_accelerator_mappers() -> List[HardwareMapperInfo]:
         deployment="Embodied AI",
         manufacturer="Stillwater",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=0.0,  # INT8 primary
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -634,8 +641,7 @@ def discover_accelerator_mappers() -> List[HardwareMapperInfo]:
         deployment="Embodied AI",
         manufacturer="Stillwater",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=0.0,  # INT8 primary
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -652,8 +658,7 @@ def discover_accelerator_mappers() -> List[HardwareMapperInfo]:
         deployment="Edge/Datacenter",
         manufacturer="AMD/Xilinx",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=0.0,  # INT8 only
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -670,8 +675,7 @@ def discover_accelerator_mappers() -> List[HardwareMapperInfo]:
         deployment="Research",
         manufacturer="Stanford",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -688,8 +692,7 @@ def discover_accelerator_mappers() -> List[HardwareMapperInfo]:
         deployment="Edge",
         manufacturer="Hailo",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=0.0,  # INT8 only
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -706,8 +709,7 @@ def discover_accelerator_mappers() -> List[HardwareMapperInfo]:
         deployment="Automotive",
         manufacturer="Hailo",
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp32=0.0,  # INT8 only
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        **_populate_precisions(mapper),
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
         power_tdp=_get_tdp_from_mapper(mapper),
         thermal_profiles=_get_thermal_profiles(mapper),
@@ -758,11 +760,22 @@ def generate_text_report(all_mappers: List[HardwareMapperInfo], category_filter:
             print()
 
             for mapper in sorted(dep_mappers, key=lambda x: x.peak_flops_int8, reverse=True):
-                print(f"  • {mapper.name}")
+                print(f"  - {mapper.name}")
                 print(f"    Manufacturer: {mapper.manufacturer}")
                 print(f"    Compute Units: {mapper.compute_units}")
-                print(f"    Peak FP32: {mapper.peak_flops_fp32:.1f} GFLOPS" if mapper.peak_flops_fp32 > 0 else "    Peak FP32: N/A")
-                print(f"    Peak INT8: {mapper.peak_flops_int8:.1f} GOPS")
+                peak_parts = []
+                for label, value in [
+                    ("FP64", mapper.peak_flops_fp64),
+                    ("FP32", mapper.peak_flops_fp32),
+                    ("FP16", mapper.peak_flops_fp16),
+                    ("FP8",  mapper.peak_flops_fp8),
+                    ("INT32", mapper.peak_flops_int32),
+                    ("INT16", mapper.peak_flops_int16),
+                    ("INT8",  mapper.peak_flops_int8),
+                ]:
+                    if value > 0:
+                        peak_parts.append(f"{label}={value:.1f}")
+                print(f"    Peak (G[FL]OPS): {'  '.join(peak_parts) if peak_parts else 'N/A'}")
                 print(f"    Memory BW: {mapper.memory_bandwidth:.1f} GB/s")
                 print(f"    Power (TDP): {mapper.power_tdp:.1f} W")
                 if mapper.thermal_profiles:
@@ -780,9 +793,10 @@ def generate_text_report(all_mappers: List[HardwareMapperInfo], category_filter:
         print()
 
     # Overall comparison table (segmented by deployment)
-    print("=" * 100)
-    print("PERFORMANCE COMPARISON (by Deployment)")
-    print("=" * 100)
+    table_width = 130
+    print("=" * table_width)
+    print("PEAK THROUGHPUT BY PRECISION (TFLOPS / TOPS) -- segmented by Deployment")
+    print("=" * table_width)
     print()
 
     # Group by deployment
@@ -804,6 +818,13 @@ def generate_text_report(all_mappers: List[HardwareMapperInfo], category_filter:
         "Research"
     ]
 
+    header = (
+        f"{'Hardware':<35}{'Cat':<6}"
+        f"{'FP64':>9}{'FP32':>9}{'FP16':>9}{'FP8':>9}"
+        f"{'INT32':>9}{'INT16':>9}{'INT8':>9}"
+        f"{'TDP(W)':>10}{'TOPS/W':>10}"
+    )
+
     # Print each deployment segment
     for deployment in deployment_order:
         if deployment not in deployment_groups:
@@ -813,20 +834,31 @@ def generate_text_report(all_mappers: List[HardwareMapperInfo], category_filter:
 
         print(f"--- {deployment} ({len(mappers)} devices) ---")
         print()
-        print(f"{'Hardware':<35} {'Category':<8} {'INT8 TOPS':<12} {'Power (W)':<10} {'Efficiency (TOPS/W)':<15}")
-        print("-" * 100)
+        print(header)
+        print("-" * table_width)
 
         # Sort by INT8 TOPS within deployment
         for mapper in sorted(mappers, key=lambda x: x.peak_flops_int8, reverse=True):
             int8_tops = mapper.peak_flops_int8 / 1000
             efficiency = int8_tops / mapper.power_tdp if mapper.power_tdp > 0 else 0
-            print(f"{mapper.name:<35} {mapper.category:<8} {int8_tops:<12.1f} {mapper.power_tdp:<10.1f} {efficiency:<15.2f}")
+            row = (
+                f"{mapper.name:<35}{mapper.category:<6}"
+                f"{mapper.peak_flops_fp64/1000:>9.1f}"
+                f"{mapper.peak_flops_fp32/1000:>9.1f}"
+                f"{mapper.peak_flops_fp16/1000:>9.1f}"
+                f"{mapper.peak_flops_fp8/1000:>9.1f}"
+                f"{mapper.peak_flops_int32/1000:>9.1f}"
+                f"{mapper.peak_flops_int16/1000:>9.1f}"
+                f"{mapper.peak_flops_int8/1000:>9.1f}"
+                f"{mapper.power_tdp:>10.1f}{efficiency:>10.2f}"
+            )
+            print(row)
 
         print()
 
-    print("=" * 100)
+    print("=" * table_width)
     print(f"Total: {len(all_mappers)} hardware mappers available")
-    print("=" * 100)
+    print("=" * table_width)
 
 
 def generate_json_report(all_mappers: List[HardwareMapperInfo], category_filter: Optional[str] = None):

--- a/cli/list_hardware_mappers.py
+++ b/cli/list_hardware_mappers.py
@@ -12,10 +12,14 @@ Usage:
     python cli/list_hardware_mappers.py --format json
 """
 
+import csv
 import json
+import os
+import sys
 import argparse
+import contextlib
 from typing import Dict, List, Optional
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, fields
 
 from graphs.hardware.resource_model import HardwareType, Precision
 
@@ -891,23 +895,85 @@ def generate_json_report(all_mappers: List[HardwareMapperInfo], category_filter:
     print(json.dumps(report, indent=2))
 
 
+def generate_csv_report(all_mappers: List[HardwareMapperInfo], category_filter: Optional[str] = None):
+    """Generate a CSV report: one row per mapper, columns are the dataclass fields.
+
+    list[str] fields (thermal_profiles, use_cases) are joined with ``;`` so each
+    cell stays single-valued. Written to stdout; main() routes via redirection
+    when ``--output FILE.csv`` is given.
+    """
+    if category_filter:
+        all_mappers = [m for m in all_mappers if m.category.lower() == category_filter.lower()]
+
+    field_names = [f.name for f in fields(HardwareMapperInfo)]
+    writer = csv.writer(sys.stdout)
+    writer.writerow(field_names)
+    for mapper in all_mappers:
+        row = []
+        for name in field_names:
+            value = getattr(mapper, name)
+            if isinstance(value, list):
+                value = ";".join(str(v) for v in value)
+            row.append(value)
+        writer.writerow(row)
+
+
+# Format auto-detection table for --output. Markdown is rendered as text since
+# the comparison table is already valid Markdown.
+_EXT_TO_FORMAT = {
+    ".json": "json",
+    ".csv": "csv",
+    ".md": "text",
+    ".markdown": "text",
+    ".txt": "text",
+}
+
+
+def _resolve_format(output_path: Optional[str], explicit_format: str) -> str:
+    """Pick the output format. Extension wins for ``--output FILE.ext``;
+    ``--format`` provides the explicit override and the stdout default."""
+    if output_path:
+        ext = os.path.splitext(output_path)[1].lower()
+        if ext in _EXT_TO_FORMAT:
+            return _EXT_TO_FORMAT[ext]
+        # Unknown extension: fall back to --format
+    return explicit_format
+
+
+def _emit_report(
+    fmt: str,
+    all_mappers: List[HardwareMapperInfo],
+    category_filter: Optional[str],
+):
+    """Dispatch to the right generator. Each generator prints to stdout; the
+    caller can redirect stdout to a file via contextlib.redirect_stdout."""
+    if fmt == "json":
+        generate_json_report(all_mappers, category_filter)
+    elif fmt == "csv":
+        generate_csv_report(all_mappers, category_filter)
+    else:
+        generate_text_report(all_mappers, category_filter)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Discover and report on all available hardware mappers",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # List all mappers
+  # List all mappers (text, stdout)
   python cli/list_hardware_mappers.py
 
   # List only CPUs
   python cli/list_hardware_mappers.py --category cpu
 
-  # List only accelerators
-  python cli/list_hardware_mappers.py --category tpu
-
-  # Generate JSON report
+  # Generate JSON report (format from --format flag, stdout)
   python cli/list_hardware_mappers.py --format json
+
+  # Write report to a file -- format auto-detected from extension
+  python cli/list_hardware_mappers.py --output mappers.json
+  python cli/list_hardware_mappers.py --output mappers.csv
+  python cli/list_hardware_mappers.py --output mappers.md
         """
     )
 
@@ -919,9 +985,14 @@ Examples:
 
     parser.add_argument(
         "--format",
-        choices=["text", "json"],
+        choices=["text", "json", "csv"],
         default="text",
-        help="Output format (default: text)"
+        help="Output format. Used as default for stdout and as override when --output extension is unrecognized (default: text)"
+    )
+
+    parser.add_argument(
+        "--output",
+        help="Output file path. Format auto-detected from extension (.json, .csv, .md, .txt). Overridden by --format if extension is unrecognized."
     )
 
     args = parser.parse_args()
@@ -933,11 +1004,15 @@ Examples:
     all_mappers.extend(discover_dsp_mappers())
     all_mappers.extend(discover_accelerator_mappers())
 
-    # Generate report
-    if args.format == "json":
-        generate_json_report(all_mappers, args.category)
+    fmt = _resolve_format(args.output, args.format)
+
+    if args.output:
+        with open(args.output, "w", newline="") as fh:
+            with contextlib.redirect_stdout(fh):
+                _emit_report(fmt, all_mappers, args.category)
+        print(f"Wrote {fmt} report to {args.output}", file=sys.stderr)
     else:
-        generate_text_report(all_mappers, args.category)
+        _emit_report(fmt, all_mappers, args.category)
 
 
 if __name__ == "__main__":

--- a/docs/assessments/compute-product-unification.md
+++ b/docs/assessments/compute-product-unification.md
@@ -1,0 +1,253 @@
+# Assessment: Unified ComputeProduct Schema for embodied-schemas
+
+**Date:** 2026-05-08
+**Context:** While extending `cli/list_hardware_mappers.py` to report die size and
+transistor count alongside peak throughput, we surfaced a structural problem in
+`embodied-schemas`: the `DieSpec` data we want (transistors, die size, foundry,
+process node) is only defined and populated for GPUs. CPU/NPU/SoC schemas don't
+even have those fields. This assessment captures the architectural conversation
+about whether to unify the per-category schemas into a single `ComputeProduct`
+schema, and what that migration would look like.
+
+---
+
+## Survey results: how badly is the data fragmented today?
+
+### `embodied-schemas` data coverage (74 total YAML files)
+
+| Type | Files | `transistors_billion` | `die_size_mm2` | Process node |
+|------|-------|-----------------------|----------------|--------------|
+| GPUs | 22 | 22/22 | 22/22 | `process_nm` int + `process_name` |
+| CPUs | 36 | 0/36 | 0/36 | `process_node` enum only |
+| NPUs | 4 | 0/4 | 0/4 | (none) |
+| SoCs/Chips | 12 | 0/12 | 0/12 | `process_node_nm` only |
+
+GPU YAMLs are gold-standard. H100 has die size 814 mm², 80B transistors, TSMC N4,
+foundry, launch date, MSRP, full FP/INT peak tables. **The schema (`DieSpec`)
+only exists for GPUs**: CPU/NPU/Chip Pydantic models in embodied-schemas don't
+define `transistors_billion` or `die_size_mm2` fields at all.
+
+### `hardware_registry/` (graphs repo) coverage
+
+51 spec.json files. **Zero** have structured die size, transistor count, or
+process node. One file (B100) mentions transistors in free-text notes. Schema is
+purely operational: `ops_per_clock`, `theoretical_peaks`, `peak_bandwidth_gbps`,
+`compute_units`, `tdp_watts`, clocks.
+
+### Cross-repo wiring
+
+`grep -rn "base_id\|embodied_schemas" src/graphs/hardware/` returns zero matches.
+CLAUDE.md describes `base_id` linkage to embodied-schemas as the intended
+architecture, but it isn't implemented in code. No mapper has any reference to
+its embodied-schemas counterpart today.
+
+---
+
+## Why the schemas are split today
+
+The categorical split looks like a historical artifact of how data was
+bootstrapped, not a deliberate architectural choice:
+
+- Each vendor publishes datasheets organized by product category (Intel ARK,
+  NVIDIA GPU pages, Hailo NPU pages). Mirroring those pages into category-shaped
+  Pydantic models was the path of least resistance.
+- Each category emphasizes different facets in vendor marketing: CPUs talk about
+  P-cores/E-cores/cache levels, GPUs about SMs/tensor cores, NPUs about TOPS.
+- Schemas grew up at different times. `gpu.py` got a real `DieSpec`; `cpu.py`
+  only got a `process_node` enum. Nobody backfilled.
+
+The cost is now visible:
+- DieSpec only exists on GPU; the same field set isn't reachable for
+  CPUs/NPUs/SoCs even though the underlying physics is identical.
+- Field names diverge: `process_nm` (GPU) vs `process_node` enum (CPU) vs
+  `process_node_nm` (Chip).
+- Bug fixes don't propagate. A `PowerSpec` definition in `gpu.py` is independent
+  of the `PowerSpec` in `cpu.py`.
+
+---
+
+## The industry has already moved past clean categories
+
+Modern compute products defy the categorical split:
+
+| Product | What is it? |
+|---------|-------------|
+| Apple M3 Max | CPU + GPU + NPU + media engines, one die |
+| AMD MI300A | CPU chiplets + GPU chiplets, MCM |
+| NVIDIA Grace-Hopper | Grace CPU + Hopper GPU, MCM via NVLink-C2C |
+| NVIDIA B100/B200 | dual-die GPU bridged by NV-HBI |
+| Jetson Orin | CPU + GPU + 2x DLA + PVA + NVENC, all on one SoC |
+| DGX H100 | 8x H100 + dual Sapphire Rapids + NVSwitch + ConnectX, board-level |
+| Tesla Dojo | training tile that's neither chip-shaped nor server-shaped |
+
+Forcing these into "GPU" or "CPU" buckets is increasingly false labelling. The
+downstream consumers (graphs/ mappers, the agentic orchestrator) ultimately care
+about *capabilities and resources* -- peak FP16, BW, TDP, die area, transistor
+budget -- not whether vendor marketing called it a GPU.
+
+---
+
+## Proposed shape: `ComputeProduct` with discriminated blocks
+
+A unified schema works only if we **don't** flatten everything into one bag.
+Three concepts:
+
+### 1. `ComputeProduct` (the spine) -- uniform across all products
+
+```yaml
+id: nvidia_h100_sxm5_80gb
+name: NVIDIA H100 SXM5 80GB
+vendor: nvidia
+packaging:
+  form_factor: sxm5            # chip | sxm | pcie_card | m2 | board | rack
+  num_dies: 1                  # 2 for B100, 8+CPU+switch for DGX
+  is_chiplet: false
+  package_type: monolithic     # | mcm | board | system
+physical:
+  die_size_mm2: 814            # sum across dies
+  transistors_billion: 80
+  process_node_nm: 4
+  process_node_name: "TSMC N4"
+  foundry: tsmc
+power:
+  tdp_watts: 700
+  modes: [...]                 # MAXN/30W/15W for Jetson; PL1/PL2 for Intel
+memory:
+  on_package_gb: 80
+  type: hbm3
+  bandwidth_gbps: 3350
+peak_throughput:               # uniform precision dict, applies to whole product
+  fp64: 33.45
+  fp32: 66.91
+  fp16: 989.4                  # tensor-core peak
+  fp8:  1978.9
+  int8: 1978.9
+market:
+  launch_date: 2022-09-20
+  launch_msrp_usd: 30000
+contains: []                   # for board/rack products: refs to child products
+blocks:                        # category-specific detail, see below
+  - kind: gpu
+    ...
+```
+
+### 2. `blocks: list[Block]` -- discriminated union for category-specific detail
+
+```yaml
+blocks:
+  - kind: gpu
+    streaming_multiprocessors: 132
+    cuda_cores: 16896
+    tensor_cores: 528
+    tensor_core_gen: 4
+
+  - kind: cpu
+    p_cores: 8
+    e_cores: 4
+    isa: x86_64
+    vector_ext: [avx2, avx512_vnni]
+
+  - kind: npu
+    dataflow: systolic
+    sparsity_support: true
+```
+
+A pure GPU has one `gpu` block. Jetson Orin has `[cpu, gpu, npu, npu]`
+(CPU + Ampere GPU + 2x DLA). DGX H100 has zero blocks at the top level
+and a populated `contains: [h100, h100, ..., sapphire_rapids, ...]`.
+
+### 3. Hierarchy via `contains`
+
+Board-level products reference chip-level products. The schema is recursive:
+a rack contains boards contains chips. Top-level fields like `peak_throughput`
+can be computed by summing children, or stated explicitly with a note.
+
+This handles every product type uniformly: pure chip, MCM, multi-die,
+multi-chip board, full rack.
+
+---
+
+## What it would take
+
+Roughly a **3-4 week project** in embodied-schemas, plus consumer migration in
+graphs/ and Embodied-AI-Architect.
+
+### Phase 1 -- Design & RFC (3-5 days)
+- Pydantic models for `ComputeProduct`, `Packaging`, `Physical`, `Power`,
+  `Memory`, `Block` (CPUBlock/GPUBlock/NPUBlock/DSPBlock/CGRABlock/...).
+- Decide on tricky cases up-front:
+  - How does a CPU-with-iGPU split? (Two blocks under one product.)
+  - How does B100 dual-die look? (One product, `num_dies: 2`, one logical
+    GPUBlock; or two contained chip-products.)
+  - How are thermal modes represented uniformly? (GPUs: single TDP. Jetson: 4.)
+  - What lives in `peak_throughput` for a CPU-with-iGPU? Sum, or per-block only?
+- Migration matrix: every old field -> new home, with explicit "drop" /
+  "extras" decisions for orphans.
+- Tests covering ~5 reference products spanning categories before bulk
+  migration.
+
+### Phase 2 -- Migration tooling (2-3 days)
+- Converter script: reads old `gpu/*.yaml`, `cpu/*.yaml`, etc., emits new
+  `products/<vendor>/<id>.yaml`.
+- Round-trip validation: load old, convert, load new, assert structural
+  equivalence.
+- Flag low-confidence conversions for human review.
+
+### Phase 3 -- Bulk migration (~1 week)
+- Run converter on all 74 existing files.
+- Hand-edit converter-flagged cases.
+- **Backfill the gap data while we're in the file anyway** -- die sizes and
+  transistor counts for CPUs/NPUs/SoCs from datasheets / Wikichip / Anandtech.
+  This is the only chance to touch all those files at once.
+- New folder layout: `data/products/<vendor>/<id>.yaml` (flat).
+
+### Phase 4 -- Update consumers (1-2 weeks)
+- embodied-schemas: deprecate `GPUEntry`/`CPUEntry`/`NPUEntry` exports with
+  shim adapters. Add `ComputeProduct` exports.
+- graphs/: implement `mapper.physical_spec` (or `mapper.compute_product`) that
+  pulls from `ComputeProduct`. Build `cli/list_hardware_resources.py`.
+- Embodied-AI-Architect: update prompts or hardware-selection logic that uses
+  category-keyed fields.
+
+### Phase 5 -- Sunset (1-2 weeks lag, parallel with normal work)
+- Remove deprecated Pydantic models.
+- Remove old `data/{gpus,cpus,npus,chips}/` folders after consumers cut over.
+
+---
+
+## Risks worth flagging up front
+
+1. **Discriminated unions in YAML are not free.** Pydantic v2 handles them
+   cleanly with a `kind:` discriminator; YAML editors and humans won't validate
+   the union as easily as a flat shape. Plan for editor tooling (JSON Schema
+   export) so authors get autocomplete.
+2. **The 80/20 trap.** ~20% of fields are genuinely block-specific. Resist
+   temptation to flatten them onto the spine -- that re-creates the original
+   bag-of-optional-fields problem. Block discrimination is what makes this
+   schema honest.
+3. **Information loss.** Some old fields don't have an obvious home (e.g., GPU
+   `nvenc: false`, CPU `socket: lga1700`). Decide policy: drop, move to a typed
+   `block.platform_metadata`, or keep as `extras: dict[str, Any]`.
+4. **External consumers.** If anything outside graphs/ and Embodied-AI-Architect
+   consumes embodied-schemas, the deprecation window needs to cover them too.
+
+---
+
+## Recommended sequencing relative to the immediate deliverable
+
+The unification project is the right answer but it's a 3-4 week investment.
+Don't block `cli/list_hardware_resources.py` on it. Sequence:
+
+1. **Now**: ship `PhysicalSpec` in graphs/ and the new CLI. Hand-populate from
+   datasheets for non-GPU chips. This is the consumer-side abstraction we want
+   regardless of how embodied-schemas evolves.
+2. **Soon**: open an embodied-schemas RFC for `ComputeProduct`. Start with phase
+   1 design while consumers (graphs/) are using `PhysicalSpec` as a stable
+   interface.
+3. **Later**: when `ComputeProduct` lands, `PhysicalSpec` becomes a thin loader
+   that reads from a `ComputeProduct` YAML. Consumer code (mappers, the agentic
+   system, the CLI) doesn't change -- only the data source behind
+   `PhysicalSpec` changes.
+
+This way the consumer interface is stable, the unification project doesn't
+block today's deliverable, and the work invested now isn't thrown away later.

--- a/src/graphs/hardware/mappers/gpu.py
+++ b/src/graphs/hardware/mappers/gpu.py
@@ -899,6 +899,7 @@ def create_h100_sxm5_80gb_mapper(thermal_profile: str = None) -> GPUMapper:
     from ..models.datacenter.h100_sxm5_80gb import h100_sxm5_80gb_resource_model
     from ..architectural_energy import DataParallelEnergyModel
     from ..technology_profile import DATACENTER_4NM_HBM3
+    from ..physical_spec import PhysicalSpec
 
     # Create resource model
     resource_model = h100_sxm5_80gb_resource_model()
@@ -909,7 +910,25 @@ def create_h100_sxm5_80gb_mapper(thermal_profile: str = None) -> GPUMapper:
         tech_profile=DATACENTER_4NM_HBM3
     )
 
-    return GPUMapper(resource_model, thermal_profile=thermal_profile)
+    mapper = GPUMapper(resource_model, thermal_profile=thermal_profile)
+
+    # Source: embodied-schemas/data/gpus/nvidia/h100_sxm5_80gb_hbm3.yaml
+    mapper.physical_spec = PhysicalSpec(
+        die_size_mm2=814.0,
+        transistors_billion=80.0,
+        process_node_nm=4,
+        process_node_name="TSMC N4",
+        foundry="tsmc",
+        architecture="Hopper",
+        num_dies=1,
+        is_chiplet=False,
+        package_type="monolithic",
+        launch_date="2022-09-20",
+        launch_msrp_usd=30000.0,
+        source="embodied-schemas:gpus/nvidia/h100_sxm5_80gb_hbm3.yaml",
+    )
+
+    return mapper
 
 
 def create_b100_sxm6_192gb_mapper(thermal_profile: str = None) -> GPUMapper:

--- a/src/graphs/hardware/physical_spec.py
+++ b/src/graphs/hardware/physical_spec.py
@@ -98,7 +98,10 @@ class PhysicalSpec:
         """
         if self.die_size_mm2 is None or self.transistors_billion is None:
             return None
-        if self.die_size_mm2 == 0:
+        # Treat non-positive values as invalid: a real chip has die_size > 0
+        # and transistors > 0. Guard so a malformed PhysicalSpec doesn't
+        # produce a nonsensical negative density.
+        if self.die_size_mm2 <= 0 or self.transistors_billion <= 0:
             return None
         return (self.transistors_billion * 1000.0) / self.die_size_mm2
 

--- a/src/graphs/hardware/physical_spec.py
+++ b/src/graphs/hardware/physical_spec.py
@@ -1,0 +1,107 @@
+"""
+PhysicalSpec: chip-level physical / fabrication attributes.
+
+Sibling to HardwareResourceModel. Holds the spec-sheet view of a compute
+product -- die size, transistor budget, process node, foundry, launch info --
+that is NOT consumed by the mapping path (roofline / energy / scheduling
+estimators read HardwareResourceModel, not this).
+
+This separation keeps the mapper hot path uncluttered while still letting
+spec-sheet tools (e.g., cli/list_hardware_resources.py) report the full
+chip-level view.
+
+Source-of-truth roadmap: today these values are populated inline in factory
+functions, sourced from datasheets. When the embodied-schemas ComputeProduct
+unification (RFC 0001) lands, PhysicalSpec will become a thin loader that
+reads from a ComputeProduct YAML, and consumers won't change.
+"""
+
+from dataclasses import dataclass, asdict, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class PhysicalSpec:
+    """Physical / fabrication attributes of a compute product.
+
+    All fields are optional. Many will be unknown for research-stage chips
+    (e.g., proprietary KPUs, hypothetical CGRAs); leave those as None and
+    let downstream tools render "N/A".
+
+    Multi-die products (chiplets, MCMs) report SUM values for ``die_size_mm2``
+    and ``transistors_billion`` across all dies in the package, with
+    ``num_dies`` and ``is_chiplet`` describing the packaging.
+    """
+
+    # Fabrication
+    die_size_mm2: Optional[float] = None
+    """Total silicon area in mm^2 (sum across all dies in the package)."""
+
+    transistors_billion: Optional[float] = None
+    """Total transistor count in billions (sum across all dies)."""
+
+    process_node_nm: Optional[int] = None
+    """Process node in nanometers. May be a marketing-rounded value
+    (e.g., 4 for TSMC N4 or Intel 4); see ``process_node_name`` for the
+    exact node string."""
+
+    process_node_name: Optional[str] = None
+    """Vendor name for the process node, e.g. ``TSMC N4``, ``Intel 7``,
+    ``Samsung 5LPE``."""
+
+    foundry: Optional[str] = None
+    """Foundry that fabricated the silicon, e.g. ``tsmc``, ``samsung``,
+    ``intel``, ``globalfoundries``."""
+
+    # Architecture / generation
+    architecture: Optional[str] = None
+    """Microarchitecture or codename, e.g. ``Hopper``, ``Blackwell``,
+    ``Alder Lake``, ``Zen 4``."""
+
+    # Packaging
+    num_dies: int = 1
+    """Number of silicon dies in the package. >1 for chiplet / MCM /
+    multi-die products (B100 = 2, MI300X = 8 + 4, etc.)."""
+
+    is_chiplet: bool = False
+    """True if the product uses chiplet packaging (multiple dies bridged
+    by an interposer or organic substrate)."""
+
+    package_type: Optional[str] = None
+    """Packaging classification: ``monolithic``, ``mcm``, ``chiplet``,
+    ``board``, ``system``."""
+
+    # Market
+    launch_date: Optional[str] = None
+    """ISO date string of public launch, e.g. ``2022-09-20``."""
+
+    launch_msrp_usd: Optional[float] = None
+    """Launch MSRP in USD. None for products without public list pricing."""
+
+    # Provenance
+    source: Optional[str] = None
+    """Where the values came from, e.g. ``embodied-schemas:nvidia/h100_sxm5_80gb_hbm3.yaml``,
+    ``vendor datasheet 2023-04``, ``Wikichip``. Use a short citation that
+    survives schema changes."""
+
+    extras: Dict[str, Any] = field(default_factory=dict)
+    """Vendor-specific or category-specific fields that don't fit the spine.
+    Keep typed values when possible. Examples: ``{"chiplet_count": 4,
+    "interposer_type": "CoWoS"}``."""
+
+    @property
+    def transistor_density_mtx_mm2(self) -> Optional[float]:
+        """Transistor density in millions of transistors per mm^2.
+
+        Returns None if either die size or transistor count is unknown.
+        Useful for cross-process comparisons (e.g., 5nm vs 3nm density).
+        """
+        if self.die_size_mm2 is None or self.transistors_billion is None:
+            return None
+        if self.die_size_mm2 == 0:
+            return None
+        return (self.transistors_billion * 1000.0) / self.die_size_mm2
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dict (e.g., for JSON output)."""
+        return asdict(self)

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -36,6 +36,7 @@ FusionReport = PartitionReport
 if TYPE_CHECKING:
     from graphs.hardware.architectural_energy import ArchitecturalEnergyModel
     from graphs.hardware.fabric_model import SoCFabricModel
+    from graphs.hardware.physical_spec import PhysicalSpec
 
 
 class HardwareType(Enum):
@@ -1699,11 +1700,22 @@ class HardwareMapper(ABC):
         Initialize hardware mapper.
 
         Args:
-            resource_model: Hardware resource model
+            resource_model: Hardware resource model (read by the mapping path:
+                            roofline, energy, scheduling estimators).
             thermal_profile: Thermal profile name (e.g., "15W", "30W").
                            If None, uses default_thermal_profile from resource_model.
+
+        Notes:
+            Mappers also expose a ``physical_spec`` attribute (initially ``None``)
+            for chip-level fabrication / spec-sheet metadata (die size,
+            transistors, process node, launch info). Factory functions assign
+            it post-construction when data is available; consumers like
+            ``cli/list_hardware_resources.py`` read it to render spec tables.
+            The mapping path never reads ``physical_spec`` -- it is metadata
+            only and never affects estimation.
         """
         self.resource_model = resource_model
+        self.physical_spec: Optional["PhysicalSpec"] = None
 
         # Select thermal profile
         if resource_model.thermal_operating_points:

--- a/tests/cli/test_list_hardware_mappers_output.py
+++ b/tests/cli/test_list_hardware_mappers_output.py
@@ -1,0 +1,75 @@
+"""Tests for the --output / --format contract on cli/list_hardware_mappers.py.
+
+Locks in:
+- Format auto-detection from file extension (.json/.csv/.md/.txt)
+- --format as override when extension is unrecognized
+- Each format produces parseable / non-empty output
+"""
+
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CLI = Path(__file__).resolve().parents[2] / "cli" / "list_hardware_mappers.py"
+
+
+def _run(*args, output_path=None):
+    """Invoke the CLI with the given args; return (stdout, stderr, returncode)."""
+    cmd = [sys.executable, str(CLI), *args]
+    if output_path is not None:
+        cmd.extend(["--output", str(output_path)])
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    return proc.stdout, proc.stderr, proc.returncode
+
+
+class TestOutputFormatDetection:
+    def test_json_extension_writes_valid_json(self, tmp_path):
+        out = tmp_path / "mappers.json"
+        _, stderr, rc = _run(output_path=out)
+        assert rc == 0
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert "total_mappers" in data
+        assert data["total_mappers"] > 0
+        assert "Wrote json report" in stderr
+
+    def test_csv_extension_writes_valid_csv(self, tmp_path):
+        out = tmp_path / "mappers.csv"
+        _, stderr, rc = _run(output_path=out)
+        assert rc == 0
+        rows = list(csv.reader(out.open()))
+        # header + at least 10 mappers
+        assert len(rows) > 10
+        # Header includes the new precision fields
+        header = rows[0]
+        for col in ("peak_flops_fp64", "peak_flops_fp16", "peak_flops_fp8"):
+            assert col in header
+
+    def test_md_extension_routes_to_text(self, tmp_path):
+        out = tmp_path / "mappers.md"
+        _, stderr, rc = _run(output_path=out)
+        assert rc == 0
+        assert "Wrote text report" in stderr
+        body = out.read_text()
+        assert "HARDWARE MAPPER DISCOVERY REPORT" in body
+
+    def test_txt_extension_routes_to_text(self, tmp_path):
+        out = tmp_path / "mappers.txt"
+        _, _, rc = _run(output_path=out)
+        assert rc == 0
+        assert "HARDWARE MAPPER DISCOVERY REPORT" in out.read_text()
+
+    def test_unknown_extension_falls_back_to_format_flag(self, tmp_path):
+        out = tmp_path / "mappers.weird"
+        _, _, rc = _run("--format", "json", output_path=out)
+        assert rc == 0
+        # Format override resolved to JSON despite the unknown extension.
+        json.loads(out.read_text())
+
+    def test_no_output_prints_to_stdout(self):
+        stdout, _, rc = _run("--category", "gpu", "--format", "json")
+        assert rc == 0
+        # JSON to stdout still parses
+        json.loads(stdout)

--- a/tests/hardware/test_physical_spec.py
+++ b/tests/hardware/test_physical_spec.py
@@ -36,6 +36,18 @@ class TestPhysicalSpec:
         spec = PhysicalSpec(die_size_mm2=0.0, transistors_billion=80.0)
         assert spec.transistor_density_mtx_mm2 is None
 
+    def test_density_rejects_negative_die_size(self):
+        spec = PhysicalSpec(die_size_mm2=-1.0, transistors_billion=80.0)
+        assert spec.transistor_density_mtx_mm2 is None
+
+    def test_density_rejects_negative_transistors(self):
+        spec = PhysicalSpec(die_size_mm2=814.0, transistors_billion=-1.0)
+        assert spec.transistor_density_mtx_mm2 is None
+
+    def test_density_rejects_zero_transistors(self):
+        spec = PhysicalSpec(die_size_mm2=814.0, transistors_billion=0.0)
+        assert spec.transistor_density_mtx_mm2 is None
+
     def test_to_dict_serializes_cleanly(self):
         spec = PhysicalSpec(
             die_size_mm2=814.0,

--- a/tests/hardware/test_physical_spec.py
+++ b/tests/hardware/test_physical_spec.py
@@ -1,0 +1,89 @@
+"""Unit tests for PhysicalSpec dataclass and mapper integration."""
+
+from graphs.hardware.physical_spec import PhysicalSpec
+from graphs.hardware.mappers.gpu import (
+    create_h100_sxm5_80gb_mapper,
+    create_a100_sxm4_80gb_mapper,
+)
+
+
+class TestPhysicalSpec:
+    def test_all_fields_optional(self):
+        spec = PhysicalSpec()
+        assert spec.die_size_mm2 is None
+        assert spec.transistors_billion is None
+        assert spec.process_node_nm is None
+        assert spec.foundry is None
+        assert spec.architecture is None
+        assert spec.num_dies == 1
+        assert spec.is_chiplet is False
+        assert spec.extras == {}
+
+    def test_density_computed_when_both_known(self):
+        spec = PhysicalSpec(die_size_mm2=814.0, transistors_billion=80.0)
+        # 80B / 814mm^2 = 98.28 Mtx/mm^2
+        assert abs(spec.transistor_density_mtx_mm2 - 98.28) < 0.1
+
+    def test_density_none_when_die_unknown(self):
+        spec = PhysicalSpec(transistors_billion=80.0)
+        assert spec.transistor_density_mtx_mm2 is None
+
+    def test_density_none_when_transistors_unknown(self):
+        spec = PhysicalSpec(die_size_mm2=814.0)
+        assert spec.transistor_density_mtx_mm2 is None
+
+    def test_density_handles_zero_die_size(self):
+        spec = PhysicalSpec(die_size_mm2=0.0, transistors_billion=80.0)
+        assert spec.transistor_density_mtx_mm2 is None
+
+    def test_to_dict_serializes_cleanly(self):
+        spec = PhysicalSpec(
+            die_size_mm2=814.0,
+            transistors_billion=80.0,
+            architecture="Hopper",
+        )
+        d = spec.to_dict()
+        assert d["die_size_mm2"] == 814.0
+        assert d["transistors_billion"] == 80.0
+        assert d["architecture"] == "Hopper"
+        assert d["num_dies"] == 1
+        assert d["extras"] == {}
+
+    def test_extras_accepts_arbitrary_keys(self):
+        spec = PhysicalSpec(extras={"chiplet_count": 4, "interposer_type": "CoWoS"})
+        assert spec.extras["chiplet_count"] == 4
+        assert spec.extras["interposer_type"] == "CoWoS"
+
+
+class TestMapperPhysicalSpecIntegration:
+    """Verify the PhysicalSpec attribute is wired onto every mapper, that
+    populated factories surface real data, and that unpopulated factories
+    return None without crashing."""
+
+    def test_h100_sxm5_factory_populates_physical_spec(self):
+        mapper = create_h100_sxm5_80gb_mapper()
+        assert mapper.physical_spec is not None
+        assert mapper.physical_spec.die_size_mm2 == 814.0
+        assert mapper.physical_spec.transistors_billion == 80.0
+        assert mapper.physical_spec.process_node_nm == 4
+        assert mapper.physical_spec.foundry == "tsmc"
+        assert mapper.physical_spec.architecture == "Hopper"
+        assert mapper.physical_spec.source.startswith("embodied-schemas:")
+
+    def test_unpopulated_factory_returns_none_physical_spec(self):
+        # A100 factory hasn't been backfilled yet -- physical_spec should be
+        # None, not raise. This guards graceful degradation for the long tail
+        # of mappers that haven't had die specs populated.
+        mapper = create_a100_sxm4_80gb_mapper()
+        assert mapper.physical_spec is None
+
+    def test_physical_spec_does_not_affect_mapping_path(self):
+        # The mapping path reads resource_model, not physical_spec. Confirm
+        # both populated and unpopulated mappers expose the same operational
+        # surface area.
+        h100 = create_h100_sxm5_80gb_mapper()
+        a100 = create_a100_sxm4_80gb_mapper()
+        assert h100.resource_model is not None
+        assert a100.resource_model is not None
+        assert h100.resource_model.compute_units == 132
+        assert a100.resource_model.compute_units == 108


### PR DESCRIPTION
## Summary

Two related changes that came out of the same investigation: extending `cli/list_hardware_mappers.py` to report die size + transistor count surfaced that those fields don't exist anywhere structured in this repo. Rather than backfill them onto `HardwareResourceModel` (which would burden the mapping path with spec-sheet metadata), this PR introduces `PhysicalSpec` as a separate dataclass living alongside the resource model.

- **`feat(cli):` precision columns** -- `list_hardware_mappers.py` now reports peak throughput at every precision the resource model knows about (FP64/FP32/FP16/FP8/INT32/INT16/INT8), not just FP32 + INT8. New comparison table is segmented by deployment with TDP and TOPS/W efficiency. Helper consolidates 30+ duplicated call sites; FP8 column reports the max across `FP8` / `FP8_E4M3` / `FP8_E5M2` since most resource models register the variants but not the generic enum.
- **`feat(hardware):` PhysicalSpec** -- new `src/graphs/hardware/physical_spec.py` dataclass with optional fab/launch fields (die size, transistors, process node, foundry, architecture, launch date, MSRP) and a derived `transistor_density_mtx_mm2` property. `HardwareMapper.__init__` initializes `self.physical_spec = None`; factory functions assign post-construction when data is available -- no subclass `__init__` changes needed. The mapping path (roofline / energy / scheduling) reads `resource_model` and never sees `physical_spec`. H100 SXM5 factory populated as a worked example, sourced from `embodied-schemas/data/gpus/nvidia/h100_sxm5_80gb_hbm3.yaml`. Other ~45 mappers remain `physical_spec=None` until backfilled (tracked in #130).

## Why a separate dataclass

Survey of `embodied-schemas` showed `DieSpec` is defined and populated only for GPUs (22/22), with zero coverage for CPUs (0/36), NPUs (0/4), or SoCs/Chips (0/12). The clean separation lets us populate spec metadata at our own pace without risking accidental coupling into estimation. Full rationale and the proposed `embodied-schemas` `ComputeProduct` unification (which will eventually back `PhysicalSpec` via a YAML loader) in `docs/assessments/compute-product-unification.md` and [embodied-schemas RFC 0001](https://github.com/branes-ai/embodied-schemas/pull/new/docs/compute-product-unification-rfc).

## Test plan

- [x] `python -m pytest tests/hardware/test_physical_spec.py -v` -- 10 new tests covering dataclass behavior, density derivation, and mapper integration including graceful `None` for unpopulated factories
- [x] `python -m pytest tests/` -- 2118 pass, 0 failures (no regressions)
- [x] `python cli/list_hardware_mappers.py` -- runs cleanly across all 31 mappers, FP8 column populated for H100/B100
- [x] `python cli/list_hardware_mappers.py --format json` -- new precision fields serialize via `asdict`
- [x] `python cli/list_hardware_mappers.py --category cpu` -- category filter still works

## Tracking

- branes-ai/graphs#130 (foundation + backfill umbrella)
- branes-ai/graphs#131 (build `cli/list_hardware_resources.py` against PhysicalSpec)
- branes-ai/graphs#132 (switch PhysicalSpec source to ComputeProduct loader, depends on embodied-schemas Phase 4)
- branes-ai/embodied-schemas#1 (ComputeProduct unification epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hardware mapper CLI now reports peak throughput across eight precision levels (FP64, FP32, FP16, FP8, INT32, INT16, INT8) instead of two.
  * Added physical specification support for hardware devices, capturing die size, transistor count, process node, foundry, and launch metadata.
  * Improved hardware device comparison table with precision-segmented reporting.

* **Documentation**
  * Added architectural assessment for unified hardware model schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->