### PR TITLE
feat(cli): --profiles all expansion + Mode/clock columns (#136 Phase 2)

### DIFF
--- a/cli/list_hardware_resources.py
+++ b/cli/list_hardware_resources.py
@@ -92,6 +92,17 @@ class HardwareResourceInfo:
     physical_spec_source: Optional[str]
     extras: Dict[str, Any] = field(default_factory=dict)
 
+    # Per-profile operational (from the active ThermalOperatingPoint).
+    # Always Optional: chips with a single placeholder thermal profile
+    # (datacenter GPUs that don't expose nvpmodel-style modes) keep these
+    # at None. Phase 2 of #136 -- replaces "show one number, hope it's
+    # the right one" with explicit profile addressing for power-modulated
+    # edge SoCs. Fields are at the end of the dataclass so existing
+    # positional construction keeps working.
+    mode: Optional[str] = None             # Profile name, e.g. "7W", "MAXN"
+    core_base_mhz: Optional[float] = None
+    core_boost_mhz: Optional[float] = None
+
 
 # ---------------------------------------------------------------------------
 # Discovery
@@ -124,36 +135,161 @@ def _peak_fp8_gflops(mapper) -> float:
     )
 
 
-def _tdp_watts(mapper) -> float:
-    """TDP from the default thermal profile, or 0.0 if no profiles registered."""
+def _resolve_active_profile(mapper) -> Optional[str]:
+    """Return the active thermal profile name for ``mapper``, or None.
+
+    Order of preference: the resource model's ``default_thermal_profile``,
+    falling back to the first registered profile if the default is missing.
+    Returns None when no thermal_operating_points are registered (typical
+    for datacenter GPUs that don't expose nvpmodel-style modes).
+    """
     rm = mapper.resource_model
