### PR TITLE
fix(cli): widen Node column for Samsung 8LPP and other long process names

### DIFF
--- a/cli/list_hardware_resources.py
+++ b/cli/list_hardware_resources.py
@@ -448,7 +448,11 @@ def generate_text_report(
         f"{'Die mm2':>10}"
         f"{'Tx (B)':>9}"
         f"{'Mtx/mm2':>10}"
-        f"{'Node':>10}"
+        # Node column widened to 14 so values like "Samsung 8LPP" (12)
+        # don't overflow and push later columns right. 13-char truncation
+        # protects against vendor-name combos longer than that (e.g.,
+        # "GlobalFoundries 12LP" would be 20 chars otherwise).
+        f"{'Node':>14}"
         f"{'Foundry':>10}"
         f"{'Arch':>14}"
         f"{'Memory':>9}"
@@ -490,8 +494,11 @@ def generate_text_report(
                 f"{_na(r.transistor_density_mtx_mm2):>10}"
                 # Prefer the named version; fall back to the raw nm value.
                 # Don't pre-format with _na -- "N/A" is truthy and would mask
-                # nm-only specs.
-                f"{(r.process_node_name or _na(r.process_node_nm)):>10}"
+                # nm-only specs. Truncate to 13 chars so very long composed
+                # names (e.g., "GlobalFoundries 12LP") don't push later
+                # columns right; the column is sized at 14 to leave a
+                # one-char visual gap.
+                f"{(r.process_node_name or _na(r.process_node_nm))[:13]:>14}"
                 f"{_na(r.foundry):>10}"
                 f"{(r.architecture or 'N/A')[:13]:>14}"
                 f"{(r.memory_type or 'N/A')[:8]:>9}"


### PR DESCRIPTION
## Summary

The Node column in `cli/list_hardware_resources.py`'s text renderer was sized at `>10` chars — enough for `"TSMC N4"` (7 chars) but overflows for `"Samsung 8LPP"` (12 chars). Python f-string format width doesn't truncate; longer content just pushes the rest of the row right, breaking column alignment for every column after Node.

## Before

```
Jetson-Orin-AGX-64GB                 30W     455.0     17.0      37.4Samsung 8LPP   samsung        Ampere   lpddr5   256   3200.0      30.0     612.0     1150.0        4.7   2022-03-22
                                                                       ^^^^^^^^^^^^
                                                                       overflows; pushes "samsung" / "Ampere" / etc. right
```

## After

```
Jetson-Orin-AGX-64GB                 30W     455.0     17.0      37.4  Samsung 8LPP   samsung        Ampere   lpddr5   256   3200.0      30.0     612.0     1150.0        4.7   2022-03-22
                                                                     ^                ^^^^^^^^^^^^^^
                                                                     properly aligned with one-char gap before
```

## Fix

- Node column widened from `>10` to `>14`.
- Value truncated to `[:13]` to handle hypothetical longer composed names (e.g., `"GlobalFoundries 12LP"` = 20 chars) without reintroducing the same overflow.

Markdown renderer already auto-fits via markdown table syntax — only the fixed-width text renderer needed this fix.

## Test plan

- [x] Locally verified: text spec-sheet output now aligns columns correctly
- [x] 47 CLI tests pass (no behavior changes, just column width)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)