### PR TITLE
feat(hardware): populate PhysicalSpec for 4 Jetson SKUs (relates #130)

### DIFF
--- a/docs/hardware/nvidia_jetson_skus.md
+++ b/docs/hardware/nvidia_jetson_skus.md
@@ -1,0 +1,68 @@
+● PhysicalSpec for all 4 Jetson SKUs landed
+  PR: #135 (draft) (https://github.com/branes-ai/graphs/pull/135) — feat(hardware): populate PhysicalSpec for 4 Jetson SKUs (relates #130)
+  Branch: feat/issue-130-jetson-physical-specs (off main)
+  Status: 18 PhysicalSpec tests pass, 205 hardware tests pass, no regressions
+
+  Data captured
+  Orin AGX 64GB / NX 16GB / Nano 8GB — all three share the GA10B (T234) silicon; module bins differ but die does not. 
+  Single helper _orin_soc_physical_spec() 
+  builds the shared chip-level fields:
+  ┌─────────────────────────────────────┬──────────────────────────────┐
+  │ Chip-level (identical across all 3) │            Value             │
+  ├─────────────────────────────────────┼──────────────────────────────┤
+  │ die_size_mm²                        │ 455.0                        │
+  ├─────────────────────────────────────┼──────────────────────────────┤
+  │ transistors (B)                     │ 17.0                         │
+  ├─────────────────────────────────────┼──────────────────────────────┤
+  │ process                             │ Samsung 8N (8LPP derivative) │
+  ├─────────────────────────────────────┼──────────────────────────────┤
+  │ foundry                             │ samsung                      │
+  ├─────────────────────────────────────┼──────────────────────────────┤
+  │ architecture                        │ Ampere                       │
+  ├─────────────────────────────────────┼──────────────────────────────┤
+  │ density                             │ 37.4 Mtx/mm² (derived)       │
+  └─────────────────────────────────────┴──────────────────────────────┘                                                                                      
+  
+  ┌────────────────────────┬────────────────────────────┬────────────────┐
+  │ Module-level (per SKU) │           Launch           │      MSRP      │
+  ├────────────────────────┼────────────────────────────┼────────────────┤
+  │ AGX 64GB               │ 2022-11-08 (GTC Fall 2022) │ $1,999         │
+  ├────────────────────────┼────────────────────────────┼────────────────┤
+  │ NX 16GB                │ 2023-01-04                 │ $899           │
+  ├────────────────────────┼────────────────────────────┼────────────────┤
+  │ Nano 8GB               │ 2023-03-22 (GTC 2023)      │ $499 (dev kit) │
+  └────────────────────────┴────────────────────────────┴────────────────┘
+                                                            
+  Thor 128GB — different generation (Blackwell on TSMC 4N), launched 2025-08-25 at $2,999. 
+  die_size_mm² and transistors_billion are None — NVIDIA hasn't publicly disclosed those for Thor; 
+  the spec-sheet view will render them as N/A (graceful degradation by design).
+
+  Caveats noted in commit message and PR body
+ 
+  - The 455 mm² figure is NVIDIA's commonly-cited number; an X die-shot photo measurement reported 448 mm². 
+    NVIDIA has not officially published an exact die area. The discrepancy is small (~1.5%) and the 
+    17B transistor count is solid (NVIDIA-disclosed at Hot Chips).
+  - The Orin Nano 8GB MSRP of $499 reflects the dev kit launch price; the production module sold for ~$199 later. Source field documents this.
+
+  Open PRs in flight
+  - #133 (https://github.com/branes-ai/graphs/pull/133) — merged earlier (PhysicalSpec foundation)
+  - #134 (https://github.com/branes-ai/graphs/pull/134) — cli/list_hardware_resources.py (the spec-sheet CLI; in draft)
+  - #135 (https://github.com/branes-ai/graphs/pull/135) — this one (Jetson backfill; in draft)
+
+  Once #135 and #134 both land, running python cli/list_hardware_resources.py --category gpu --sort die_size --reverse will show H100 first, 
+  then Orin AGX/NX/Nano with their populated GA10B specs, then Thor (process node populated, die size N/A).
+
+  Sources
+  - NVIDIA Jetson AGX Orin Series Technical Brief
+    (https://www.nvidia.com/content/dam/en-zz/Solutions/gtcf21/jetson-orin/nvidia-jetson-agx-orin-technical-brief.pdf)
+  - Wikipedia: NVIDIA Tegra (Orin / Thor) (https://en.wikipedia.org/wiki/Tegra)
+  - NVIDIA's Next-Gen GPU Architecture Powers The DRIVE AGX Orin (WCCFTech)
+    (https://wccftech.com/nvidia-next-gen-gpu-architecture-powered-orin-soc-announced/) — 17B transistor announcement
+  - GA10B die size measurement (X / @lafaiel) (https://x.com/lafaiel/status/1869311677000458418) — die-shot reporting 448 mm²
+  - Introducing NVIDIA Jetson Thor (NVIDIA Technical Blog)
+    (https://developer.nvidia.com/blog/introducing-nvidia-jetson-thor-the-ultimate-platform-for-physical-ai/) — Thor T5000 specs
+  - NVIDIA Blackwell-Powered Jetson Thor Now Available (NVIDIA Newsroom)
+    (https://nvidianews.nvidia.com/news/nvidia-blackwell-powered-jetson-thor-now-available-accelerating-the-age-of-general-robotics) 
+    — 2025-08-25 launch + $2,999 module pricing                                     
+  - $3499 NVIDIA Jetson AGX Thor Developer Kit (CNX Software)
+    (https://www.cnx-software.com/2025/08/19/3499-nvidia-jetson-agx-thor-developer-kit-2070-tops-jetson-t5000-som-for-robotics-and-edge-ai/) — pricing detail 

--- a/src/graphs/hardware/mappers/gpu.py
+++ b/src/graphs/hardware/mappers/gpu.py
@@ -1112,6 +1112,52 @@ def create_t4_pcie_16gb_mapper(thermal_profile: str = None) -> GPUMapper:
     return GPUMapper(t4_pcie_16gb_resource_model(), thermal_profile=thermal_profile)
 
 
+# ---------------------------------------------------------------------------
+# Jetson Orin SoC family (Nano / NX / AGX)
+# ---------------------------------------------------------------------------
+# All three Orin modules share the SAME silicon -- the GA10B (T234) die. Module
+# differentiation is by bin (active CUDA cores / CPU cores) and power
+# envelope, not by die. Chip-level fields (die_size, transistors, process
+# node, foundry, architecture) are identical; only module-level fields
+# (launch_date, launch_msrp_usd, source citation) vary per SKU.
+#
+# Die data sources:
+#   Transistors: 17B  -- NVIDIA's official figure (DRIVE Orin Hot Chips
+#                        announcement, also cited on Wikipedia/Tegra page).
+#   Die size: 455 mm^2 (commonly cited; ~448 mm^2 per third-party die-shot
+#             measurement -- NVIDIA has not officially disclosed an exact
+#             figure, so this is approximate).
+#   Process: Samsung 8N (8LPP derivative), same node as GeForce RTX 30-series.
+
+def _orin_soc_physical_spec(
+    *,
+    launch_date: str,
+    launch_msrp_usd: float,
+    source: str,
+) -> "PhysicalSpec":
+    """Build a PhysicalSpec for one Orin module SKU.
+
+    Chip-level fields are identical across AGX / NX / Nano (same GA10B die);
+    callers customize the module-level fields (launch info + source citation).
+    """
+    from ..physical_spec import PhysicalSpec
+
+    return PhysicalSpec(
+        die_size_mm2=455.0,
+        transistors_billion=17.0,
+        process_node_nm=8,
+        process_node_name="Samsung 8N",
+        foundry="samsung",
+        architecture="Ampere",
+        num_dies=1,
+        is_chiplet=False,
+        package_type="monolithic",
+        launch_date=launch_date,
+        launch_msrp_usd=launch_msrp_usd,
+        source=source,
+    )
+
+
 def create_jetson_orin_agx_64gb_mapper(
     thermal_profile: str = None, calibration=None
 ) -> GPUMapper:
@@ -1141,9 +1187,15 @@ def create_jetson_orin_agx_64gb_mapper(
         tech_profile=EDGE_8NM_LPDDR5
     )
 
-    return GPUMapper(
+    mapper = GPUMapper(
         resource_model, thermal_profile=thermal_profile, calibration=calibration
     )
+    mapper.physical_spec = _orin_soc_physical_spec(
+        launch_date="2022-11-08",  # GTC Fall 2022 production launch (64GB module)
+        launch_msrp_usd=1999.0,    # production module price
+        source="NVIDIA Jetson AGX Orin Series Technical Brief (2022); 17B transistors / Samsung 8N",
+    )
+    return mapper
 
 
 def create_jetson_orin_nano_8gb_mapper(
@@ -1164,11 +1216,17 @@ def create_jetson_orin_nano_8gb_mapper(
     """
     from ..models.edge.jetson_orin_nano_8gb import jetson_orin_nano_8gb_resource_model
 
-    return GPUMapper(
+    mapper = GPUMapper(
         jetson_orin_nano_8gb_resource_model(),
         thermal_profile=thermal_profile,
         calibration=calibration,
     )
+    mapper.physical_spec = _orin_soc_physical_spec(
+        launch_date="2023-03-22",  # GTC 2023 announcement
+        launch_msrp_usd=499.0,     # developer kit launch price; production module $199 later
+        source="NVIDIA GTC 2023 Orin Nano dev kit launch; same GA10B die as AGX",
+    )
+    return mapper
 
 
 def create_jetson_orin_nx_16gb_mapper(
@@ -1198,11 +1256,17 @@ def create_jetson_orin_nx_16gb_mapper(
     """
     from ..models.edge.jetson_orin_nx_16gb import jetson_orin_nx_16gb_resource_model
 
-    return GPUMapper(
+    mapper = GPUMapper(
         jetson_orin_nx_16gb_resource_model(),
         thermal_profile=thermal_profile,
         calibration=calibration,
     )
+    mapper.physical_spec = _orin_soc_physical_spec(
+        launch_date="2023-01-04",  # general availability Q1 2023
+        launch_msrp_usd=899.0,     # production module price
+        source="NVIDIA Jetson Orin NX series launch (2023-01); same GA10B die as AGX",
+    )
+    return mapper
 
 
 def create_jetson_thor_128gb_mapper(thermal_profile: str = None) -> GPUMapper:
@@ -1219,10 +1283,30 @@ def create_jetson_thor_128gb_mapper(thermal_profile: str = None) -> GPUMapper:
         GPUMapper configured for Jetson Thor 128GB
     """
     from ..models.automotive.jetson_thor_128gb import jetson_thor_128gb_resource_model
+    from ..physical_spec import PhysicalSpec
 
-    return GPUMapper(
+    mapper = GPUMapper(
         jetson_thor_128gb_resource_model(), thermal_profile=thermal_profile
     )
+    # Thor T5000 (T264). NVIDIA has not publicly disclosed die size or
+    # transistor count, so those fields stay None. Process node is TSMC 4nm
+    # (consistent with consumer Blackwell on TSMC 4N; Thor is the embedded
+    # Blackwell variant).
+    mapper.physical_spec = PhysicalSpec(
+        die_size_mm2=None,
+        transistors_billion=None,
+        process_node_nm=4,
+        process_node_name="TSMC 4N",
+        foundry="tsmc",
+        architecture="Blackwell",
+        num_dies=1,
+        is_chiplet=False,
+        package_type="monolithic",
+        launch_date="2025-08-25",   # general availability per NVIDIA newsroom
+        launch_msrp_usd=2999.0,     # T5000 production module price
+        source="NVIDIA Jetson Thor T5000 launch (2025-08-25); die size / transistors not publicly disclosed",
+    )
+    return mapper
 
 
 # ============================================================================

--- a/tests/hardware/test_physical_spec.py
+++ b/tests/hardware/test_physical_spec.py
@@ -4,6 +4,10 @@ from graphs.hardware.physical_spec import PhysicalSpec
 from graphs.hardware.mappers.gpu import (
     create_h100_sxm5_80gb_mapper,
     create_a100_sxm4_80gb_mapper,
+    create_jetson_orin_agx_64gb_mapper,
+    create_jetson_orin_nano_8gb_mapper,
+    create_jetson_orin_nx_16gb_mapper,
+    create_jetson_thor_128gb_mapper,
 )
 
 
@@ -99,3 +103,70 @@ class TestMapperPhysicalSpecIntegration:
         assert a100.resource_model is not None
         assert h100.resource_model.compute_units == 132
         assert a100.resource_model.compute_units == 108
+
+
+class TestJetsonPhysicalSpecs:
+    """Verify the four Jetson SKUs are populated. Orin AGX/NX/Nano share the
+    GA10B die so chip-level fields (die_size, transistors, process) match
+    across all three; only module-level fields (launch info) differ. Thor is
+    a separate generation -- die details not publicly disclosed yet."""
+
+    def test_orin_agx_chip_fields(self):
+        spec = create_jetson_orin_agx_64gb_mapper().physical_spec
+        assert spec is not None
+        assert spec.die_size_mm2 == 455.0
+        assert spec.transistors_billion == 17.0
+        assert spec.process_node_nm == 8
+        assert spec.foundry == "samsung"
+        assert spec.architecture == "Ampere"
+        assert spec.launch_date == "2022-11-08"
+        assert spec.launch_msrp_usd == 1999.0
+
+    def test_orin_nx_chip_fields_match_agx(self):
+        # NX uses the same GA10B die as AGX -- chip-level fields identical
+        agx = create_jetson_orin_agx_64gb_mapper().physical_spec
+        nx = create_jetson_orin_nx_16gb_mapper().physical_spec
+        assert nx.die_size_mm2 == agx.die_size_mm2
+        assert nx.transistors_billion == agx.transistors_billion
+        assert nx.process_node_nm == agx.process_node_nm
+        assert nx.foundry == agx.foundry
+        # But module-level fields differ
+        assert nx.launch_date != agx.launch_date
+        assert nx.launch_msrp_usd != agx.launch_msrp_usd
+
+    def test_orin_nano_chip_fields_match_agx(self):
+        agx = create_jetson_orin_agx_64gb_mapper().physical_spec
+        nano = create_jetson_orin_nano_8gb_mapper().physical_spec
+        assert nano.die_size_mm2 == agx.die_size_mm2
+        assert nano.transistors_billion == agx.transistors_billion
+        assert nano.process_node_nm == agx.process_node_nm
+        # Module-level
+        assert nano.launch_date == "2023-03-22"
+        assert nano.launch_msrp_usd == 499.0
+
+    def test_thor_partial_population(self):
+        # Thor's die size and transistor count are not publicly disclosed,
+        # so they remain None. The rest of the chip-level fields plus
+        # module info are populated.
+        spec = create_jetson_thor_128gb_mapper().physical_spec
+        assert spec is not None
+        assert spec.die_size_mm2 is None
+        assert spec.transistors_billion is None
+        assert spec.transistor_density_mtx_mm2 is None  # depends on die + transistors
+        assert spec.process_node_nm == 4
+        assert spec.foundry == "tsmc"
+        assert spec.architecture == "Blackwell"
+        assert spec.launch_date == "2025-08-25"
+        assert spec.launch_msrp_usd == 2999.0
+
+    def test_orin_density_is_consistent_across_skus(self):
+        # All three Orin variants are the same die -> identical density.
+        agx = create_jetson_orin_agx_64gb_mapper().physical_spec
+        nx = create_jetson_orin_nx_16gb_mapper().physical_spec
+        nano = create_jetson_orin_nano_8gb_mapper().physical_spec
+        d_agx = agx.transistor_density_mtx_mm2
+        assert d_agx is not None
+        # 17B / 455 mm^2 = ~37.4 Mtx/mm^2 (Samsung 8nm density floor)
+        assert abs(d_agx - 37.4) < 0.5
+        assert nx.transistor_density_mtx_mm2 == d_agx
+        assert nano.transistor_density_mtx_mm2 == d_agx


### PR DESCRIPTION
## Summary

Backfills chip-level fabrication data (die size, transistors, process node, foundry, architecture, launch info) for all four Jetson modules in the mapper registry. First substantial advance on the #130 PhysicalSpec backfill umbrella.

Relates to #130 (does not fully resolve -- ~41 mappers still unpopulated).

## What's populated

### Orin AGX 64GB / NX 16GB / Nano 8GB

All three modules use the **same GA10B (T234) silicon** -- module differentiation is by bin (active CUDA cores / CPU cores) and power envelope, not by die. So chip-level fields are identical across the three SKUs; only module-level fields (launch date, MSRP, source) vary.

A new module-level helper `_orin_soc_physical_spec()` builds the shared chip-level fields; each factory customizes the module-level fields. This avoids duplicating the GA10B die data three times.

| Field | Value | Source |
|-------|-------|--------|
| die_size_mm2 | 455.0 | Commonly cited; ~448 mm² per third-party die-shot. NVIDIA has not officially disclosed an exact figure. |
| transistors_billion | 17.0 | NVIDIA's official announcement (DRIVE Orin Hot Chips) |
| process_node_nm / process_node_name | 8 / "Samsung 8N" | Same 8LPP derivative as RTX 30-series |
| foundry | samsung | |
| architecture | Ampere | GPU side; SoC codename is Orin |

| SKU | Launch | Module MSRP |
|-----|--------|-------------|
| AGX 64GB | 2022-11-08 (GTC Fall 2022 production) | $1,999 |
| NX 16GB  | 2023-01-04 (Q1 2023 GA) | $899 |
| Nano 8GB | 2023-03-22 (GTC 2023) | $499 (dev kit; module $199 later) |

### Thor T5000 128GB

Separate inline PhysicalSpec since Thor is a different generation (Blackwell architecture, TSMC 4N, ARM Neoverse-V3AE CPU). **NVIDIA has not publicly disclosed Thor's die size or transistor count**, so those fields stay `None` -- the spec-sheet renderer will show `N/A`.

| Field | Value |
|-------|-------|
| die_size_mm2 / transistors_billion | None (not publicly disclosed) |
| process_node_nm / process_node_name | 4 / "TSMC 4N" (consistent with consumer Blackwell; Thor is the embedded Blackwell variant) |
| foundry | tsmc |
| architecture | Blackwell |
| launch_date | 2025-08-25 (NVIDIA newsroom GA) |
| launch_msrp_usd | $2,999 (T5000 production module) |

## Test plan

- [x] `tests/hardware/test_physical_spec.py` — 5 new tests:
  - Each SKU's chip-level fields populated correctly
  - AGX/NX/Nano share identical chip-level fields, differ only in module-level fields
  - Thor's None fields don't crash density derivation
  - Orin density is ~37.4 Mtx/mm² (Samsung 8N density floor; consistent with the process)
- [x] Hardware test sweep clean: 205 tests pass, no regressions
- [ ] Draft fast CI passes
- [ ] Promote when satisfied: `gh pr ready NNN`

## Related PRs

- #133 (merged): PhysicalSpec foundation
- #134 (open): cli/list_hardware_resources.py — once both this and #134 land, the CLI will surface the populated Jetson rows automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)