-    profile_name = rm.default_thermal_profile
-    if profile_name is None or profile_name not in rm.thermal_operating_points:
-        if rm.thermal_operating_points:
-            profile_name = next(iter(rm.thermal_operating_points.keys()))
-        else:
-            return 0.0
-    return rm.thermal_operating_points[profile_name].tdp_watts
+    if not rm.thermal_operating_points:
+        return None
+    profile = rm.default_thermal_profile
+    if profile is None or profile not in rm.thermal_operating_points:
+        profile = next(iter(rm.thermal_operating_points.keys()))
+    return profile
 
 
-def _build_record(name: str, mapper, info: Dict[str, Any]) -> HardwareResourceInfo:
-    """Project one mapper + its registry metadata into a HardwareResourceInfo."""
+def _tdp_watts(mapper, profile_override: Optional[str] = None) -> float:
+    """TDP at the active profile, or 0.0 if no profiles registered."""
+    rm = mapper.resource_model
+    profile = profile_override if profile_override is not None else _resolve_active_profile(mapper)
+    if profile is None:
+        return 0.0
+    return rm.thermal_operating_points[profile].tdp_watts
+
+
+def _per_profile_peak_gflops(mapper, profile_name: str, precision: Precision) -> float:
+    """Per-profile peak ops at ``precision`` from the named ThermalOperatingPoint.
+
+    Reads from ``thermal_operating_points[profile].performance_specs[precision]
+    .compute_resource`` (the per-profile clock domain) so peaks reflect the
+    profile-specific boost clock.
+
+    Falls back to ``mapper.resource_model.get_peak_ops`` (the profile-agnostic
+    legacy path) when:
+    - the profile doesn't carry per-precision performance_specs (datacenter
+      GPU placeholder thermal_operating_point), or
+    - the compute_resource doesn't expose ``calc_peak_ops`` (architecture-
+      specific subclass like KPUComputeResource that uses tile allocation
+      semantics).
+
+    Returns 0.0 for unsupported precisions so the table stays rectangular.
+    """
+    top = mapper.resource_model.thermal_operating_points.get(profile_name)
+    if top is not None:
+        perf_char = top.performance_specs.get(precision)
+        if perf_char is not None:
+            calc = getattr(perf_char.compute_resource, "calc_peak_ops", None)
+            if callable(calc):
+                try:
+                    return calc(precision) / 1e9
+                except Exception:
+                    pass  # Fall through to legacy path.
+    return _safe_peak_gflops(mapper, precision)
+
+
+def _per_profile_peak_fp8_gflops(mapper, profile_name: str) -> float:
+    """FP8 peak across the generic + IEEE-variant enums for the named profile."""
+    return max(
+        _per_profile_peak_gflops(mapper, profile_name, Precision.FP8),
+        _per_profile_peak_gflops(mapper, profile_name, Precision.FP8_E4M3),
+        _per_profile_peak_gflops(mapper, profile_name, Precision.FP8_E5M2),
+    )
+
+
+def _clocks_from_profile(mapper, profile_name: str):
+    """Return ``(base_mhz, boost_mhz)`` from the profile's ClockDomain.
+
+    All precisions in a given ThermalOperatingPoint share the same
+    ClockDomain (verified in the resource models -- the same
+    compute_resource is reused across precision entries), so we read from
+    the first available PerformanceCharacteristics.
+
+    Returns ``(None, None)`` when:
+    - the profile has no performance_specs (datacenter GPU placeholder
+      thermal_operating_point), or
+    - the compute_resource has no ``clock_domain`` attribute (custom
+      architecture-specific subclass like KPUComputeResource), or
+    - the clock_domain has no max_boost_clock_hz / base_clock_hz fields.
+
+    Conservative on purpose: this is for spec-sheet rendering, not
+    estimation. Better to render N/A than to crash on architecture
+    variants we haven't seen.
+    """
+    top = mapper.resource_model.thermal_operating_points.get(profile_name)
+    if top is None or not top.performance_specs:
+        return None, None
+    first = next(iter(top.performance_specs.values()))
+    cd = getattr(first.compute_resource, "clock_domain", None)
+    if cd is None:
+        return None, None
+    base_hz = getattr(cd, "base_clock_hz", None)
+    boost_hz = getattr(cd, "max_boost_clock_hz", None)
+    if base_hz is None or boost_hz is None:
+        return None, None
+    return base_hz / 1e6, boost_hz / 1e6
+
+
+def _build_record(
+    name: str,
+    mapper,
+    info: Dict[str, Any],
+    profile_override: Optional[str] = None,
+) -> HardwareResourceInfo:
+    """Project one mapper + its registry metadata into a HardwareResourceInfo.
+
+    When ``profile_override`` is given, peaks / TDP / clocks are read from
+    that specific ThermalOperatingPoint (used by ``--profiles all``).
+    When None, the default profile is used (legacy behavior).
+    """
     spec: Optional[PhysicalSpec] = getattr(mapper, "physical_spec", None)
