### PR TITLE
feat(hardware): memory_clock_mhz per ThermalOperatingPoint (#136 Phase 4)

### DIFF
--- a/cli/list_hardware_resources.py
+++ b/cli/list_hardware_resources.py
@@ -106,6 +106,12 @@ class HardwareResourceInfo:
     mode: Optional[str] = None             # Profile name, e.g. "7W", "MAXN"
     core_base_mhz: Optional[float] = None
     core_boost_mhz: Optional[float] = None
+    # Phase 4 of #136. Per-profile memory clock from the active
+    # ThermalOperatingPoint.memory_clock_mhz. Internal DRAM clock (data
+    # rate / 2) -- e.g. 3200 for LPDDR5-6400, 4267 for LPDDR5X-8533.
+    # None for profiles whose ThermalOperatingPoint hasn't been
+    # backfilled with the field yet.
+    memory_clock_mhz: Optional[float] = None
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +273,11 @@ def _build_record(
         peak_int16 = _per_profile_peak_gflops(mapper, active_profile, Precision.INT16)
         peak_int8 = _per_profile_peak_gflops(mapper, active_profile, Precision.INT8)
         base_mhz, boost_mhz = _clocks_from_profile(mapper, active_profile)
+        # Phase 4 of #136: per-profile memory clock from the active
+        # ThermalOperatingPoint. Defaults to None for profiles that
+        # haven't been backfilled.
+        active_top = mapper.resource_model.thermal_operating_points.get(active_profile)
+        mem_clock_mhz = active_top.memory_clock_mhz if active_top is not None else None
     else:
         peak_fp64 = _safe_peak_gflops(mapper, Precision.FP64)
         peak_fp32 = _safe_peak_gflops(mapper, Precision.FP32)
@@ -276,6 +287,7 @@ def _build_record(
         peak_int16 = _safe_peak_gflops(mapper, Precision.INT16)
         peak_int8 = _safe_peak_gflops(mapper, Precision.INT8)
         base_mhz, boost_mhz = None, None
+        mem_clock_mhz = None
 
     return HardwareResourceInfo(
         name=name,
@@ -294,6 +306,7 @@ def _build_record(
         mode=active_profile,
         core_base_mhz=base_mhz,
         core_boost_mhz=boost_mhz,
+        memory_clock_mhz=mem_clock_mhz,
         die_size_mm2=spec.die_size_mm2 if spec else None,
         transistors_billion=spec.transistors_billion if spec else None,
         transistor_density_mtx_mm2=spec.transistor_density_mtx_mm2 if spec else None,
@@ -440,6 +453,7 @@ def generate_text_report(
         f"{'Arch':>14}"
         f"{'Memory':>9}"
         f"{'Bus':>6}"
+        f"{'Mem MHz':>9}"
         f"{'TDP (W)':>10}"
         f"{'Base MHz':>10}"
         f"{'Boost MHz':>11}"
@@ -482,6 +496,7 @@ def generate_text_report(
                 f"{(r.architecture or 'N/A')[:13]:>14}"
                 f"{(r.memory_type or 'N/A')[:8]:>9}"
                 f"{_na(r.memory_bus_width_bits):>6}"
+                f"{_na(r.memory_clock_mhz):>9}"
                 f"{r.power_tdp:>10.1f}"
                 f"{_na(r.core_base_mhz):>10}"
                 f"{_na(r.core_boost_mhz):>11}"
@@ -583,10 +598,10 @@ def generate_markdown_report(
         print()
         print(
             "| Hardware | Vendor | Mode | Die mm² | Tx (B) | Mtx/mm² | Node | "
-            "Foundry | Arch | Memory | Bus | TDP (W) | Base MHz | Boost MHz | INT8 TOPS | Launched |"
+            "Foundry | Arch | Memory | Bus | Mem MHz | TDP (W) | Base MHz | Boost MHz | INT8 TOPS | Launched |"
         )
         print(
-            "| --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |"
+            "| --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
         )
         for r in cat_records:
             print(
@@ -596,6 +611,7 @@ def generate_markdown_report(
                 f"{(r.process_node_name or _na(r.process_node_nm))} | "
                 f"{_na(r.foundry)} | {r.architecture or 'N/A'} | "
                 f"{r.memory_type or 'N/A'} | {_na(r.memory_bus_width_bits)} | "
+                f"{_na(r.memory_clock_mhz)} | "
                 f"{r.power_tdp:.1f} | {_na(r.core_base_mhz)} | {_na(r.core_boost_mhz)} | "
                 f"{r.peak_flops_int8/1000:.1f} | "
                 f"{_na(r.launch_date)} |"

--- a/src/graphs/hardware/models/automotive/jetson_thor_128gb.py
+++ b/src/graphs/hardware/models/automotive/jetson_thor_128gb.py
@@ -142,6 +142,7 @@ def jetson_thor_128gb_resource_model() -> HardwareResourceModel:
         name="30W-active",
         tdp_watts=30.0,
         cooling_solution="active-fan",
+        memory_clock_mhz=4267.0,  # LPDDR5X-8533 (Thor T5000 silicon spec)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
@@ -192,6 +193,7 @@ def jetson_thor_128gb_resource_model() -> HardwareResourceModel:
         name="60W-active",
         tdp_watts=60.0,
         cooling_solution="active-fan-enhanced",
+        memory_clock_mhz=4267.0,  # LPDDR5X-8533 (Thor T5000 silicon spec)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
@@ -242,6 +244,7 @@ def jetson_thor_128gb_resource_model() -> HardwareResourceModel:
         name="100W-max",
         tdp_watts=100.0,
         cooling_solution="active-fan-max",
+        memory_clock_mhz=4267.0,  # LPDDR5X-8533 (Thor T5000 silicon spec)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,

--- a/src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py
+++ b/src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py
@@ -186,6 +186,7 @@ def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
         name="15W-passive",
         tdp_watts=15.0,
         cooling_solution="passive-heatsink",
+        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
@@ -238,6 +239,7 @@ def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
         name="30W-active",
         tdp_watts=30.0,
         cooling_solution="active-fan",
+        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
@@ -296,6 +298,7 @@ def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
         name="50W-performance",
         tdp_watts=50.0,
         cooling_solution="active-fan-high",
+        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
@@ -357,6 +360,7 @@ def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
         name="MAXN-unconstrained",
         tdp_watts=60.0,  # Can exceed this, triggering throttling
         cooling_solution="active-fan-max",
+        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,

--- a/src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py
+++ b/src/graphs/hardware/models/edge/jetson_orin_nano_8gb.py
@@ -185,6 +185,14 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
         name="7W-battery",
         tdp_watts=7.0,
         cooling_solution="passive-heatsink-small",
+        # Memory clock (issue #136 Phase 4). Conservative assumption:
+        # Orin Nano Super silicon supports LPDDR5-6400 (= 3200 MHz
+        # internal DRAM clock) across all nvpmodel profiles. NVIDIA
+        # doesn't publish a clean per-mode DRAM throttling table, so
+        # absent authoritative data we report the silicon's max rate.
+        # Refine in a follow-up when per-mode telemetry confirms or
+        # rejects throttling at 7W.
+        memory_clock_mhz=3200.0,
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
@@ -241,6 +249,7 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
         name="15W-Super",
         tdp_watts=15.0,
         cooling_solution="passive-heatsink",
+        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Super silicon's headline rate)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
@@ -308,6 +317,7 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
         name="25W-Super",
         tdp_watts=25.0,
         cooling_solution="active-fan",
+        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Super silicon's headline rate)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
@@ -366,6 +376,7 @@ def jetson_orin_nano_8gb_resource_model() -> HardwareResourceModel:
         name="MAXN-Super",
         tdp_watts=25.0,  # Super raised TDP cap from 15W to 25W
         cooling_solution="active-fan",
+        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Super silicon's headline rate)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,

--- a/src/graphs/hardware/models/edge/jetson_orin_nx_16gb.py
+++ b/src/graphs/hardware/models/edge/jetson_orin_nx_16gb.py
@@ -187,6 +187,7 @@ def jetson_orin_nx_16gb_resource_model() -> HardwareResourceModel:
         name="10W-battery",
         tdp_watts=10.0,
         cooling_solution="passive-heatsink-small",
+        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
@@ -236,6 +237,7 @@ def jetson_orin_nx_16gb_resource_model() -> HardwareResourceModel:
         name="15W-compact",
         tdp_watts=15.0,
         cooling_solution="passive-heatsink",
+        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
@@ -285,6 +287,7 @@ def jetson_orin_nx_16gb_resource_model() -> HardwareResourceModel:
         name="25W-standard",
         tdp_watts=25.0,
         cooling_solution="active-fan",
+        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,
@@ -334,6 +337,7 @@ def jetson_orin_nx_16gb_resource_model() -> HardwareResourceModel:
         name="40W-maxn-super",
         tdp_watts=40.0,
         cooling_solution="active-fan-high",
+        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
         performance_specs={
             Precision.INT8: PerformanceCharacteristics(
                 precision=Precision.INT8,

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -751,6 +751,18 @@ class ThermalOperatingPoint:
         default_factory=dict
     )
 
+    # Memory clock at this thermal profile, in MHz. Per-profile because
+    # Jetson nvpmodel can throttle DRAM separately from compute clocks
+    # (e.g., Orin Nano 7W mode reduces LPDDR5 to ~2133 MT/s while
+    # Orin Nano 15W runs at the full 6400 MT/s). Issue #136 Phase 4.
+    #
+    # Convention: this is the EFFECTIVE data rate divided by 2 (i.e.,
+    # the internal DRAM clock for DDR-style memory). For LPDDR5-6400
+    # the value is 3200; for HBM3 at 5.23 GT/s the value is ~2615.
+    # Renderers display it as "Memory Clock". None when not yet
+    # populated for a given profile.
+    memory_clock_mhz: Optional[float] = None
+
     def get_effective_ops(self, precision: Precision) -> float:
         """Get actual achieved performance for a precision"""
         perf_spec = self.performance_specs.get(precision)

--- a/tests/cli/test_list_hardware_resources.py
+++ b/tests/cli/test_list_hardware_resources.py
@@ -606,3 +606,71 @@ class TestPhase3MemoryColumn:
         a100 = next(p for p in data["products"] if p["name"] == "A100-SXM4-80GB")
         assert a100["memory_type"] is None
         assert a100["memory_bus_width_bits"] is None
+
+
+class TestPhase4MemoryClock:
+    """Phase 4 of #136: Memory Clock column. Per-profile memory_clock_mhz
+    surfaces from each ThermalOperatingPoint."""
+
+    def test_text_header_includes_mem_mhz_column(self):
+        stdout, _, _ = _run("--category", "gpu")
+        # Header has the new column ('Mem MHz', between 'Bus' and 'TDP').
+        assert "Mem MHz" in stdout
+
+    def test_markdown_header_includes_mem_mhz_column(self, tmp_path):
+        out = tmp_path / "spec.md"
+        _run(output_path=out)
+        assert "Mem MHz" in out.read_text()
+
+    def test_csv_includes_memory_clock_column(self, tmp_path):
+        out = tmp_path / "spec.csv"
+        _run(output_path=out)
+        header = next(csv.reader(out.open()))
+        assert "memory_clock_mhz" in header
+
+    def test_jetson_default_profiles_populated(self, tmp_path):
+        # Phase 4 backfilled all 4 Jetson SKUs with the silicon's
+        # headline DRAM rate. Default-mode rows (the ones rendered
+        # without --profiles all) should show those values.
+        out = tmp_path / "spec.json"
+        _run("--category", "gpu", output_path=out)
+        data = json.loads(out.read_text())
+        nano = next(p for p in data["products"] if p["name"] == "Jetson-Orin-Nano-8GB")
+        agx = next(p for p in data["products"] if p["name"] == "Jetson-Orin-AGX-64GB")
+        nx = next(p for p in data["products"] if p["name"] == "Jetson-Orin-NX-16GB")
+        thor = next(p for p in data["products"] if p["name"] == "Jetson-Thor-128GB")
+        # Orin family at LPDDR5-6400 (3200 MHz internal); Thor at
+        # LPDDR5X-8533 (4267 MHz internal).
+        assert nano["memory_clock_mhz"] == 3200.0
+        assert agx["memory_clock_mhz"] == 3200.0
+        assert nx["memory_clock_mhz"] == 3200.0
+        assert thor["memory_clock_mhz"] == 4267.0
+
+    def test_unpopulated_chips_render_none_for_mem_clock(self, tmp_path):
+        # H100 / A100 / B100 / etc. don't have memory_clock_mhz set on
+        # their thermal_operating_points yet -- they render None
+        # gracefully (-> "N/A" in text/markdown, "" in CSV).
+        out = tmp_path / "spec.json"
+        _run(output_path=out)
+        data = json.loads(out.read_text())
+        h100 = next(p for p in data["products"] if p["name"] == "H100-SXM5-80GB")
+        a100 = next(p for p in data["products"] if p["name"] == "A100-SXM4-80GB")
+        assert h100["memory_clock_mhz"] is None
+        assert a100["memory_clock_mhz"] is None
+
+    def test_profiles_all_propagates_per_profile_memory_clock(self, tmp_path):
+        # Under --profiles all, each Orin Nano alias row carries the
+        # memory_clock_mhz from its specific ThermalOperatingPoint. The
+        # current backfill assigns the same 3200 MHz to all 4 modes
+        # (Super silicon's max); when authoritative throttling data
+        # later refines 7W, the per-profile expansion will reflect that.
+        out = tmp_path / "spec.json"
+        _run("--profiles", "all", "--category", "gpu", output_path=out)
+        data = json.loads(out.read_text())
+        nano_records = [
+            p for p in data["products"]
+            if p["name"].startswith("Jetson-Orin-Nano-8GB@")
+        ]
+        # 4 Nano modes (7W/15W/25W/MAXN), each populated.
+        assert len(nano_records) == 4
+        assert all(r["memory_clock_mhz"] == 3200.0 for r in nano_records)


### PR DESCRIPTION
## Summary

Phase 4 of #136. Adds per-profile memory clock to `ThermalOperatingPoint` and surfaces it as the **Mem MHz** column in the spec-sheet view. Closes the last data-source gap from the Phase 2 design doc.

## What changed

### `src/graphs/hardware/resource_model.py`

```python
class ThermalOperatingPoint:
    name: str
    tdp_watts: float
    cooling_solution: str
    performance_specs: Dict[Precision, PerformanceCharacteristics] = field(...)
    memory_clock_mhz: Optional[float] = None  # NEW
```

Convention: internal DRAM clock (data rate / 2). So LPDDR5-6400 = 3200, LPDDR5X-8533 = 4267, HBM3-5230 = 2615.

Per-profile because Jetson `nvpmodel` can throttle DRAM separately from compute clocks (e.g., low-power modes may reduce LPDDR rates). Each `ThermalOperatingPoint` carries its own value.

### Jetson resource models populated — 15 profiles total

| File | Profiles | Memory Clock |
|------|----------|--------------|
| `jetson_orin_nano_8gb.py` | 7W / 15W / 25W / MAXN | 3200 MHz (LPDDR5-6400) |
| `jetson_orin_agx_64gb.py` | 15W / 30W / 50W / MAXN | 3200 MHz (LPDDR5-6400) |
| `jetson_orin_nx_16gb.py` | 10W / 15W / 25W / 40W | 3200 MHz (LPDDR5-6400) |
| `jetson_thor_128gb.py` | 30W / 60W / 100W | 4267 MHz (LPDDR5X-8533) |

**Conservative population**: NVIDIA doesn't publish a clean per-mode DRAM throttling table for Jetson. Until authoritative telemetry arrives, all profiles report the silicon's headline DRAM rate. When refined data is available (e.g., low-mode DRAM throttling on Orin Nano 7W that some community reports describe), updating the per-profile values causes the spec sheet to pick them up automatically.

### `cli/list_hardware_resources.py`

- New `memory_clock_mhz` field on `HardwareResourceInfo`, populated from the active `ThermalOperatingPoint`.
- **Mem MHz** column added to text + markdown renderers (positioned between Bus and TDP, since memory clock is operational state).
- CSV / JSON pick up the new field automatically.

## Sample output

```
Hardware                            Mode   Die mm2   Tx (B)   Mtx/mm2      Node   Foundry          Arch   Memory   Bus  Mem MHz   TDP (W)  ...
H100-SXM5-80GB                   default     814.0     80.0      98.3   TSMC N4      tsmc        Hopper     hbm3  5120      N/A     700.0  ...
Jetson-Thor-128GB                    30W     600.0     50.0      83.3   TSMC N4      tsmc     Blackwell  lpddr5x   256   4267.0      30.0  ...
Jetson-Orin-AGX-64GB                 30W     455.0     17.0      37.4Samsung 8LPP   samsung        Ampere   lpddr5   256   3200.0      30.0  ...
Jetson-Orin-NX-16GB                  25W     455.0     17.0      37.4Samsung 8LPP   samsung        Ampere   lpddr5   128   3200.0      25.0  ...
Jetson-Orin-Nano-8GB                 15W     455.0     17.0      37.4Samsung 8LPP   samsung        Ampere   lpddr5   128   3200.0      15.0  ...
A100-SXM4-80GB                   default       N/A      N/A       N/A       N/A       N/A           N/A      N/A   N/A      N/A     400.0  ...
```

H100 / A100 etc. don't yet have `memory_clock_mhz` on their thermal_operating_points — they render N/A gracefully.

## Test plan

- [x] `TestPhase4MemoryClock` (6 new tests in `tests/cli/test_list_hardware_resources.py`):
  - Mem MHz / `memory_clock_mhz` column appears in text / markdown / CSV
  - Default-profile rendering populates the field for all 4 Jetson SKUs (Orin family at 3200, Thor at 4267)
  - Unpopulated chips render None gracefully
  - `--profiles all` expansion propagates per-profile memory clock on the 4 Orin Nano alias rows
- [x] Full sweep: 420 tests pass across `tests/cli/` + `tests/hardware/` (no regressions on the 414 from #141 + the 6 new Phase 4 tests)
- [ ] Draft fast CI passes
- [ ] Promote when satisfied: `gh pr ready NNN`

## Tracking

- #136 (umbrella) — this PR is Phase 4
- Phase 1: PR #137 (merged)
- Phase 2: PR #138 (merged)
- Phase 3: PR #139 (merged)
- Phase 3.5: PR #141 (merged)
- Phase 5 (Embodied-AI-Architect orchestrator update — downstream-consumer change in a separate repo) is the only remaining phase on the umbrella issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)