### PR TITLE
feat(hardware): profile-as-SKU registry aliases (#136 Phase 1)

### DIFF
--- a/docs/assessments/profile-as-sku-addressing.md
+++ b/docs/assessments/profile-as-sku-addressing.md
@@ -34,7 +34,7 @@ This document captures how we resolved that tension.
 Substantial pieces of the per-profile data layer already existed:
 
 - **`ThermalOperatingPoint`** (`src/graphs/hardware/resource_model.py:733`) represents one mode -- `name`, `tdp_watts`, `cooling_solution`, and `performance_specs: Dict[Precision, PerformanceCharacteristics]`.
-- **The Orin Nano resource model** (`src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py`) already enumerated `7W`, `15W`, `MAXN` profiles with full per-profile clock and peak data populated from NVIDIA's published specs.
+- **The Orin Nano resource model** (`src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py`) enumerates the four canonical Orin Nano Super modes -- `7W`, `15W`, `25W`, `MAXN` -- with full per-profile clock and peak data populated from NVIDIA's published specs. (The original Phase 1 implementation registered three; the `25W` mode was added when reconciling this doc with the user-directed mode count.)
 - **`HardwareMapper.__init__`** accepts `thermal_profile` to select which mode is active for the returned mapper.
 - **`HardwareResourceModel.default_thermal_profile`** designates a sensible default for "give me one number" queries.
 
@@ -60,7 +60,7 @@ Three concrete costs:
 
 2. **Drift risk.** When NVIDIA discloses a new transistor count or someone corrects a die-size measurement, you'd have to update all profile variants in lockstep. Single source of truth says: chip-level data should live in exactly one place.
 
-3. **Adding a new profile becomes a copy-paste exercise.** If NVIDIA ships an "Orin Nano Super 2.0" 25W mode, you'd construct a brand-new full-spec entry. With the alias model, you just add a new `ThermalOperatingPoint` to the existing resource model and the alias machinery picks it up automatically.
+3. **Adding a new profile becomes a copy-paste exercise.** If NVIDIA ships a new mode (e.g., a hypothetical 50W envelope on a future Super refresh), you'd construct a brand-new full-spec entry. With the alias model, you just add a new `ThermalOperatingPoint` to the existing resource model and the alias machinery picks it up automatically. (Concrete example: the `25W` mode was added to Orin Nano under issue #136 simply by registering one extra `ThermalOperatingPoint`; no registry, factory, or PhysicalSpec changes were needed.)
 
 ### Why "leave it as-is and have callers know about thermal_profile" didn't survive either
 
@@ -172,7 +172,7 @@ The mechanism doesn't impose itself where it's not useful: any chip with one the
 These are open questions deferred to Phases 2-5 or to a future RFC:
 
 - **Should we deprecate the dashed alias form?** The `@` form is unambiguous; the dashed form requires longest-prefix-match parsing. We support both for now because the dashed form is what the user originally proposed and it's friendlier to type. If we see the parsing become a maintenance burden, we can deprecate dashed in a future major version.
-- **Should aliases include short forms like `Jetson-Orin-Nano-8GB-7W` instead of the full profile name `Jetson-Orin-Nano-8GB@7W-battery`?** Currently aliases use whatever's in `thermal_operating_points` as the key. Short-form generation would require resolving collisions when two profiles share a TDP wattage but differ in cooling. Punted to Phase 2 if user demand surfaces.
+- **Should aliases include short forms or auto-generated TDP-based names?** Currently aliases use whatever's in `thermal_operating_points` as the key. We've already encountered the collision case in practice: Orin Nano's `25W` and `MAXN` modes both have `tdp_watts=25.0` (they differ in DVFS behavior, not envelope). If we ever auto-generate TDP-based aliases like `@25W` from raw watts, that approach would need a tiebreaker or compound key (e.g., `@25W-dvfs`, `@25W-locked`). Punted to a later phase.
 - **Should `default_thermal_profile` be discoverable from the alias?** Today, bare `Jetson-Orin-Nano-8GB` returns the default profile silently. We could emit `Jetson-Orin-Nano-8GB@default` as an alias, but that adds noise. Status quo stands until someone asks for it.
 - **How does this interact with the `embodied-schemas` ComputeProduct unification (RFC 0001)?** The `ComputeProduct` shape will need to express modes. We could put modes in a new `power_modes: list[PowerMode]` field at the spine level (mirroring `ThermalOperatingPoint` here), or as a property of each `Block` if modes are sometimes block-scoped. Decision deferred to Phase 1 of the unification RFC.
 

--- a/docs/assessments/profile-as-sku-addressing.md
+++ b/docs/assessments/profile-as-sku-addressing.md
@@ -1,0 +1,196 @@
+# Assessment: Profile-as-SKU Addressing for Power-Modulated Edge SoCs
+
+**Date:** 2026-05-08
+**Tracking issue:** [#136](https://github.com/branes-ai/graphs/issues/136)
+**Phase 1 PR:** [#137](https://github.com/branes-ai/graphs/pull/137)
+**Status:** Phase 1 implemented; Phases 2-5 outlined.
+
+---
+
+## Background
+
+While building out `PhysicalSpec` (PR #133) and the `cli/list_hardware_resources.py` spec-sheet view (PR #134), and then populating the four Jetson SKUs (PR #135), a structural question surfaced: how do we represent the fact that the same silicon ships in multiple persistent power profiles?
+
+For embodied AI, this isn't a corner case -- it's the dominant deployment pattern. The Jetson Orin Nano alone has 4 power modes (7W, 15W, 25W, MAXN). Each mode:
+
+- Is set via `nvpmodel` -- writes to the device's flash storage
+- Requires a reboot to commit the new mode
+- Locks CPU / GPU / DLA frequencies into a specific bin
+- Yields materially different peak FP16, peak INT8, sustained throughput
+- Implies different cooling solution (passive vs active fan vs thermal headroom)
+- Implies different battery life on mobile platforms
+- Has different software stack guarantees (some CUDA features are gated behind certain power profiles)
+
+From the **deployment perspective**, "Jetson Orin Nano in 7W mode" and "Jetson Orin Nano in 15W mode" are different products that the agentic system should reason about distinctly. The roboticist deciding whether their drone-payload AI fits in 7W envelope or needs 15W shouldn't be asking "Orin Nano" -- they should be asking "Orin Nano at which mode?".
+
+But from the **data perspective**, chip-level fab attributes (die size, transistor count, process node, foundry, architecture, launch date, MSRP) are identical across all modes. They're properties of the silicon, not properties of the runtime configuration.
+
+This document captures how we resolved that tension.
+
+---
+
+## What the repo had before this work
+
+Substantial pieces of the per-profile data layer already existed:
+
+- **`ThermalOperatingPoint`** (`src/graphs/hardware/resource_model.py:733`) represents one mode -- `name`, `tdp_watts`, `cooling_solution`, and `performance_specs: Dict[Precision, PerformanceCharacteristics]`.
+- **The Orin Nano resource model** (`src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py`) already enumerated `7W`, `15W`, `MAXN` profiles with full per-profile clock and peak data populated from NVIDIA's published specs.
+- **`HardwareMapper.__init__`** accepts `thermal_profile` to select which mode is active for the returned mapper.
+- **`HardwareResourceModel.default_thermal_profile`** designates a sensible default for "give me one number" queries.
+
+So the **per-profile data** was reachable; it just wasn't **addressable**. Three concrete gaps:
+
+1. **No alias-style lookup**: `get_mapper_by_name("Jetson-Orin-Nano-8GB-7W")` returned `None`. The profile was a separate kwarg.
+2. **No SKU enumeration that included profiles**: `list_all_mappers()` returned 46 silicon-bin names. The agentic system couldn't enumerate "all addressable deployment targets" without manually walking each mapper's `thermal_operating_points`.
+3. **No clean home for module-level fields that aren't profile-dependent**: `memory_type` (LPDDR5 / HBM3 / etc.) and `memory_bus_width_bits` are silicon-bin properties (don't change across nvpmodel modes) but had no structured location in `PhysicalSpec`.
+
+---
+
+## The user-side ergonomics question
+
+The original suggestion was: **make each (silicon × profile) a separate registry entry**. So instead of `Jetson-Orin-Nano-8GB`, the registry would have `Jetson-Orin-Nano-8GB-7W`, `Jetson-Orin-Nano-8GB-15W`, `Jetson-Orin-Nano-8GB-MAXN` as 3 distinct entries. Each gets its own full `PhysicalSpec`.
+
+This was the right deployment-perspective intuition: power profiles ARE SKU-like for embodied AI. The question was the data-layer realization.
+
+### Why "duplicate the registry entry" didn't survive review
+
+Three concrete costs:
+
+1. **Data duplication.** Across the registry, ~5 of the 46 mappers have multiple thermal profiles. Each has 3-4 modes. So ~5 × ~3.5 = ~17.5 SKU records would replace ~5 silicon-bin records. Each profile-SKU would carry the full `PhysicalSpec` -- die size, transistors, foundry, process node, architecture, launch date, MSRP, packaging metadata. That's ~10 fields × ~17.5 records = ~175 redundant cells, where ~140 are exact-copy duplications.
+
+2. **Drift risk.** When NVIDIA discloses a new transistor count or someone corrects a die-size measurement, you'd have to update all profile variants in lockstep. Single source of truth says: chip-level data should live in exactly one place.
+
+3. **Adding a new profile becomes a copy-paste exercise.** If NVIDIA ships an "Orin Nano Super 2.0" 25W mode, you'd construct a brand-new full-spec entry. With the alias model, you just add a new `ThermalOperatingPoint` to the existing resource model and the alias machinery picks it up automatically.
+
+### Why "leave it as-is and have callers know about thermal_profile" didn't survive either
+
+The user's deployment intuition was correct. From the orchestrator's perspective, "give me the deployment SKU we should provision against" needs an answer that includes the power mode, because that's what the customer is deploying onto. Forcing every consumer to know to pass `thermal_profile=` is poor ergonomics, and it makes "list all SKUs we support" awkward (you'd have to walk per-mapper and union with thermal_operating_points keys).
+
+---
+
+## The chosen design: aliases at the registry layer
+
+The registry continues to hold ONE entry per silicon-bin -- one PhysicalSpec, one factory, one set of category/vendor metadata. **Profile addressability is provided through alias resolution at lookup time**, not through duplicated registry entries.
+
+Two alias forms are accepted:
+
+| Form | Example | When to use |
+|------|---------|-------------|
+| Explicit separator | `Jetson-Orin-Nano-8GB@7W` | Unambiguous; recommended for code, scripts, agentic-system enumeration |
+| Dashed | `Jetson-Orin-Nano-8GB-7W` | Convenience for human typing; resolved by longest-prefix-match against registry keys |
+
+`get_mapper_by_name` resolves either form by:
+
+1. Looking the name up directly in the silicon-bin registry. If hit -> use legacy code path with optional `thermal_profile` kwarg.
+2. Otherwise, parse as `{silicon}@{profile}` first (explicit separator wins). Validate the profile against the silicon's registered `thermal_operating_points` before resolving.
+3. Otherwise, parse as `{silicon}-{profile}` by trying every registered silicon-bin as a longest-prefix candidate.
+4. If neither resolves, return `None` (preserves existing not-found semantics).
+
+`list_all_skus(include_profile_aliases=True)` enumerates the silicon-bins plus one alias per registered profile, using the explicit-separator form. The agentic system iterating "all available deployment targets" calls this; legacy callers continue to use `list_all_mappers()` and see only silicon-bins.
+
+### Why the kwarg always wins over an alias-encoded profile
+
+If a caller passes BOTH a profile-suffixed name AND `thermal_profile=`, that's ambiguous. We resolve in favor of the kwarg because it's the more explicit user signal -- they specifically typed the parameter name. This is documented in `get_mapper_by_name`'s docstring and locked in by `TestKwargPrecedence` in `tests/hardware/test_profile_aliases.py`.
+
+### Why `@` is the right separator
+
+The alternatives are:
+- `_` (underscore): would clash with profile names like `MAXN_Super` if vendors used underscores.
+- `-` (dash): already used inside both silicon names (`Jetson-Orin-Nano-8GB`) and profile names (`MAXN-Super`). Parsing requires longest-prefix-match, which works but is not unambiguous.
+- `:` (colon): unfriendly to filesystem-aware tools and copy-paste from URLs.
+- `@`: not used anywhere else in our naming, can't appear in either silicon names or profile names. Matches conventions like Docker image references (`name@digest`) and `pip install package@version`.
+
+`@` wins by elimination. The dashed form is supported as a convenience but the explicit form is what `list_all_skus` emits and what we recommend in documentation.
+
+---
+
+## Where each field belongs
+
+| Field | Layer | Why |
+|-------|-------|-----|
+| `die_size_mm2`, `transistors_billion`, `process_node_nm`, `process_node_name`, `foundry`, `architecture` | `PhysicalSpec` (silicon-bin) | Properties of silicon. Unchanged across modes. |
+| `launch_date`, `launch_msrp_usd` | `PhysicalSpec` (silicon-bin) | Module-level commercial property. Unchanged across modes. |
+| `num_dies`, `is_chiplet`, `package_type` | `PhysicalSpec` (silicon-bin) | Packaging is silicon-level. |
+| `memory_type` (LPDDR5 / HBM3 / etc.) | `PhysicalSpec` -- **to be added in Phase 3** | Module SKU constant. Doesn't change per nvpmodel mode. |
+| `memory_bus_width_bits` | `PhysicalSpec` -- **to be added in Phase 3** | Module SKU constant. |
+| `tdp_watts`, `cooling_solution` | `ThermalOperatingPoint` (already there) | Defines the mode. |
+| Core base / boost clocks | `PerformanceCharacteristics` per `ThermalOperatingPoint` (already there as `core_frequency_hz` / `sustained_clock_hz`) | Varies by mode. |
+| `memory_clock_mhz` | `ThermalOperatingPoint` -- **to be added in Phase 4** | Varies by mode on Jetson (lower power modes throttle DRAM clock). |
+| Peak throughput per precision | `ThermalOperatingPoint.performance_specs` (already there) | Mode-dependent. |
+| `name`, `category`, `vendor`, `description` | Registry metadata (already there) | Identity. |
+
+The principle: **silicon properties on `PhysicalSpec`, mode properties on `ThermalOperatingPoint`**. Memory clock straddles the line because Jetson throttles DRAM in low-power modes, so it goes per-mode. Memory type is fixed by the package, so it stays at the silicon-bin level.
+
+---
+
+## Implementation phases
+
+### Phase 1 (this commit, PR #137) -- Profile addressability via registry aliases
+
+- `get_mapper_by_name` resolves both `{silicon}@{profile}` and `{silicon}-{profile}` forms.
+- `list_all_skus(include_profile_aliases=True)` enumerates all addressable forms.
+- 20 new tests in `tests/hardware/test_profile_aliases.py`.
+- Backward-compatible: legacy callers see no behavior change.
+
+### Phase 2 -- Spec-sheet expansion
+
+`cli/list_hardware_resources.py` gains a `--profiles {default, all}` flag. `default` (current behavior) shows one row per silicon SKU using the default profile; `all` expands to one row per (silicon × profile) combination, with new columns for Mode, Base MHz, Boost MHz, Memory Clock, Memory Type. The `name` column shows the alias form when expanded so output is self-describing.
+
+### Phase 3 -- Promote module-level fields to PhysicalSpec
+
+Add `memory_type: Optional[str]` and `memory_bus_width_bits: Optional[int]` to `PhysicalSpec`. These are silicon-bin constants that today live nowhere structured (only embedded in resource_model internals). Backfill on H100 + the 4 Jetson SKUs we've populated so far.
+
+### Phase 4 -- Add `memory_clock_mhz` to `ThermalOperatingPoint`
+
+The base/boost core clocks already live in `PerformanceCharacteristics` per profile. Add memory clock as a typed field on `ThermalOperatingPoint` so renderers can read it without diving into PerformanceCharacteristics indirection. Per-profile because Jetson 7W mode throttles DRAM (~2133 MHz vs 3200 MHz at 15W).
+
+### Phase 5 -- Update Embodied-AI-Architect orchestrator
+
+The orchestrator should recommend full silicon-profile SKUs (`Jetson-Orin-Nano-8GB@7W`), not bare silicon names. This is a downstream-consumer change in a separate repo; the `list_all_skus()` API in this repo is what enables it.
+
+---
+
+## Cross-vendor applicability
+
+The alias mechanism is a clean fit for vendors that ship enumerable persistent profiles (NVIDIA Jetson). It's inert for the rest:
+
+| Vendor / Type | Profile semantics | Alias behavior |
+|---------------|-------------------|----------------|
+| NVIDIA Jetson (Orin, Thor) | nvpmodel; persistent boot-time configuration | Multiple aliases per silicon-bin |
+| NVIDIA datacenter GPUs (H100 PCIe vs SXM5) | Form-factor + TDP are both fixed per SKU | One alias per silicon-bin (same as silicon-bin name + default profile) |
+| Apple Silicon (M-series) | Dynamic thermal throttling; no enumerable profiles | One alias (default profile) |
+| Server CPUs (Intel Xeon / AMD EPYC) | cTDP-up / cTDP-down via BIOS; coarse and platform-dependent | Could expose 2-3 aliases if the resource model registered them, but typically just one |
+| Mobile SoCs (Qualcomm, MediaTek) | Dynamic; device-tree configurable in some Linux deployments | One alias per registered profile |
+| Research accelerators (KPU, Plasticine v2) | Single TDP point in spec | One alias |
+
+The mechanism doesn't impose itself where it's not useful: any chip with one thermal_operating_point gets exactly one alias (`{silicon}@{default_profile}`), and the bare silicon-bin name continues to be the canonical address. So Phase 1 doesn't churn the addressing surface for the ~41 chips that aren't power-modulated -- it just unlocks proper addressing for the ~5 that are.
+
+---
+
+## Decisions captured for later
+
+These are open questions deferred to Phases 2-5 or to a future RFC:
+
+- **Should we deprecate the dashed alias form?** The `@` form is unambiguous; the dashed form requires longest-prefix-match parsing. We support both for now because the dashed form is what the user originally proposed and it's friendlier to type. If we see the parsing become a maintenance burden, we can deprecate dashed in a future major version.
+- **Should aliases include short forms like `Jetson-Orin-Nano-8GB-7W` instead of the full profile name `Jetson-Orin-Nano-8GB@7W-battery`?** Currently aliases use whatever's in `thermal_operating_points` as the key. Short-form generation would require resolving collisions when two profiles share a TDP wattage but differ in cooling. Punted to Phase 2 if user demand surfaces.
+- **Should `default_thermal_profile` be discoverable from the alias?** Today, bare `Jetson-Orin-Nano-8GB` returns the default profile silently. We could emit `Jetson-Orin-Nano-8GB@default` as an alias, but that adds noise. Status quo stands until someone asks for it.
+- **How does this interact with the `embodied-schemas` ComputeProduct unification (RFC 0001)?** The `ComputeProduct` shape will need to express modes. We could put modes in a new `power_modes: list[PowerMode]` field at the spine level (mirroring `ThermalOperatingPoint` here), or as a property of each `Block` if modes are sometimes block-scoped. Decision deferred to Phase 1 of the unification RFC.
+
+---
+
+## Test artifacts
+
+- `tests/hardware/test_profile_aliases.py` (20 tests, this commit)
+- `tests/cli/test_list_hardware_resources.py` -- two stale assertions fixed (PR #135 invalidated H100-is-the-only-populated-GPU assumption when populating the 4 Jetsons; rewrote to test the actual contract that populated rows precede missing rows in any sort direction)
+
+---
+
+## Related work
+
+- #133 (merged) -- PhysicalSpec foundation
+- #134 (merged) -- `cli/list_hardware_resources.py` spec-sheet CLI
+- #135 (merged) -- Backfill PhysicalSpec for 4 Jetson SKUs
+- #136 (open umbrella) -- This work, full plan
+- #137 (this PR) -- Phase 1 implementation
+- #132 (open) -- Switch PhysicalSpec source to embodied-schemas ComputeProduct loader; ComputeProduct will need to express modes too
+- embodied-schemas RFC 0001 (merged as #7) -- Unified ComputeProduct schema; the alias mechanism here is what the orchestrator will use to recommend full silicon-profile SKUs once the schema lands

--- a/src/graphs/hardware/mappers/__init__.py
+++ b/src/graphs/hardware/mappers/__init__.py
@@ -7,7 +7,8 @@ This module provides a registry of all available hardware mappers and functions
 to discover and instantiate them.
 """
 
-from typing import Dict, List, Optional, Callable, Any
+import re
+from typing import Dict, List, Optional, Callable, Any, Tuple
 from dataclasses import dataclass
 
 # Lazy import to avoid circular dependencies
@@ -523,9 +524,90 @@ def _init_registry():
 
 
 def list_all_mappers() -> List[str]:
-    """Return list of all available mapper names."""
+    """Return list of all available silicon-bin mapper names.
+
+    Profile aliases (e.g., ``Jetson-Orin-Nano-8GB@7W-battery``) are NOT
+    included here -- this preserves the original API for callers that only
+    care about silicon SKUs. Use :func:`list_all_skus` to get the expanded
+    list including profile aliases.
+    """
     _init_registry()
     return list(_MAPPER_REGISTRY.keys())
+
+
+# ---------------------------------------------------------------------------
+# Profile-as-SKU addressing (issue #136)
+# ---------------------------------------------------------------------------
+#
+# For embodied AI deployment, the same silicon ships in multiple persistent
+# power profiles (e.g., Jetson Orin Nano: 7W / 15W / MAXN). These are
+# `nvpmodel` modes -- boot-time configurations that lock CPU/GPU/DLA
+# frequencies and yield materially different peak performance and TDP.
+#
+# We expose them as addressable SKUs without duplicating chip-level data:
+# the registry stores ONE entry per silicon-bin (its PhysicalSpec, factory,
+# metadata are unique). Profile addressability is provided by parsing
+# alias names of the form ``{silicon}@{profile}`` (or ``{silicon}-{profile}``
+# for a friendlier dashed form) at ``get_mapper_by_name`` time, validating
+# the profile against the mapper's registered ``thermal_operating_points``,
+# and instantiating the factory with the selected profile.
+
+_AT_PROFILE_RE = re.compile(r"^(.+?)@(.+)$")
+
+
+def _resolve_profile_alias(name: str) -> Optional[Tuple[str, str]]:
+    """Parse a profile-suffixed alias and return ``(silicon_bin, profile)``.
+
+    Two forms are supported, in priority order:
+
+    1. **Explicit separator**: ``"{silicon}@{profile}"``. Unambiguous;
+       ``@`` cannot appear in either silicon names or profile names.
+    2. **Dashed form**: ``"{silicon}-{profile}"``. Resolved by trying every
+       registered silicon-bin as a longest-match prefix; the suffix must
+       be a registered ``thermal_operating_point`` of that mapper.
+
+    Returns ``None`` if the input doesn't match any silicon-bin in the
+    registry or if the profile portion isn't a registered thermal profile.
+
+    Note: this function may instantiate factories to read the
+    ``thermal_operating_points`` dict. The cost is one factory call per
+    candidate prefix tried, so worst-case for the dashed form is O(N)
+    instantiations where N is the registry size. For frequently-queried
+    aliases consider an explicit-separator form which short-circuits.
+    """
+    _init_registry()
+
+    # Form 1: explicit separator.
+    m = _AT_PROFILE_RE.match(name)
+    if m:
+        silicon, profile = m.group(1), m.group(2)
+        info = _MAPPER_REGISTRY.get(silicon)
+        if info is None:
+            return None
+        try:
+            mapper = info["factory"]()
+        except Exception:
+            return None
+        if profile in mapper.resource_model.thermal_operating_points:
+            return silicon, profile
+        # @ form was tried explicitly; don't fall through to dashed.
+        return None
+
+    # Form 2: dashed. Try registry keys as prefixes, longest first to
+    # disambiguate (e.g., when "Foo-Bar" and "Foo" are both registered).
+    for silicon in sorted(_MAPPER_REGISTRY.keys(), key=len, reverse=True):
+        if not name.startswith(silicon + "-"):
+            continue
+        profile = name[len(silicon) + 1:]
+        try:
+            mapper = _MAPPER_REGISTRY[silicon]["factory"]()
+        except Exception:
+            continue
+        if profile in mapper.resource_model.thermal_operating_points:
+            return silicon, profile
+        # Don't break -- a shorter prefix might still resolve if the
+        # current prefix's thermal profiles don't cover the suffix.
+    return None
 
 
 def get_mapper_by_name(name: str, thermal_profile: str = None):
@@ -533,25 +615,68 @@ def get_mapper_by_name(name: str, thermal_profile: str = None):
     Get a hardware mapper by name.
 
     Args:
-        name: Mapper name (e.g., "Jetson-Orin-Nano-8GB")
-        thermal_profile: Optional thermal profile override
+        name: Either a silicon-bin name (e.g., ``"Jetson-Orin-Nano-8GB"``)
+              or a profile-aliased name (e.g., ``"Jetson-Orin-Nano-8GB@7W-battery"``
+              or the dashed form ``"Jetson-Orin-Nano-8GB-7W-battery"``).
+        thermal_profile: Optional thermal profile override. If provided, it
+              ALWAYS wins over a profile encoded in ``name``.
 
     Returns:
-        HardwareMapper instance or None if not found
+        HardwareMapper instance or ``None`` if neither the silicon-bin nor
+        any alias resolves.
     """
     _init_registry()
-    info = _MAPPER_REGISTRY.get(name)
-    if info is None:
-        return None
 
-    factory = info["factory"]
+    silicon = name
+    alias_profile: Optional[str] = None
+
+    if silicon not in _MAPPER_REGISTRY:
+        resolved = _resolve_profile_alias(name)
+        if resolved is None:
+            return None
+        silicon, alias_profile = resolved
+
+    # Explicit kwarg wins over alias-derived profile.
+    profile_to_use = thermal_profile or alias_profile
+    factory = _MAPPER_REGISTRY[silicon]["factory"]
     try:
-        if thermal_profile:
-            return factory(thermal_profile=thermal_profile)
+        if profile_to_use:
+            return factory(thermal_profile=profile_to_use)
         return factory()
     except TypeError:
-        # Factory doesn't accept thermal_profile
+        # Factory doesn't accept thermal_profile kwarg -- fall back to
+        # default-profile instantiation.
         return factory()
+
+
+def list_all_skus(include_profile_aliases: bool = True) -> List[str]:
+    """Return all addressable SKU names: silicon-bins plus profile aliases.
+
+    With ``include_profile_aliases=True`` (default), enumerates each
+    silicon-bin's ``thermal_operating_points`` and emits one alias of the
+    form ``"{silicon}@{profile}"`` per profile. The explicit-separator form
+    is used because the dashed form depends on parser disambiguation.
+
+    The ergonomics: deployments that target a specific power mode can
+    address it directly (``Jetson-Orin-Nano-8GB@7W-battery``). The agentic
+    system enumerating all available SKUs sees the full per-profile set.
+
+    Cost: instantiates every registered factory once. For a fast view of
+    silicon-bin names only, prefer :func:`list_all_mappers`.
+    """
+    _init_registry()
+    skus: List[str] = []
+    for silicon, info in _MAPPER_REGISTRY.items():
+        skus.append(silicon)
+        if not include_profile_aliases:
+            continue
+        try:
+            mapper = info["factory"]()
+        except Exception:
+            continue
+        for profile in mapper.resource_model.thermal_operating_points:
+            skus.append(f"{silicon}@{profile}")
+    return skus
 
 
 def get_mapper_info(name: str) -> Optional[Dict[str, Any]]:
@@ -609,6 +734,7 @@ def list_mappers_by_tdp_range(min_tdp_w: float, max_tdp_w: float) -> List[str]:
 
 __all__ = [
     "list_all_mappers",
+    "list_all_skus",
     "get_mapper_by_name",
     "get_mapper_info",
     "list_mappers_by_category",

--- a/src/graphs/hardware/mappers/__init__.py
+++ b/src/graphs/hardware/mappers/__init__.py
@@ -636,17 +636,27 @@ def get_mapper_by_name(name: str, thermal_profile: str = None):
             return None
         silicon, alias_profile = resolved
 
-    # Explicit kwarg wins over alias-derived profile.
-    profile_to_use = thermal_profile or alias_profile
+    # Explicit kwarg wins over alias-derived profile. Using ``is not None``
+    # rather than truthiness so an explicit empty-string ``thermal_profile=""``
+    # doesn't silently fall back to the alias profile (the empty string is
+    # an invalid profile anyway, but the precedence rule should be uniform).
+    profile_to_use = thermal_profile if thermal_profile is not None else alias_profile
     factory = _MAPPER_REGISTRY[silicon]["factory"]
     try:
-        if profile_to_use:
+        if profile_to_use is not None:
             return factory(thermal_profile=profile_to_use)
         return factory()
     except TypeError:
-        # Factory doesn't accept thermal_profile kwarg -- fall back to
-        # default-profile instantiation.
-        return factory()
+        # Factory doesn't accept thermal_profile kwarg. Instantiate with
+        # default and post-hoc-assign the requested profile if one was
+        # resolved (we already validated it exists during alias resolution
+        # / kwarg dispatch above, so no re-check needed).
+        mapper = factory()
+        if profile_to_use is not None and profile_to_use in (
+            mapper.resource_model.thermal_operating_points or {}
+        ):
+            mapper.thermal_profile = profile_to_use
+        return mapper
 
 
 def list_all_skus(include_profile_aliases: bool = True) -> List[str]:

--- a/src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py
+++ b/src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py
@@ -272,6 +272,68 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
     )
 
     # ========================================================================
+    # 25W MODE: Orin Nano Super at fixed 25W cap (production deployment)
+    # ========================================================================
+    # The Super refresh (Dec 2024) raised the chip's power budget to 25W.
+    # The "25W" mode is an explicit fixed-cap deployment config -- DVFS
+    # allowed within the 25W envelope so the chip can scale down for
+    # power-aware workloads while still being thermally provisioned for
+    # full Super performance. This is the recommended production mode for
+    # devices that have active cooling but want predictable power
+    # accounting. Compare to MAXN below, which locks DVFS off and runs at
+    # boost regardless of headroom.
+    #
+    # Performance characteristics match MAXN at peak workloads (cuBLAS pegs
+    # at boost in both); the operational difference is in idle / mixed
+    # workloads where 25W mode allows DVFS to drop clocks for power saving.
+    clock_25w = ClockDomain(
+        base_clock_hz=306e6,
+        max_boost_clock_hz=1020e6,
+        sustained_clock_hz=1020e6,  # Same boost ceiling as MAXN
+        dvfs_enabled=True,           # KEY DIFFERENCE vs MAXN: DVFS allowed
+    )
+
+    compute_resource_25w = ComputeResource(
+        resource_type="Ampere-SM-TensorCore",
+        num_units=num_sms,
+        ops_per_unit_per_clock={
+            Precision.INT8: int8_ops_per_sm_per_clock,
+            Precision.FP16: fp16_ops_per_sm_per_clock,
+            Precision.FP32: fp32_ops_per_sm_per_clock,
+        },
+        clock_domain=clock_25w,
+    )
+
+    thermal_25w = ThermalOperatingPoint(
+        name="25W-Super",
+        tdp_watts=25.0,
+        cooling_solution="active-fan",
+        performance_specs={
+            Precision.INT8: PerformanceCharacteristics(
+                precision=Precision.INT8,
+                compute_resource=compute_resource_25w,
+                instruction_efficiency=0.95,
+                memory_bottleneck_factor=0.80,
+                efficiency_factor=0.80,
+                native_acceleration=True,
+            ),
+            Precision.FP16: PerformanceCharacteristics(
+                precision=Precision.FP16,
+                compute_resource=compute_resource_25w,
+                # Same calibration as MAXN (cuBLAS pegs at boost).
+                efficiency_factor=0.85,
+                native_acceleration=True,
+            ),
+            Precision.FP32: PerformanceCharacteristics(
+                precision=Precision.FP32,
+                compute_resource=compute_resource_25w,
+                efficiency_factor=0.40,
+                native_acceleration=True,
+            ),
+        },
+    )
+
+    # ========================================================================
     # MAXN MODE: Orin Nano Super (Dec 2024 refresh) at full power
     # ========================================================================
     # Super refresh raised the power budget from 15W to 25W, allowing higher
@@ -363,11 +425,20 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
         threads_per_unit=64,
         warps_per_unit=2,
         warp_size=32,
-        # Thermal operating points with DVFS modeling
+        # Thermal operating points with DVFS modeling.
+        # Four canonical modes for Orin Nano Super (Dec 2024+):
+        #   7W   -- battery / drone-payload deployment
+        #   15W  -- standard edge AI baseline (Phase B reference)
+        #   25W  -- production deployment with explicit 25W cap (DVFS on)
+        #   MAXN -- developer/burst mode, locked at boost (DVFS off)
+        # 25W and MAXN share the same TDP cap (the silicon's max envelope on
+        # Super) but differ in DVFS behavior: 25W scales down on idle for
+        # power-aware deployments, MAXN locks at boost regardless.
         thermal_operating_points={
-            "7W": thermal_7w,  # Battery-powered devices
+            "7W": thermal_7w,    # Battery-powered devices
             "15W": thermal_15w,  # Orin Nano Super 15W (Phase B baseline)
-            "MAXN": thermal_maxn,  # Orin Nano Super at full 25W power
+            "25W": thermal_25w,  # Production 25W cap with DVFS (#136)
+            "MAXN": thermal_maxn,  # Orin Nano Super at full 25W power, DVFS off
         },
         # 15W is the default because the V4 Phase B baseline (#90) was
         # captured in the 15W thermal profile. Operators running at

--- a/tests/cli/test_list_hardware_resources.py
+++ b/tests/cli/test_list_hardware_resources.py
@@ -238,18 +238,48 @@ class TestSorting:
         data = json.loads(out.read_text())
         return [p["name"] for p in data["products"]]
 
-    def test_sort_die_size_reverse_puts_populated_first(self, tmp_path):
-        names = self._names_for_sort(tmp_path, "--category", "gpu", "--sort", "die_size", "--reverse")
-        # H100 SXM5 is the only populated GPU; it should appear FIRST under
-        # --sort die_size --reverse, not last (regression guard for the
-        # missing-value placement bug).
-        assert names[0] == "H100-SXM5-80GB"
+    def _records_for_sort(self, tmp_path, *args):
+        out = tmp_path / "spec.json"
+        _run(*args, output_path=out)
+        data = json.loads(out.read_text())
+        return data["products"]
 
-    def test_sort_die_size_ascending_still_puts_populated_first(self, tmp_path):
-        # In ascending order, populated values come first too because we
-        # explicitly trail missing values at the end.
-        names = self._names_for_sort(tmp_path, "--category", "gpu", "--sort", "die_size")
-        assert names[0] == "H100-SXM5-80GB"
+    def test_sort_die_size_reverse_populated_rows_precede_missing(self, tmp_path):
+        # The contract: missing-value rows always trail, regardless of
+        # sort direction. This is the regression guard for the original
+        # missing-value-placement bug (PR #134) -- with the naive
+        # `key=(missing, value), reverse=True` approach, missing rows
+        # would flip to the FRONT under --reverse.
+        records = self._records_for_sort(
+            tmp_path, "--category", "gpu", "--sort", "die_size", "--reverse"
+        )
+        die_sizes = [r["die_size_mm2"] for r in records]
+        # Non-None dies first, then Nones.
+        last_populated = next(
+            (i for i, d in enumerate(die_sizes) if d is None), len(die_sizes)
+        )
+        assert all(d is not None for d in die_sizes[:last_populated])
+        assert all(d is None for d in die_sizes[last_populated:])
+        # Populated rows are sorted descending.
+        populated = die_sizes[:last_populated]
+        assert populated == sorted(populated, reverse=True)
+        # And H100 (largest die at 814 mm^2) should come first among GPUs.
+        assert records[0]["name"] == "H100-SXM5-80GB"
+
+    def test_sort_die_size_ascending_populated_rows_precede_missing(self, tmp_path):
+        # Same contract as above for ascending order: populated rows first,
+        # then missing. Populated rows sorted ascending.
+        records = self._records_for_sort(
+            tmp_path, "--category", "gpu", "--sort", "die_size"
+        )
+        die_sizes = [r["die_size_mm2"] for r in records]
+        last_populated = next(
+            (i for i, d in enumerate(die_sizes) if d is None), len(die_sizes)
+        )
+        assert all(d is not None for d in die_sizes[:last_populated])
+        assert all(d is None for d in die_sizes[last_populated:])
+        populated = die_sizes[:last_populated]
+        assert populated == sorted(populated)
 
     def test_sort_name_default_is_alphabetical(self, tmp_path):
         names = self._names_for_sort(tmp_path, "--category", "gpu")

--- a/tests/hardware/test_profile_aliases.py
+++ b/tests/hardware/test_profile_aliases.py
@@ -110,6 +110,25 @@ class TestKwargPrecedence:
         assert m is not None
         assert m.thermal_profile == "MAXN"
 
+    def test_empty_string_kwarg_does_not_silently_fall_back_to_alias(self):
+        # ``thermal_profile=""`` is an explicit (if invalid) user signal,
+        # not a "not provided" sentinel. Precedence is checked with
+        # ``is not None`` so the empty string takes priority over the
+        # alias-encoded profile. The empty string isn't a registered
+        # profile, so the underlying factory call fails the lookup and
+        # the resource model raises -- but we should NOT have silently
+        # routed the request to the alias-encoded "7W".
+        try:
+            m = get_mapper_by_name(
+                "Jetson-Orin-Nano-8GB@7W", thermal_profile=""
+            )
+        except (ValueError, KeyError):
+            # Expected: empty string isn't a valid profile.
+            return
+        # If the factory was tolerant of empty-string and didn't raise,
+        # at minimum the alias-encoded "7W" should NOT have leaked through.
+        assert m is None or m.thermal_profile != "7W"
+
 
 class TestSkuEnumeration:
     def test_list_all_skus_includes_silicon_and_aliases(self):
@@ -131,14 +150,34 @@ class TestSkuEnumeration:
         for a in aliases:
             assert a.count("@") == 1
 
-    def test_list_all_skus_orin_nano_has_three_profiles(self):
-        # Orin Nano resource model registers 7W, 15W, MAXN. Confirm the
-        # alias enumeration matches.
+    def test_list_all_skus_orin_nano_has_four_profiles(self):
+        # Orin Nano Super resource model registers four canonical modes:
+        # 7W (battery), 15W (Phase B baseline), 25W (production cap with
+        # DVFS), MAXN (developer/burst, DVFS off). Anchored on the user
+        # directive captured in #136. Should this expand in the future
+        # (e.g., a 50W mode for some hypothetical refresh), update this
+        # test alongside the resource model -- the assertion is exact by
+        # design to catch silent profile additions/removals.
         nano_aliases = [
             s for s in list_all_skus() if s.startswith("Jetson-Orin-Nano-8GB@")
         ]
         profiles = sorted(s.split("@", 1)[1] for s in nano_aliases)
-        assert profiles == ["15W", "7W", "MAXN"]
+        assert profiles == ["15W", "25W", "7W", "MAXN"]
+
+    def test_orin_nano_25w_and_maxn_share_tdp_but_differ_in_dvfs(self):
+        # 25W mode and MAXN mode both cap at 25W TDP on the Super silicon
+        # but have different DVFS semantics: 25W allows scaling down for
+        # power-aware workloads, MAXN locks at boost. Spec invariant:
+        # both modes have tdp_watts=25.0 but different cooling and DVFS
+        # configurations.
+        m_25w = get_mapper_by_name("Jetson-Orin-Nano-8GB@25W")
+        m_maxn = get_mapper_by_name("Jetson-Orin-Nano-8GB@MAXN")
+        assert m_25w is not None and m_maxn is not None
+        rm_25w = m_25w.resource_model.thermal_operating_points["25W"]
+        rm_maxn = m_maxn.resource_model.thermal_operating_points["MAXN"]
+        assert rm_25w.tdp_watts == rm_maxn.tdp_watts == 25.0
+        # Distinct entries -- not aliases of the same object.
+        assert rm_25w.name != rm_maxn.name
 
     def test_include_profile_aliases_false_returns_silicon_only(self):
         skus = list_all_skus(include_profile_aliases=False)

--- a/tests/hardware/test_profile_aliases.py
+++ b/tests/hardware/test_profile_aliases.py
@@ -1,0 +1,173 @@
+"""Tests for profile-as-SKU registry aliases (issue #136 Phase 1).
+
+Locks in the contract:
+- ``list_all_mappers()`` returns silicon-bin names only (backward-compat)
+- ``list_all_skus()`` adds profile aliases of the form ``"{silicon}@{profile}"``
+- ``get_mapper_by_name`` resolves both ``@`` and dashed alias forms
+- Bare silicon-bin name still uses the default thermal profile
+- ``thermal_profile`` kwarg always wins over an alias-derived profile
+- Invalid profile names return ``None``, not raise
+"""
+
+import pytest
+
+from graphs.hardware.mappers import (
+    get_mapper_by_name,
+    list_all_mappers,
+    list_all_skus,
+)
+from graphs.hardware.mappers import _resolve_profile_alias
+
+
+class TestBackwardCompat:
+    def test_list_all_mappers_returns_silicon_bins_only(self):
+        names = list_all_mappers()
+        assert len(names) > 0
+        # No alias forms in this list -- preserves legacy callers.
+        assert all("@" not in n for n in names)
+
+    def test_bare_silicon_name_uses_default_profile(self):
+        # get_mapper_by_name without a kwarg should return the default
+        # thermal profile, identical to pre-#136 behavior.
+        m = get_mapper_by_name("Jetson-Orin-Nano-8GB")
+        assert m is not None
+        # 15W is the default profile on Orin Nano (set in the resource model).
+        assert m.thermal_profile == "15W"
+
+    def test_legacy_thermal_profile_kwarg_still_works(self):
+        # Pre-#136 callers passing `thermal_profile=` to a bare name should
+        # behave unchanged.
+        m = get_mapper_by_name("Jetson-Orin-Nano-8GB", thermal_profile="7W")
+        assert m is not None
+        assert m.thermal_profile == "7W"
+
+
+class TestAliasResolution:
+    """Both alias forms (@ and dashed) resolve correctly."""
+
+    def test_at_form_resolves(self):
+        m = get_mapper_by_name("Jetson-Orin-Nano-8GB@7W")
+        assert m is not None
+        assert m.thermal_profile == "7W"
+        # Operational fields reflect the chosen profile.
+        tdp = m.resource_model.thermal_operating_points[m.thermal_profile].tdp_watts
+        assert tdp == 7.0
+
+    def test_dashed_form_resolves(self):
+        m = get_mapper_by_name("Jetson-Orin-Nano-8GB-15W")
+        assert m is not None
+        assert m.thermal_profile == "15W"
+        tdp = m.resource_model.thermal_operating_points[m.thermal_profile].tdp_watts
+        assert tdp == 15.0
+
+    def test_at_and_dashed_forms_return_equivalent_mappers(self):
+        m_at = get_mapper_by_name("Jetson-Orin-Nano-8GB@MAXN")
+        m_dashed = get_mapper_by_name("Jetson-Orin-Nano-8GB-MAXN")
+        assert m_at is not None
+        assert m_dashed is not None
+        assert m_at.thermal_profile == m_dashed.thermal_profile == "MAXN"
+
+    def test_alias_resolution_works_for_orin_agx(self):
+        # Orin AGX 64GB has 4 thermal profiles (15W, 30W, 50W, MAXN per
+        # nvpmodel). Spot-check that the alias machinery works there too.
+        m = get_mapper_by_name("Jetson-Orin-AGX-64GB@30W")
+        assert m is not None
+        assert m.thermal_profile == "30W"
+
+
+class TestInvalidAliases:
+    def test_unknown_silicon_returns_none(self):
+        assert get_mapper_by_name("Definitely-Not-A-Chip") is None
+        assert get_mapper_by_name("Definitely-Not-A-Chip@7W") is None
+
+    def test_unknown_profile_returns_none(self):
+        # Silicon exists, but the profile suffix is bogus.
+        assert get_mapper_by_name("Jetson-Orin-Nano-8GB@99W-imaginary") is None
+        assert get_mapper_by_name("Jetson-Orin-Nano-8GB-99W-imaginary") is None
+
+    def test_at_form_does_not_fall_through_to_dashed(self):
+        # If the user types the @ form with an invalid profile, we must NOT
+        # silently fall through and try to interpret the whole string as a
+        # dashed alias. The @ is an explicit user signal of intent.
+        assert (
+            get_mapper_by_name("Jetson-Orin-Nano-8GB@imaginary")
+            is None
+        )
+
+
+class TestKwargPrecedence:
+    def test_kwarg_overrides_alias_profile(self):
+        # User typed @7W in the name AND passed thermal_profile=MAXN.
+        # The kwarg is the more explicit signal -- it wins.
+        m = get_mapper_by_name(
+            "Jetson-Orin-Nano-8GB@7W", thermal_profile="MAXN"
+        )
+        assert m is not None
+        assert m.thermal_profile == "MAXN"
+
+    def test_kwarg_overrides_dashed_alias_profile(self):
+        m = get_mapper_by_name(
+            "Jetson-Orin-Nano-8GB-7W", thermal_profile="MAXN"
+        )
+        assert m is not None
+        assert m.thermal_profile == "MAXN"
+
+
+class TestSkuEnumeration:
+    def test_list_all_skus_includes_silicon_and_aliases(self):
+        skus = list_all_skus()
+        silicon = list_all_mappers()
+        # Every silicon-bin name appears.
+        for s in silicon:
+            assert s in skus
+        # And we have strictly more entries (every silicon-bin has at least
+        # one thermal profile).
+        assert len(skus) > len(silicon)
+
+    def test_list_all_skus_alias_format_uses_at_separator(self):
+        skus = list_all_skus()
+        # Every alias entry should contain exactly one '@'. (Silicon-bin
+        # names never contain '@'.)
+        aliases = [s for s in skus if "@" in s]
+        assert len(aliases) > 0
+        for a in aliases:
+            assert a.count("@") == 1
+
+    def test_list_all_skus_orin_nano_has_three_profiles(self):
+        # Orin Nano resource model registers 7W, 15W, MAXN. Confirm the
+        # alias enumeration matches.
+        nano_aliases = [
+            s for s in list_all_skus() if s.startswith("Jetson-Orin-Nano-8GB@")
+        ]
+        profiles = sorted(s.split("@", 1)[1] for s in nano_aliases)
+        assert profiles == ["15W", "7W", "MAXN"]
+
+    def test_include_profile_aliases_false_returns_silicon_only(self):
+        skus = list_all_skus(include_profile_aliases=False)
+        assert all("@" not in s for s in skus)
+        assert sorted(skus) == sorted(list_all_mappers())
+
+    def test_every_alias_resolves(self):
+        # Sanity: every entry in list_all_skus() can be looked up by
+        # get_mapper_by_name. Guards against alias-format drift.
+        for sku in list_all_skus():
+            m = get_mapper_by_name(sku)
+            assert m is not None, f"alias did not resolve: {sku}"
+
+
+class TestResolveProfileAliasInternal:
+    """Direct tests for the private _resolve_profile_alias function. Useful
+    because the public get_mapper_by_name swallows the silicon/profile pair
+    and only exposes the resulting mapper instance."""
+
+    def test_at_form_returns_silicon_and_profile(self):
+        result = _resolve_profile_alias("Jetson-Orin-Nano-8GB@7W")
+        assert result == ("Jetson-Orin-Nano-8GB", "7W")
+
+    def test_dashed_form_returns_silicon_and_profile(self):
+        result = _resolve_profile_alias("Jetson-Orin-Nano-8GB-15W")
+        assert result == ("Jetson-Orin-Nano-8GB", "15W")
+
+    def test_unknown_returns_none(self):
+        assert _resolve_profile_alias("not-a-thing") is None
+        assert _resolve_profile_alias("Jetson-Orin-Nano-8GB@bogus") is None

--- a/tests/hardware/test_profile_aliases.py
+++ b/tests/hardware/test_profile_aliases.py
@@ -9,8 +9,6 @@ Locks in the contract:
 - Invalid profile names return ``None``, not raise
 """
 
-import pytest
-
 from graphs.hardware.mappers import (
     get_mapper_by_name,
     list_all_mappers,


### PR DESCRIPTION
## Summary

Phase 1 of #136. Makes power profiles addressable as first-class SKU names without duplicating chip-level data. The registry stays one-entry-per-silicon-bin; `get_mapper_by_name` now resolves alias names that include a profile suffix.

## Why

For embodied AI, the same silicon ships in multiple persistent power profiles (Jetson Orin Nano: 7W / 15W / MAXN; AGX: 15W / 30W / 50W / MAXN). These are `nvpmodel` modes -- boot-time configurations that lock CPU/GPU/DLA frequencies and yield materially different peaks and TDP. From the deployment perspective, each is a distinct product. The agentic system should be able to recommend `Jetson-Orin-Nano-8GB@15W` as a complete deployment target.

But chip-level fab data (die size, transistors, process node, foundry, architecture, launch, MSRP) is identical across all modes. Replicating it 4-5x per silicon family would be wasteful and create drift risk. So we expose addressability through aliases, not duplicate registry entries.

## What changed

`src/graphs/hardware/mappers/__init__.py`:
- New private `_resolve_profile_alias(name)` parses two alias forms:
  - `{silicon}@{profile}` -- explicit separator (recommended; unambiguous)
  - `{silicon}-{profile}` -- dashed (longest-prefix-match against registry keys; convenience form)
  Both validate the profile against the mapper's `thermal_operating_points` before resolving.
- `get_mapper_by_name` falls through to alias resolution on registry miss; `thermal_profile` kwarg always wins over alias-derived profile.
- New `list_all_skus(include_profile_aliases=True)` enumerates every addressable form. 46 silicon-bins -> 122 addressable SKUs (76 profile aliases) across the registry.
- Backward-compatible: `list_all_mappers()` still returns silicon-bin names only; bare-name lookup still uses default profile.

## Worked example

```python
>>> from graphs.hardware.mappers import get_mapper_by_name, list_all_skus

>>> get_mapper_by_name("Jetson-Orin-Nano-8GB").thermal_profile
'15W'  # default

>>> get_mapper_by_name("Jetson-Orin-Nano-8GB@7W").thermal_profile
'7W'   # battery-power deployment

>>> get_mapper_by_name("Jetson-Orin-Nano-8GB-MAXN").thermal_profile
'MAXN' # dashed form, peak power

>>> [s for s in list_all_skus() if "Orin-Nano" in s]
['Jetson-Orin-Nano-8GB',
 'Jetson-Orin-Nano-8GB@7W',
 'Jetson-Orin-Nano-8GB@15W',
 'Jetson-Orin-Nano-8GB@MAXN']
```

## Test plan

- [x] `tests/hardware/test_profile_aliases.py` -- 20 new tests:
  - Backward compat (list_all_mappers unchanged; bare-name uses default profile; legacy kwarg still works)
  - Alias resolution (both `@` and dashed forms; equivalence)
  - Invalid input handling (unknown silicon / unknown profile both return None; `@` form doesn't fall through to dashed)
  - kwarg precedence (kwarg wins over alias-encoded profile)
  - SKU enumeration (silicon-bins + aliases; format conformance; round-trip resolution)
- [x] Fixed two stale tests in `test_list_hardware_resources.py` that asserted "H100 is first under --sort die_size" (PR #135 invalidated those when populating the 4 Jetsons; rewrote to test the actual contract)
- [x] 44 tests pass locally (`tests/hardware/test_profile_aliases.py` + `tests/cli/test_list_hardware_resources.py`)
- [x] Draft fast CI passes
- [x] Promote when satisfied: `gh pr ready NNN`

## Tracking

- #136 (umbrella) -- this PR is Phase 1.
- Follow-ups: Phase 2 (`cli/list_hardware_resources.py --profiles all`), Phase 3 (`memory_type` / `memory_bus_width_bits` on PhysicalSpec), Phase 4 (`memory_clock_mhz` on ThermalOperatingPoint).

## Risks worth flagging

- **Cost**: dashed-form parsing instantiates one factory per candidate prefix tried (worst case O(N) instantiations where N is the registry size). For frequently-queried aliases the `@` form short-circuits at the first prefix match, so real-world cost is dominated by `@`-form callers. If this becomes hot, we can cache `(silicon, profiles)` metadata at registry-init time.
- **Profile-name churn**: Resolution always reads `thermal_operating_points` keys from the live resource model, so renames in vendor profile names propagate without code changes here. But callers hard-coding alias strings will need updates -- documented in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hardware can now be addressed using `{silicon}@{profile}` or `{silicon}-{profile}` notation for power-modulated systems.
  * New SKU enumeration function lists both silicon variants and thermal profile options.
  * Profile resolution with automatic precedence: explicit thermal parameters override alias-derived profiles.

* **Documentation**
  * Added comprehensive design documentation for profile-as-SKU addressing phases and system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->