+    active_profile = profile_override if profile_override is not None else _resolve_active_profile(mapper)
+
+    # Per-profile peaks: use thermal_operating_point's compute_resource if
+    # it carries performance_specs, else fall through to the legacy
+    # precision_profiles. The latter is profile-agnostic, so
+    # ``--profiles all`` will show the same per-precision numbers across
+    # the (typically single) profile of a datacenter GPU. That's correct
+    # -- those chips don't model per-profile peak variation.
+    if active_profile is not None:
+        peak_fp64 = _per_profile_peak_gflops(mapper, active_profile, Precision.FP64)
+        peak_fp32 = _per_profile_peak_gflops(mapper, active_profile, Precision.FP32)
+        peak_fp16 = _per_profile_peak_gflops(mapper, active_profile, Precision.FP16)
+        peak_fp8 = _per_profile_peak_fp8_gflops(mapper, active_profile)
+        peak_int32 = _per_profile_peak_gflops(mapper, active_profile, Precision.INT32)
+        peak_int16 = _per_profile_peak_gflops(mapper, active_profile, Precision.INT16)
+        peak_int8 = _per_profile_peak_gflops(mapper, active_profile, Precision.INT8)
+        base_mhz, boost_mhz = _clocks_from_profile(mapper, active_profile)
+    else:
+        peak_fp64 = _safe_peak_gflops(mapper, Precision.FP64)
+        peak_fp32 = _safe_peak_gflops(mapper, Precision.FP32)
+        peak_fp16 = _safe_peak_gflops(mapper, Precision.FP16)
+        peak_fp8 = _peak_fp8_gflops(mapper)
+        peak_int32 = _safe_peak_gflops(mapper, Precision.INT32)
+        peak_int16 = _safe_peak_gflops(mapper, Precision.INT16)
+        peak_int8 = _safe_peak_gflops(mapper, Precision.INT8)
+        base_mhz, boost_mhz = None, None
 
     return HardwareResourceInfo(
         name=name,
         category=info["category"],
         vendor=info["vendor"],
         compute_units=mapper.resource_model.compute_units,
-        peak_flops_fp64=_safe_peak_gflops(mapper, Precision.FP64),
-        peak_flops_fp32=_safe_peak_gflops(mapper, Precision.FP32),
-        peak_flops_fp16=_safe_peak_gflops(mapper, Precision.FP16),
-        peak_flops_fp8=_peak_fp8_gflops(mapper),
-        peak_flops_int32=_safe_peak_gflops(mapper, Precision.INT32),
-        peak_flops_int16=_safe_peak_gflops(mapper, Precision.INT16),
-        peak_flops_int8=_safe_peak_gflops(mapper, Precision.INT8),
+        peak_flops_fp64=peak_fp64,
+        peak_flops_fp32=peak_fp32,
+        peak_flops_fp16=peak_fp16,
+        peak_flops_fp8=peak_fp8,
+        peak_flops_int32=peak_int32,
+        peak_flops_int16=peak_int16,
+        peak_flops_int8=peak_int8,
         memory_bandwidth=mapper.resource_model.peak_bandwidth / 1e9,
-        power_tdp=_tdp_watts(mapper),
+        power_tdp=_tdp_watts(mapper, profile_override=active_profile),
+        mode=active_profile,
+        core_base_mhz=base_mhz,
+        core_boost_mhz=boost_mhz,
         die_size_mm2=spec.die_size_mm2 if spec else None,
         transistors_billion=spec.transistors_billion if spec else None,
         transistor_density_mtx_mm2=spec.transistor_density_mtx_mm2 if spec else None,
@@ -171,26 +307,53 @@ def _build_record(name: str, mapper, info: Dict[str, Any]) -> HardwareResourceIn
     )
 
 
-def discover_all_resources(category_filter: Optional[str] = None) -> List[HardwareResourceInfo]:
-    """Walk the mapper registry and build a HardwareResourceInfo per entry."""
+def discover_all_resources(
+    category_filter: Optional[str] = None,
+    expand_profiles: bool = False,
+) -> List[HardwareResourceInfo]:
+    """Walk the mapper registry and build HardwareResourceInfo records.
+
+    Default mode (``expand_profiles=False``): one record per silicon-bin,
+    using each mapper's default thermal profile. This is the original
+    behavior shipped in PR #134.
+
+    Expanded mode (``expand_profiles=True``, Phase 2 of #136): one record
+    per (silicon x profile) combination. For chips with multiple
+    thermal_operating_points (Jetson nvpmodel modes), each mode produces
+    its own row with the alias name ``{silicon}@{profile}`` and per-profile
+    peaks/clocks/TDP. Chips without thermal_operating_points (or with a
+    single placeholder profile) emit one row with the silicon-bin name --
+    this avoids degenerate ``{name}@default`` aliases that duplicate the
+    silicon-bin row.
+    """
     records: List[HardwareResourceInfo] = []
-    for name in list_all_mappers():
-        info = get_mapper_info(name)
+    for silicon in list_all_mappers():
+        info = get_mapper_info(silicon)
         if info is None:
             continue
         if category_filter and info["category"].lower() != category_filter.lower():
             continue
         try:
-            mapper = get_mapper_by_name(name)
+            mapper = get_mapper_by_name(silicon)
         except Exception as exc:  # pragma: no cover - defensive
             print(
-                f"warning: failed to instantiate {name!r}: {exc}",
+                f"warning: failed to instantiate {silicon!r}: {exc}",
                 file=sys.stderr,
             )
             continue
         if mapper is None:
             continue
-        records.append(_build_record(name, mapper, info))
+
+        profiles = mapper.resource_model.thermal_operating_points
+        if expand_profiles and len(profiles) > 1:
+            # Multi-profile chip: emit one record per profile, named with
+            # the alias form. Single-profile chips fall through to the
+            # default-profile path below to avoid name@default duplicates.
+            for profile_name in profiles.keys():
+                alias = f"{silicon}@{profile_name}"
+                records.append(_build_record(alias, mapper, info, profile_override=profile_name))
+        else:
+            records.append(_build_record(silicon, mapper, info))
     return records
 
 
@@ -256,7 +419,7 @@ def generate_text_report(
     verbose: bool = False,
 ) -> None:
     """Human-readable text report. Wide table, segmented by category."""
-    table_width = 145
+    table_width = 165
     print("=" * table_width)
     print("HARDWARE RESOURCES SPEC SHEET")
     print("=" * table_width)
@@ -272,7 +435,8 @@ def generate_text_report(
         by_category.setdefault(r.category, []).append(r)
 
     header = (
-        f"{'Hardware':<28}"
+        f"{'Hardware':<32}"
+        f"{'Mode':>8}"
         f"{'Die mm2':>10}"
         f"{'Tx (B)':>9}"
         f"{'Mtx/mm2':>10}"
@@ -280,6 +444,8 @@ def generate_text_report(
         f"{'Foundry':>10}"
         f"{'Arch':>14}"
         f"{'TDP (W)':>10}"
+        f"{'Base MHz':>10}"
+        f"{'Boost MHz':>11}"
         f"{'INT8 TOPS':>11}"
         f"{'Launched':>13}"
     )
@@ -293,7 +459,8 @@ def generate_text_report(
         print("-" * table_width)
         for r in cat_records:
             row = (
-                f"{r.name[:27]:<28}"
+                f"{r.name[:31]:<32}"
+                f"{(r.mode or 'N/A')[:7]:>8}"
                 f"{_na(r.die_size_mm2):>10}"
                 f"{_na(r.transistors_billion):>9}"
                 f"{_na(r.transistor_density_mtx_mm2):>10}"
@@ -304,6 +471,8 @@ def generate_text_report(
                 f"{_na(r.foundry):>10}"
                 f"{(r.architecture or 'N/A')[:13]:>14}"
                 f"{r.power_tdp:>10.1f}"
+                f"{_na(r.core_base_mhz):>10}"
+                f"{_na(r.core_boost_mhz):>11}"
                 f"{r.peak_flops_int8/1000:>11.1f}"
                 f"{_na(r.launch_date):>13}"
             )
@@ -401,19 +570,21 @@ def generate_markdown_report(
         print(f"## {category.upper()} ({len(cat_records)} products)")
         print()
         print(
-            "| Hardware | Vendor | Die mm² | Tx (B) | Mtx/mm² | Node | Foundry | "
-            "Arch | TDP (W) | INT8 TOPS | Launched |"
+            "| Hardware | Vendor | Mode | Die mm² | Tx (B) | Mtx/mm² | Node | "
+            "Foundry | Arch | TDP (W) | Base MHz | Boost MHz | INT8 TOPS | Launched |"
         )
         print(
-            "| --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | --- |"
+            "| --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | --- |"
         )
         for r in cat_records:
             print(
-                f"| {r.name} | {r.vendor} | {_na(r.die_size_mm2)} | "
+                f"| {r.name} | {r.vendor} | {r.mode or 'N/A'} | "
+                f"{_na(r.die_size_mm2)} | "
                 f"{_na(r.transistors_billion)} | {_na(r.transistor_density_mtx_mm2)} | "
                 f"{(r.process_node_name or _na(r.process_node_nm))} | "
                 f"{_na(r.foundry)} | {r.architecture or 'N/A'} | "
-                f"{r.power_tdp:.1f} | {r.peak_flops_int8/1000:.1f} | "
+                f"{r.power_tdp:.1f} | {_na(r.core_base_mhz)} | {_na(r.core_boost_mhz)} | "
+                f"{r.peak_flops_int8/1000:.1f} | "
                 f"{_na(r.launch_date)} |"
             )
         print()
@@ -500,6 +671,10 @@ Examples:
 
   # JSON for downstream tools
   python cli/list_hardware_resources.py --output specs.json
+
+  # Expand every silicon-bin into its power-profile aliases (e.g., Orin
+  # Nano becomes 4 rows for 7W / 15W / 25W / MAXN)
+  python cli/list_hardware_resources.py --profiles all
         """,
     )
 
@@ -507,6 +682,19 @@ Examples:
         "--category",
         help="Filter to a single category (gpu, cpu, dsp, tpu, kpu, dpu, "
              "cgra, accelerator, dfm). Case-insensitive.",
+    )
+    parser.add_argument(
+        "--profiles",
+        choices=["default", "all"],
+        default="default",
+        help="Profile expansion. ``default`` (the original behavior) emits "
+             "one row per silicon-bin using each mapper's default thermal "
+             "profile. ``all`` emits one row per (silicon x profile) "
+             "combination for chips with multiple thermal_operating_points "
+             "(Jetson nvpmodel modes, Qualcomm SAxxxx, TI TDA4); chips with "
+             "a single placeholder profile keep their silicon-bin row. The "
+             "Mode / Base MHz / Boost MHz columns become populated under "
+             "``all`` for chips that expose per-profile clock data.",
     )
     parser.add_argument(
         "--format",
@@ -544,7 +732,10 @@ Examples:
 
     args = parser.parse_args()
 
-    records = discover_all_resources(category_filter=args.category)
+    records = discover_all_resources(
+        category_filter=args.category,
+        expand_profiles=(args.profiles == "all"),
+    )
     records = _sort_records(records, args.sort, reverse=args.reverse)
 
     fmt = _resolve_format(args.output, args.format)

--- a/cli/list_hardware_resources.py
+++ b/cli/list_hardware_resources.py
@@ -419,17 +419,6 @@ def generate_text_report(
     verbose: bool = False,
 ) -> None:
     """Human-readable text report. Wide table, segmented by category."""
-    table_width = 165
-    print("=" * table_width)
-    print("HARDWARE RESOURCES SPEC SHEET")
-    print("=" * table_width)
-    print()
-    print(f"Total products: {len(records)}")
-    populated = sum(1 for r in records if r.die_size_mm2 is not None)
-    print(f"PhysicalSpec coverage: {populated}/{len(records)} populated, "
-          f"{len(records) - populated} N/A")
-    print()
-
     by_category: Dict[str, List[HardwareResourceInfo]] = {}
     for r in records:
         by_category.setdefault(r.category, []).append(r)
@@ -449,6 +438,19 @@ def generate_text_report(
         f"{'INT8 TOPS':>11}"
         f"{'Launched':>13}"
     )
+    # Compute separator width from the header itself so the equals/dash
+    # lines exactly span the data columns. Robust to future column edits
+    # without manually re-summing the format widths.
+    table_width = len(header)
+    print("=" * table_width)
+    print("HARDWARE RESOURCES SPEC SHEET")
+    print("=" * table_width)
+    print()
+    print(f"Total products: {len(records)}")
+    populated = sum(1 for r in records if r.die_size_mm2 is not None)
+    print(f"PhysicalSpec coverage: {populated}/{len(records)} populated, "
+          f"{len(records) - populated} N/A")
+    print()
 
     for category in sorted(by_category.keys()):
         cat_records = by_category[category]

--- a/tests/cli/test_list_hardware_resources.py
+++ b/tests/cli/test_list_hardware_resources.py
@@ -382,3 +382,159 @@ class TestProcessNodeFallback:
         # Find the row for our synthetic record and confirm "7" appears
         synth_line = next(line for line in out.splitlines() if "Synthetic-NMOnly" in line)
         assert " 7 " in synth_line, f"Expected nm=7 in MD row, got: {synth_line!r}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 of #136: --profiles all expansion + Mode/clock columns
+# ---------------------------------------------------------------------------
+
+class TestProfilesExpansion:
+    """`--profiles all` emits one row per (silicon x profile) for chips with
+    multiple thermal_operating_points; chips with a single profile keep their
+    silicon-bin row (no degenerate name@default duplicates)."""
+
+    def test_default_mode_row_count_unchanged(self, tmp_path):
+        # Backward compat: without --profiles, the row count matches the
+        # silicon-bin count (one row per registered mapper).
+        out = tmp_path / "spec.json"
+        _run(output_path=out)
+        data = json.loads(out.read_text())
+        # Pre-Phase 2 baseline was 46 silicon-bins; could grow as new
+        # mappers are added but should never EXCEED list_all_mappers().
+        from graphs.hardware.mappers import list_all_mappers
+        assert data["total_products"] == len(list_all_mappers())
+
+    def test_profiles_all_emits_more_rows(self, tmp_path):
+        # --profiles all expands multi-profile chips into one row per
+        # profile, so the total grows.
+        default_out = tmp_path / "default.json"
+        all_out = tmp_path / "all.json"
+        _run(output_path=default_out)
+        _run("--profiles", "all", output_path=all_out)
+        default_data = json.loads(default_out.read_text())
+        all_data = json.loads(all_out.read_text())
+        assert all_data["total_products"] > default_data["total_products"]
+
+    def test_profiles_all_orin_nano_emits_four_rows(self, tmp_path):
+        # Orin Nano has 4 modes (7W / 15W / 25W / MAXN per #136). Under
+        # --profiles all, the silicon-bin row is replaced by 4 alias rows.
+        out = tmp_path / "spec.json"
+        _run("--profiles", "all", "--category", "gpu", output_path=out)
+        data = json.loads(out.read_text())
+        nano_rows = [
+            p for p in data["products"]
+            if p["name"].startswith("Jetson-Orin-Nano-8GB")
+        ]
+        # 4 alias rows; no bare silicon-bin row in expanded mode.
+        assert len(nano_rows) == 4
+        names = sorted(r["name"] for r in nano_rows)
+        assert names == [
+            "Jetson-Orin-Nano-8GB@15W",
+            "Jetson-Orin-Nano-8GB@25W",
+            "Jetson-Orin-Nano-8GB@7W",
+            "Jetson-Orin-Nano-8GB@MAXN",
+        ]
+
+    def test_profiles_all_per_profile_tdp_distinct(self, tmp_path):
+        # Each Orin Nano alias row should report its OWN TDP, not the
+        # default profile's TDP. Spec invariant: 7W=7W, 15W=15W, 25W=25W,
+        # MAXN=25W (Super silicon's max envelope).
+        out = tmp_path / "spec.json"
+        _run("--profiles", "all", "--category", "gpu", output_path=out)
+        data = json.loads(out.read_text())
+        tdps = {
+            r["mode"]: r["power_tdp"]
+            for r in data["products"]
+            if r["name"].startswith("Jetson-Orin-Nano-8GB@")
+        }
+        assert tdps == {"7W": 7.0, "15W": 15.0, "25W": 25.0, "MAXN": 25.0}
+
+    def test_profiles_all_per_profile_clocks_distinct(self, tmp_path):
+        # 7W mode boosts to 918 MHz; 15W/25W/MAXN boost to 1020 MHz.
+        # Documents the per-profile clock variation that makes Phase 2
+        # worth shipping in the first place.
+        out = tmp_path / "spec.json"
+        _run("--profiles", "all", "--category", "gpu", output_path=out)
+        data = json.loads(out.read_text())
+        boosts = {
+            r["mode"]: r["core_boost_mhz"]
+            for r in data["products"]
+            if r["name"].startswith("Jetson-Orin-Nano-8GB@")
+        }
+        assert boosts["7W"] == 918.0
+        assert boosts["15W"] == 1020.0
+        assert boosts["25W"] == 1020.0
+        assert boosts["MAXN"] == 1020.0
+
+    def test_profiles_all_single_profile_chip_keeps_silicon_name(self, tmp_path):
+        # H100 has a single placeholder thermal_operating_point named
+        # "default". Under --profiles all, this chip should NOT get a
+        # degenerate "H100-SXM5-80GB@default" alias -- the silicon-bin
+        # row is preserved as-is. Avoids visual noise for chips that
+        # don't expose nvpmodel-style modes.
+        out = tmp_path / "spec.json"
+        _run("--profiles", "all", output_path=out)
+        data = json.loads(out.read_text())
+        h100_rows = [p for p in data["products"] if p["name"].startswith("H100-SXM5-80GB")]
+        assert len(h100_rows) == 1
+        assert h100_rows[0]["name"] == "H100-SXM5-80GB"  # bare silicon-bin
+
+    def test_default_mode_populates_clocks_for_jetson(self, tmp_path):
+        # Even in default mode, Jetson chips should populate Base/Boost MHz
+        # from their default thermal profile's ClockDomain. This is the
+        # "even default mode is more informative now" win from Phase 2.
+        out = tmp_path / "spec.json"
+        _run(output_path=out)
+        data = json.loads(out.read_text())
+        nano = next(
+            p for p in data["products"]
+            if p["name"] == "Jetson-Orin-Nano-8GB"
+        )
+        # 15W is the default profile -- clocks are 306 / 1020 MHz.
+        assert nano["mode"] == "15W"
+        assert nano["core_base_mhz"] == 306.0
+        assert nano["core_boost_mhz"] == 1020.0
+
+    def test_default_mode_chips_without_clock_domain_render_none(self, tmp_path):
+        # KPUs use KPUComputeResource which doesn't expose a ClockDomain.
+        # The defensive _clocks_from_profile helper falls back to None.
+        # The CLI renders None as empty (CSV) / N/A (text/markdown), no
+        # crash.
+        out = tmp_path / "spec.json"
+        _run("--profiles", "all", output_path=out)
+        data = json.loads(out.read_text())
+        kpu_rows = [p for p in data["products"] if p["name"].startswith("Stillwater-KPU")]
+        assert len(kpu_rows) > 0
+        for r in kpu_rows:
+            # mode populated (KPU has thermal_operating_points), but
+            # clocks are None for the architecture-specific compute
+            # resource that doesn't expose ClockDomain.
+            assert r["mode"] is not None
+            assert r["core_base_mhz"] is None
+            assert r["core_boost_mhz"] is None
+
+
+class TestPhase2Renderers:
+    """Mode / Base MHz / Boost MHz columns appear in text and markdown
+    output. CSV / JSON pick up the new fields automatically via the
+    dataclass field iteration."""
+
+    def test_text_header_includes_new_columns(self):
+        stdout, _, _ = _run("--category", "gpu")
+        for col in ("Mode", "Base MHz", "Boost MHz"):
+            assert col in stdout, f"text header missing column: {col}"
+
+    def test_markdown_header_includes_new_columns(self, tmp_path):
+        out = tmp_path / "spec.md"
+        _run(output_path=out)
+        body = out.read_text()
+        for col in ("Mode", "Base MHz", "Boost MHz"):
+            assert col in body, f"markdown header missing column: {col}"
+
+    def test_csv_includes_new_field_columns(self, tmp_path):
+        out = tmp_path / "spec.csv"
+        _run(output_path=out)
+        rows = list(csv.reader(out.open()))
+        header = rows[0]
+        for col in ("mode", "core_base_mhz", "core_boost_mhz"):
+            assert col in header, f"csv missing column: {col}"


### PR DESCRIPTION
## Summary

Phase 2 of #136. Phase 1 (PR #137) made power-profile aliases addressable in the registry. Phase 2 makes them visible in the spec-sheet view: `cli/list_hardware_resources.py --profiles all` now emits one row per (silicon × profile), with per-profile clocks and TDP.

## What changed

### CLI flag

```
--profiles {default, all}
```

- `default` (existing behavior): one row per silicon-bin using each mapper's default thermal profile.
- `all`: one row per (silicon × profile) for chips with multiple `thermal_operating_points`. Single-profile chips (datacenter GPUs that don't expose nvpmodel-style modes) keep their silicon-bin row -- avoids degenerate `{name}@default` aliases.

### New columns

`HardwareResourceInfo` gains three fields, all surfaced as new columns in text / markdown / CSV / JSON output:

- `mode` -- profile name, e.g. `"7W"`, `"MAXN"`, `"default"`
- `core_base_mhz` -- base clock from the profile's ClockDomain
- `core_boost_mhz` -- max boost clock from the profile's ClockDomain

### Defensive helpers

- `_per_profile_peak_gflops`: reads peaks from `thermal_operating_points[profile].performance_specs[precision].compute_resource`. Falls back to `mapper.resource_model.get_peak_ops` (profile-agnostic legacy path) when the compute_resource is an architecture-specific subclass that doesn't expose `calc_peak_ops` (e.g., `KPUComputeResource` uses tile allocation semantics).
- `_clocks_from_profile`: reads `(base_mhz, boost_mhz)` from the profile's ClockDomain via `getattr` chains. Returns `(None, None)` if the compute_resource has no `clock_domain` attribute. Conservative on purpose -- spec-sheet rendering, not estimation.

## Worked example

```
$ python cli/list_hardware_resources.py --profiles all --category gpu
... (17 rows; the 4 Jetson Orin Nano modes appear distinctly)

Jetson-Orin-Nano-8GB@7W    7W   455.0  17.0  37.4  Samsung 8N  samsung   Ampere   7.0  204  918  15.0  2023-03-22
Jetson-Orin-Nano-8GB@15W  15W   455.0  17.0  37.4  Samsung 8N  samsung   Ampere  15.0  306  1020 16.7  2023-03-22
Jetson-Orin-Nano-8GB@25W  25W   455.0  17.0  37.4  Samsung 8N  samsung   Ampere  25.0  306  1020 16.7  2023-03-22
Jetson-Orin-Nano-8GB@MAXN MAXN  455.0  17.0  37.4  Samsung 8N  samsung   Ampere  25.0  306  1020 16.7  2023-03-22
```

The 7W mode boosts to 918 MHz; the 15W / 25W / MAXN modes boost to 1020 MHz. That's the kind of per-profile spec the agentic system needs to recommend "deploy on Orin Nano @15W for this drone payload" instead of bare "Orin Nano".

## Registry coverage at the time of this PR

Across the 46 registered silicon-bins:
- **47 multi-profile alias rows** under `--profiles all` (Jetson Orin AGX/NX/Nano, Jetson Thor, Qualcomm SA8775P, Qualcomm Snapdragon Ride, Google TPU Edge Pro, TI TDA4 family, Stillwater KPU/DFM family).
- **30 silicon-bin rows** for single-profile chips (datacenter GPUs, etc.).
- **77 total rows** under `--profiles all` (vs 46 in default mode).

## Test plan

- [x] 11 new tests in `TestProfilesExpansion` and `TestPhase2Renderers`:
  - Default mode row count unchanged (backward-compat guard)
  - `--profiles all` emits more rows than default
  - Orin Nano emits exactly 4 alias rows (7W/15W/25W/MAXN)
  - Per-profile TDP / boost-clock are distinct between modes
  - Single-profile chips (H100) keep the silicon-bin name
  - Default mode populates clocks for Jetson chips (not just expanded mode)
  - KPU graceful degradation: mode populated, clocks render None
  - Text / markdown / CSV all show the new columns
- [x] Full regression sweep: 373 tests pass in `tests/cli/` + `tests/hardware/`
- [x] Draft fast CI passes
- [ ] Promote when satisfied: `gh pr ready NNN`

## Deferred to Phases 3 + 4

Per the design doc (`docs/assessments/profile-as-sku-addressing.md`):

- Memory Type column needs `memory_type` and `memory_bus_width_bits` on `PhysicalSpec` (Phase 3 -- module SKU constants).
- Memory Clock column needs `memory_clock_mhz` on `ThermalOperatingPoint` (Phase 4 -- per-profile, varies on Jetson).

These columns will land in Phases 3 and 4 once the underlying data is in place. Adding them as N/A-only placeholders today would be empty signal.

## Tracking

- #136 (umbrella) -- this PR is Phase 2.
- Phase 1: PR #137 (merged) -- registry alias addressability
- Phase 3 / 4 / 5 still open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--profiles` CLI flag to expand hardware resource list by thermal operating point, supporting `default` (standard view) and `all` (one row per silicon-profile combination) options for multi-profile devices
  * New output columns: Mode, Base MHz, and Boost MHz, displaying thermal-mode-specific TDP, clock speed, and performance metrics in text, Markdown, and CSV formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->