### PR TITLE
feat(hardware): Phase 4b PR 2 -- loader populates tile_energy_model + soc_fabric

### DIFF
--- a/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
+++ b/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
@@ -201,6 +201,14 @@ _NOC_TOPOLOGY_MAP: dict[str, Topology] = {
     "full_mesh": Topology.FULL_MESH,
 }
 
+# Topology strings whose mapping above is *lossy* -- we approximate
+# them with the closest enum value but downstream consumers should
+# treat the result as low-confidence (different bisection bandwidth,
+# different hop-count formula, etc.). Keep this set narrow: only
+# entries where the resolved Topology genuinely misrepresents the
+# underlying interconnect.
+_LOSSY_TOPOLOGY_MAPPINGS: frozenset[str] = frozenset({"torus_2d"})
+
 
 # ---------------------------------------------------------------------------
 # Energy lookups
@@ -266,7 +274,7 @@ def _build_tile_energy_model(
       DRAM bandwidth, clock) -- direct read from
       ``sku.kpu_architecture``.
     * ``pes_per_tile`` -- the dominant tile class's PE count
-      (``num_tiles`` × array). The energy model uses this for routing,
+      (``num_tiles`` x array). The energy model uses this for routing,
       L1 sizing, and per-tile compute energy; the dominant class's
       footprint is the right ballpark for those calculations.
     * ``mac_energy_int8/bf16/fp32`` -- from
@@ -292,12 +300,26 @@ def _build_tile_energy_model(
     # tile class are typically balanced; the matrix tile uses HP_LOGIC
     # but the model only carries one set of MAC energies, so the
     # majority class wins).
-    def _mac_energy_pj(precision: str, fallback_pj: float) -> float:
+    #
+    # Fallback strategy: when the YAML's energy_per_op_pj table is
+    # sparse for a precision, scale ``get_base_alu_energy(node_nm,
+    # "standard_cell")`` by precision-typical ratios. This keeps a
+    # node like TSMC N7 (low base energy) from collapsing back to a
+    # node-agnostic constant; sparse PDK tables stay node-aware.
+    base_alu_energy_j = get_base_alu_energy(node.node_nm, "standard_cell")
+    base_alu_energy_pj = base_alu_energy_j * 1e12
+    # Ratios are PE-datapath-width typicals: INT8 ~12% of FP32 (from
+    # observed factory ratios across N16/N7), BF16 ~50%, FP32 = 1.0
+    # (the alu energy table is FP32-keyed by convention).
+    _PRECISION_FALLBACK_RATIO = {"int8": 0.12, "bf16": 0.50, "fp32": 1.0}
+
+    def _mac_energy_pj(precision: str) -> float:
         key = f"{CircuitClass.BALANCED_LOGIC.value}:{precision}"
         pj = node.energy_per_op_pj.get(key)
-        if pj is None or pj <= 0:
-            return fallback_pj
-        return pj
+        if pj is not None and pj > 0:
+            return pj
+        ratio = _PRECISION_FALLBACK_RATIO.get(precision, 1.0)
+        return base_alu_energy_pj * ratio
 
     # DRAM PHY energy from the memory-type table (with 1.2x ratio for write).
     dram_read_pj = _DRAM_READ_PJ_PER_BYTE.get(mem.memory_type.value, 10.0)
@@ -322,10 +344,10 @@ def _build_tile_energy_model(
         l2_write_energy_per_byte=_L2_WRITE_PJ_PER_BYTE * 1e-12,
         l1_read_energy_per_byte=_L1_READ_PJ_PER_BYTE * 1e-12,
         l1_write_energy_per_byte=_L1_WRITE_PJ_PER_BYTE * 1e-12,
-        # MAC energies from PDK
-        mac_energy_int8=_mac_energy_pj("int8", 0.30) * 1e-12,
-        mac_energy_bf16=_mac_energy_pj("bf16", 0.45) * 1e-12,
-        mac_energy_fp32=_mac_energy_pj("fp32", 0.90) * 1e-12,
+        # MAC energies from PDK; node-scaled fallback when YAML is sparse
+        mac_energy_int8=_mac_energy_pj("int8") * 1e-12,
+        mac_energy_bf16=_mac_energy_pj("bf16") * 1e-12,
+        mac_energy_fp32=_mac_energy_pj("fp32") * 1e-12,
     )
 
 
@@ -352,8 +374,15 @@ def _build_soc_fabric(
     arch = sku.kpu_architecture
     noc = arch.noc
 
-    topology = _NOC_TOPOLOGY_MAP.get(noc.topology.lower(), Topology.UNKNOWN)
-    low_confidence = topology is Topology.UNKNOWN
+    topology_key = noc.topology.lower()
+    topology = _NOC_TOPOLOGY_MAP.get(topology_key, Topology.UNKNOWN)
+    # Mark low_confidence for both UNKNOWN topologies AND lossy
+    # mappings (e.g., torus_2d -> mesh_2d) so downstream consumers
+    # see the approximation instead of treating it as exact.
+    low_confidence = (
+        topology is Topology.UNKNOWN
+        or topology_key in _LOSSY_TOPOLOGY_MAPPINGS
+    )
 
     return SoCFabricModel(
         topology=topology,

--- a/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
+++ b/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
@@ -53,6 +53,8 @@ from embodied_schemas import (
 )
 from embodied_schemas.process_node import CircuitClass, ProcessNodeEntry
 
+from ...architectural_energy import KPUTileEnergyModel
+from ...fabric_model import SoCFabricModel, Topology
 from ...resource_model import (
     ClockDomain,
     ComputeFabric,
@@ -144,6 +146,63 @@ _CIRCUIT_TYPE_LABEL: dict[CircuitClass, str] = {
 
 
 # ---------------------------------------------------------------------------
+# Per-memory-type DRAM PHY energy (pJ per byte). Mirrors the table in
+# silicon_math, kept here so the loader can build tile_energy_model
+# without importing sku_validators (avoids a circular dep).
+# ---------------------------------------------------------------------------
+
+_DRAM_READ_PJ_PER_BYTE: dict[str, float] = {
+    "lpddr4": 12.0,
+    "lpddr4x": 11.0,
+    "lpddr5": 10.0,
+    "lpddr5x": 9.5,
+    "ddr5": 13.0,
+    "gddr6": 8.0,
+    "gddr6x": 7.5,
+    "hbm2": 7.0,
+    "hbm2e": 6.5,
+    "hbm3": 6.0,
+    "hbm3e": 5.5,
+    "unified": 10.0,
+}
+# Write PHY energy is typically ~20 % above read for DDR-style DRAM and
+# ~15 % above read for HBM. Apply a single 1.2x heuristic; the
+# difference vs measured silicon is well below the loader's other
+# uncertainties and matches the existing factory convention.
+_DRAM_WRITE_RATIO = 1.2
+
+
+# ---------------------------------------------------------------------------
+# On-chip SRAM energy (pJ per byte read / write). Node-agnostic v1
+# placeholders mirroring the values the existing factories hard-code
+# (which themselves are 16 nm ballpark numbers used uniformly across
+# T64 / T256 / T768). When PDK SRAM characterization data lands, swap
+# this for a per-node table.
+# ---------------------------------------------------------------------------
+
+_L3_READ_PJ_PER_BYTE = 2.0
+_L3_WRITE_PJ_PER_BYTE = 2.5
+_L2_READ_PJ_PER_BYTE = 0.8
+_L2_WRITE_PJ_PER_BYTE = 1.0
+_L1_READ_PJ_PER_BYTE = 0.3
+_L1_WRITE_PJ_PER_BYTE = 0.4
+
+
+# ---------------------------------------------------------------------------
+# YAML NoC topology -> resource_model Topology enum
+# ---------------------------------------------------------------------------
+
+_NOC_TOPOLOGY_MAP: dict[str, Topology] = {
+    "mesh_2d": Topology.MESH_2D,
+    "torus_2d": Topology.MESH_2D,  # closest fit; no TORUS_2D enum value
+    "crossbar": Topology.CROSSBAR,
+    "ring": Topology.RING,
+    "clos": Topology.CLOS,
+    "full_mesh": Topology.FULL_MESH,
+}
+
+
+# ---------------------------------------------------------------------------
 # Energy lookups
 # ---------------------------------------------------------------------------
 
@@ -195,6 +254,125 @@ def _fabric_energy_scaling(
 # ---------------------------------------------------------------------------
 # Loader
 # ---------------------------------------------------------------------------
+
+def _build_tile_energy_model(
+    sku: KPUEntry, node: ProcessNodeEntry, *, default_clock_hz: float
+) -> KPUTileEnergyModel:
+    """Construct a KPUTileEnergyModel from the YAML SKU + process node.
+
+    Mappings:
+
+    * Architectural shape (num_tiles, mesh, L1/L2/L3 sizes,
+      DRAM bandwidth, clock) -- direct read from
+      ``sku.kpu_architecture``.
+    * ``pes_per_tile`` -- the dominant tile class's PE count
+      (``num_tiles`` × array). The energy model uses this for routing,
+      L1 sizing, and per-tile compute energy; the dominant class's
+      footprint is the right ballpark for those calculations.
+    * ``mac_energy_int8/bf16/fp32`` -- from
+      ``node.energy_per_op_pj["balanced_logic:<precision>"]``. Falls
+      back to ``get_base_alu_energy(node_nm, "standard_cell")`` scaled
+      by precision-typical ratios when the YAML doesn't list a value.
+    * ``dram_read/write_energy_per_byte`` -- from the per-memory-type
+      table above.
+    * ``l1/l2/l3_read/write_energy_per_byte`` -- node-agnostic v1
+      placeholders matching the existing factory values; PR (later)
+      will swap for a per-process-node SRAM table when PDK data lands.
+    """
+    arch = sku.kpu_architecture
+    mem = arch.memory
+
+    # Dominant tile class -- the one with the highest num_tiles. In all
+    # four hand-authored Stillwater SKUs this is INT8-primary.
+    dominant_tile = max(arch.tiles, key=lambda t: t.num_tiles)
+    pes_per_tile = dominant_tile.pe_array_rows * dominant_tile.pe_array_cols
+
+    # MAC energies from the process node's per-(class, precision) table.
+    # Use BALANCED_LOGIC as the default class (the PEs of the dominant
+    # tile class are typically balanced; the matrix tile uses HP_LOGIC
+    # but the model only carries one set of MAC energies, so the
+    # majority class wins).
+    def _mac_energy_pj(precision: str, fallback_pj: float) -> float:
+        key = f"{CircuitClass.BALANCED_LOGIC.value}:{precision}"
+        pj = node.energy_per_op_pj.get(key)
+        if pj is None or pj <= 0:
+            return fallback_pj
+        return pj
+
+    # DRAM PHY energy from the memory-type table (with 1.2x ratio for write).
+    dram_read_pj = _DRAM_READ_PJ_PER_BYTE.get(mem.memory_type.value, 10.0)
+    dram_write_pj = dram_read_pj * _DRAM_WRITE_RATIO
+
+    return KPUTileEnergyModel(
+        num_tiles=arch.total_tiles,
+        pes_per_tile=pes_per_tile,
+        tile_mesh_dimensions=(arch.noc.mesh_rows, arch.noc.mesh_cols),
+        dram_bandwidth_gb_s=mem.memory_bandwidth_gbps,
+        l3_size_per_tile=mem.l3_kib_per_tile * 1024,
+        l2_size_per_tile=mem.l2_kib_per_tile * 1024,
+        l1_size_per_pe=mem.l1_kib_per_pe * 1024,
+        clock_frequency_hz=default_clock_hz,
+        # DRAM PHY energy
+        dram_read_energy_per_byte=dram_read_pj * 1e-12,
+        dram_write_energy_per_byte=dram_write_pj * 1e-12,
+        # On-chip SRAM energies (node-agnostic v1)
+        l3_read_energy_per_byte=_L3_READ_PJ_PER_BYTE * 1e-12,
+        l3_write_energy_per_byte=_L3_WRITE_PJ_PER_BYTE * 1e-12,
+        l2_read_energy_per_byte=_L2_READ_PJ_PER_BYTE * 1e-12,
+        l2_write_energy_per_byte=_L2_WRITE_PJ_PER_BYTE * 1e-12,
+        l1_read_energy_per_byte=_L1_READ_PJ_PER_BYTE * 1e-12,
+        l1_write_energy_per_byte=_L1_WRITE_PJ_PER_BYTE * 1e-12,
+        # MAC energies from PDK
+        mac_energy_int8=_mac_energy_pj("int8", 0.30) * 1e-12,
+        mac_energy_bf16=_mac_energy_pj("bf16", 0.45) * 1e-12,
+        mac_energy_fp32=_mac_energy_pj("fp32", 0.90) * 1e-12,
+    )
+
+
+def _build_soc_fabric(
+    sku: KPUEntry, node: ProcessNodeEntry
+) -> SoCFabricModel:
+    """Construct a SoCFabricModel from the YAML SKU's NoC declaration.
+
+    Maps ``kpu_architecture.noc`` directly to the resource_model fabric:
+
+    * ``topology`` -- string -> ``Topology`` enum via _NOC_TOPOLOGY_MAP.
+      Unknown topology strings produce ``Topology.UNKNOWN`` with
+      ``low_confidence=True`` so downstream consumers see the gap.
+    * ``mesh_dimensions`` -- ``(mesh_rows, mesh_cols)``.
+    * ``flit_size_bytes`` -- direct from ``noc.flit_bytes``.
+    * ``bisection_bandwidth_gbps`` -- direct, with 0.0 fallback when
+      the YAML doesn't declare it.
+    * ``controller_count`` -- ``total_tiles`` (each tile is a NoC node).
+    * ``hop_latency_ns``, ``pj_per_flit_per_hop`` -- node-agnostic v1
+      placeholders matching the values the existing factories use; the
+      analyzer treats them as approximations and is robust to
+      modest differences.
+    """
+    arch = sku.kpu_architecture
+    noc = arch.noc
+
+    topology = _NOC_TOPOLOGY_MAP.get(noc.topology.lower(), Topology.UNKNOWN)
+    low_confidence = topology is Topology.UNKNOWN
+
+    return SoCFabricModel(
+        topology=topology,
+        hop_latency_ns=1.0,           # 16 nm-ish typical; see factory comments
+        pj_per_flit_per_hop=0.5,      # ditto
+        bisection_bandwidth_gbps=noc.bisection_bandwidth_gbps or 0.0,
+        controller_count=arch.total_tiles,
+        flit_size_bytes=noc.flit_bytes,
+        mesh_dimensions=(noc.mesh_rows, noc.mesh_cols),
+        routing_distance_factor=1.2,  # typical XY routing with detours
+        low_confidence=low_confidence,
+        provenance=(
+            f"{sku.name} NoC from "
+            f"embodied-schemas:kpus/{sku.vendor}/{sku.id}.yaml "
+            f"(kpu_architecture.noc); on-chip SRAM + per-hop energy "
+            f"are node-agnostic v1 placeholders"
+        ),
+    )
+
 
 def load_kpu_resource_model_from_yaml(
     base_id: str,
@@ -451,9 +629,17 @@ def load_kpu_resource_model_from_yaml(
     energy_per_byte = _MEM_PJ_PER_BYTE.get(mem.memory_type.value, 10.0) * 1e-12
 
     # ------------------------------------------------------------------
+    # KPUTileEnergyModel + SoCFabricModel (Phase 4b PR 2)
+    # ------------------------------------------------------------------
+    tile_energy_model = _build_tile_energy_model(
+        sku, node, default_clock_hz=default_clock_hz
+    )
+    soc_fabric = _build_soc_fabric(sku, node)
+
+    # ------------------------------------------------------------------
     # Construct the model
     # ------------------------------------------------------------------
-    return HardwareResourceModel(
+    model = HardwareResourceModel(
         name=sku.name,
         hardware_type=HardwareType.KPU,
         compute_units=sku.kpu_architecture.total_tiles,
@@ -475,3 +661,12 @@ def load_kpu_resource_model_from_yaml(
         max_concurrent_kernels=4,
         wave_quantization=2,
     )
+
+    # tile_energy_model and soc_fabric aren't constructor args on
+    # HardwareResourceModel -- the existing factories attach them as
+    # post-construction attributes. Match that convention so downstream
+    # consumers (analyzers, the KPUMapper energy path) see the same shape.
+    model.tile_energy_model = tile_energy_model
+    model.soc_fabric = soc_fabric
+
+    return model

--- a/tests/hardware/test_kpu_yaml_loader.py
+++ b/tests/hardware/test_kpu_yaml_loader.py
@@ -324,6 +324,75 @@ def test_soc_fabric_unknown_topology_marks_low_confidence(catalogs):
     assert m.soc_fabric.low_confidence is True
 
 
+def test_soc_fabric_lossy_torus_mapping_marks_low_confidence(catalogs):
+    """``torus_2d`` is approximated as ``Topology.MESH_2D`` because the
+    Topology enum has no TORUS_2D value. Mark this lossy mapping with
+    ``low_confidence=True`` so consumers (hop-count, bisection-bandwidth
+    formulas) see the approximation."""
+    from graphs.hardware.fabric_model import Topology
+    real = catalogs["kpus"]["stillwater_kpu_t256"]
+    arch = real.kpu_architecture.model_copy(
+        update={"noc": real.kpu_architecture.noc.model_copy(
+            update={"topology": "torus_2d"}
+        )}
+    )
+    bad_sku = real.model_copy(update={"kpu_architecture": arch})
+    m = load_kpu_resource_model_from_yaml(
+        bad_sku.id,
+        kpus={bad_sku.id: bad_sku},
+        process_nodes=catalogs["process_nodes"],
+    )
+    # Maps to MESH_2D (the closest available enum value)...
+    assert m.soc_fabric.topology == Topology.MESH_2D
+    # ...but flagged as approximation.
+    assert m.soc_fabric.low_confidence is True
+
+
+def test_tile_energy_model_mac_fallback_is_node_scaled(catalogs):
+    """When a process node lacks ``balanced_logic:<precision>`` entries,
+    the MAC fallback must scale with ``node.node_nm`` via
+    ``get_base_alu_energy``, not collapse to a fixed constant. Lower
+    nm -> lower fallback MAC energy."""
+    from embodied_schemas.process_node import CircuitClass
+    real = catalogs["kpus"]["stillwater_kpu_t256"]
+    n16_node = catalogs["process_nodes"]["tsmc_n16"]
+    # Strip every balanced_logic energy entry to force the fallback path.
+    sparse_n16 = n16_node.model_copy(update={
+        "energy_per_op_pj": {
+            k: v for k, v in n16_node.energy_per_op_pj.items()
+            if not k.startswith(f"{CircuitClass.BALANCED_LOGIC.value}:")
+        }
+    })
+    m_n16 = load_kpu_resource_model_from_yaml(
+        real.id,
+        kpus={real.id: real},
+        process_nodes={real.process_node_id: sparse_n16},
+    )
+
+    # Same SKU, but pretend it's on TSMC N5 (much smaller node).
+    n5_node = catalogs["process_nodes"]["tsmc_n5"]
+    sparse_n5 = n5_node.model_copy(update={
+        "id": "tsmc_n16",  # rebrand so the SKU's process_node_id resolves
+        "energy_per_op_pj": {
+            k: v for k, v in n5_node.energy_per_op_pj.items()
+            if not k.startswith(f"{CircuitClass.BALANCED_LOGIC.value}:")
+        }
+    })
+    m_n5 = load_kpu_resource_model_from_yaml(
+        real.id,
+        kpus={real.id: real},
+        process_nodes={real.process_node_id: sparse_n5},
+    )
+
+    # N5 is a smaller node than N16 -> fallback MAC energy must be lower.
+    assert m_n5.tile_energy_model.mac_energy_int8 < m_n16.tile_energy_model.mac_energy_int8
+    assert m_n5.tile_energy_model.mac_energy_bf16 < m_n16.tile_energy_model.mac_energy_bf16
+    assert m_n5.tile_energy_model.mac_energy_fp32 < m_n16.tile_energy_model.mac_energy_fp32
+    # Sanity: ordering INT8 <= BF16 <= FP32 still holds in fallback path.
+    tem = m_n16.tile_energy_model
+    assert tem.mac_energy_int8 <= tem.mac_energy_bf16 <= tem.mac_energy_fp32
+
+
 @pytest.mark.parametrize("sku_id", SKU_IDS)
 def test_loader_output_remains_kpu_mapper_compatible(sku_id, catalogs):
     """The KPUMapper energy paths use ``mapper.tile_energy_model``;

--- a/tests/hardware/test_kpu_yaml_loader.py
+++ b/tests/hardware/test_kpu_yaml_loader.py
@@ -183,3 +183,155 @@ def test_loader_unresolved_process_node_raises(catalogs):
             kpus={bad_sku.id: bad_sku},
             process_nodes=catalogs["process_nodes"],
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 4b PR 2: tile_energy_model + soc_fabric
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sku_id", SKU_IDS)
+def test_loader_populates_tile_energy_model(sku_id, catalogs):
+    """The loader must attach a KPUTileEnergyModel; the existing factory
+    factories also do this, so analyzers expect it to be present."""
+    m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+    assert m.tile_energy_model is not None
+
+
+@pytest.mark.parametrize("sku_id", SKU_IDS)
+def test_tile_energy_model_architectural_shape_matches_yaml(sku_id, catalogs):
+    """num_tiles, tile_mesh_dimensions, l1/l2/l3 sizes, dram bandwidth,
+    clock are all direct reads from the SKU YAML."""
+    m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+    sku = catalogs["kpus"][sku_id]
+    arch = sku.kpu_architecture
+    tem = m.tile_energy_model
+    assert tem.num_tiles == arch.total_tiles
+    assert tem.tile_mesh_dimensions == (arch.noc.mesh_rows, arch.noc.mesh_cols)
+    assert tem.dram_bandwidth_gb_s == arch.memory.memory_bandwidth_gbps
+    assert tem.l3_size_per_tile == arch.memory.l3_kib_per_tile * 1024
+    assert tem.l2_size_per_tile == arch.memory.l2_kib_per_tile * 1024
+    assert tem.l1_size_per_pe == arch.memory.l1_kib_per_pe * 1024
+    # Default profile clock
+    default = next(
+        p for p in sku.power.thermal_profiles
+        if p.name == sku.power.default_thermal_profile
+    )
+    assert tem.clock_frequency_hz == default.clock_mhz * 1e6
+
+
+@pytest.mark.parametrize("sku_id", SKU_IDS)
+def test_tile_energy_model_pes_per_tile_uses_dominant_class(sku_id, catalogs):
+    """pes_per_tile reads from the tile class with the largest num_tiles
+    (the dominant compute class). For all 4 Stillwater SKUs this is the
+    INT8-primary class."""
+    m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+    sku = catalogs["kpus"][sku_id]
+    dominant = max(sku.kpu_architecture.tiles, key=lambda t: t.num_tiles)
+    expected = dominant.pe_array_rows * dominant.pe_array_cols
+    assert m.tile_energy_model.pes_per_tile == expected
+
+
+@pytest.mark.parametrize("sku_id", SKU_IDS)
+def test_tile_energy_model_mac_energies_in_plausible_range(sku_id, catalogs):
+    """MAC energies must land in the same range the existing
+    test_kpu_*_gemm tests expect for energy_per_mac_j (0.3-1.5 pJ for
+    16 nm, scaling down at advanced nodes). The loader pulls from the
+    process node's energy_per_op_pj table."""
+    m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+    tem = m.tile_energy_model
+    # All four current SKUs have these; relaxed plausibility ranges.
+    assert 0.05e-12 <= tem.mac_energy_int8 <= 5e-12, \
+        f"INT8 MAC energy {tem.mac_energy_int8 * 1e12:.3f} pJ implausible"
+    assert 0.1e-12 <= tem.mac_energy_bf16 <= 10e-12, \
+        f"BF16 MAC energy {tem.mac_energy_bf16 * 1e12:.3f} pJ implausible"
+    assert 0.1e-12 <= tem.mac_energy_fp32 <= 20e-12, \
+        f"FP32 MAC energy {tem.mac_energy_fp32 * 1e12:.3f} pJ implausible"
+    # FP32 should be at least as expensive as BF16 which is at least as
+    # expensive as INT8 (datapath width ratios).
+    assert tem.mac_energy_int8 <= tem.mac_energy_bf16 <= tem.mac_energy_fp32
+
+
+@pytest.mark.parametrize("sku_id", SKU_IDS)
+def test_tile_energy_model_dram_phy_energy_per_byte(sku_id, catalogs):
+    """DRAM read energy comes from the per-memory-type table (LPDDR5
+    = 10 pJ/byte, HBM3 = 6 pJ/byte, etc.); write is 1.2x read."""
+    m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+    tem = m.tile_energy_model
+    # Read >= write is wrong; write is heavier.
+    assert tem.dram_write_energy_per_byte > tem.dram_read_energy_per_byte
+    # Both in plausible 4-15 pJ/byte range.
+    assert 4e-12 <= tem.dram_read_energy_per_byte <= 15e-12
+    assert 4e-12 <= tem.dram_write_energy_per_byte <= 18e-12
+
+
+@pytest.mark.parametrize("sku_id", SKU_IDS)
+def test_tile_energy_model_sram_hierarchy_inversely_ordered(sku_id, catalogs):
+    """L1 <= L2 <= L3 <= DRAM in per-byte energy (closer to PE = cheaper)."""
+    m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+    tem = m.tile_energy_model
+    assert tem.l1_read_energy_per_byte < tem.l2_read_energy_per_byte
+    assert tem.l2_read_energy_per_byte < tem.l3_read_energy_per_byte
+    assert tem.l3_read_energy_per_byte < tem.dram_read_energy_per_byte
+
+
+@pytest.mark.parametrize("sku_id", SKU_IDS)
+def test_loader_populates_soc_fabric(sku_id, catalogs):
+    """The loader must attach a SoCFabricModel matching the YAML's
+    kpu_architecture.noc declaration."""
+    m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+    assert m.soc_fabric is not None
+
+
+@pytest.mark.parametrize("sku_id", SKU_IDS)
+def test_soc_fabric_topology_and_dimensions_match_yaml(sku_id, catalogs):
+    """topology, mesh_dimensions, flit_size_bytes, controller_count,
+    bisection_bandwidth_gbps -- all direct reads from
+    kpu_architecture.noc + total_tiles."""
+    from graphs.hardware.fabric_model import Topology
+    m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+    sku = catalogs["kpus"][sku_id]
+    noc = sku.kpu_architecture.noc
+    fab = m.soc_fabric
+    # All 4 Stillwater SKUs use mesh_2d
+    assert fab.topology == Topology.MESH_2D
+    assert fab.low_confidence is False
+    assert fab.mesh_dimensions == (noc.mesh_rows, noc.mesh_cols)
+    assert fab.flit_size_bytes == noc.flit_bytes
+    assert fab.controller_count == sku.kpu_architecture.total_tiles
+    if noc.bisection_bandwidth_gbps is not None:
+        assert fab.bisection_bandwidth_gbps == noc.bisection_bandwidth_gbps
+
+
+def test_soc_fabric_unknown_topology_marks_low_confidence(catalogs):
+    """Unknown topology strings should produce Topology.UNKNOWN with
+    low_confidence=True instead of crashing -- defensive behavior so
+    new YAML topology values land cleanly even before the enum map
+    is updated."""
+    from graphs.hardware.fabric_model import Topology
+    real = catalogs["kpus"]["stillwater_kpu_t256"]
+    bad_arch = real.kpu_architecture.model_copy(
+        update={"noc": real.kpu_architecture.noc.model_copy(
+            update={"topology": "future_topology_3d_torus"}
+        )}
+    )
+    bad_sku = real.model_copy(update={"kpu_architecture": bad_arch})
+    m = load_kpu_resource_model_from_yaml(
+        bad_sku.id,
+        kpus={bad_sku.id: bad_sku},
+        process_nodes=catalogs["process_nodes"],
+    )
+    assert m.soc_fabric.topology == Topology.UNKNOWN
+    assert m.soc_fabric.low_confidence is True
+
+
+@pytest.mark.parametrize("sku_id", SKU_IDS)
+def test_loader_output_remains_kpu_mapper_compatible(sku_id, catalogs):
+    """The KPUMapper energy paths use ``mapper.tile_energy_model``;
+    confirm the loader-populated model passes through cleanly."""
+    from graphs.hardware.mappers.accelerators.kpu import KPUMapper
+    m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+    mapper = KPUMapper(m)
+    # The mapper reads l1_cache_per_unit, l2_cache_total, num_tiles --
+    # verify they're consistent with the loaded model.
+    assert mapper.num_tiles == m.tile_energy_model.num_tiles
+    assert mapper.scratchpad_per_tile == m.l1_cache_per_unit


### PR DESCRIPTION
## Summary

Phase 4b PR 2 from `docs/designs/kpu-sku-and-process-node-plan.md`. Extends the Phase-4a KPU YAML resource-model loader to populate two post-construction attributes the existing factories attach: `tile_energy_model` (KPUTileEnergyModel) and `soc_fabric` (SoCFabricModel).

**Additive only** — no factory changes, no test changes elsewhere. Unblocks PR 5 (factory collapse) by closing the last loader-vs-factory delta that wasn't a numeric reconciliation.

## Why this PR exists

From the PR-1 contract snapshot: the loader's HardwareResourceModel was missing `tile_energy_model` and `soc_fabric`. Downstream consumers (energy analyzers, KPU mapper energy reporting, M6 fabric model) read these attributes and would crash on a loader-produced model. PR 2 closes that gap by deriving both from the YAML + ProcessNode.

## What's new

### `_build_tile_energy_model(sku, node, default_clock_hz)`

| Field | Source |
|---|---|
| `num_tiles`, `tile_mesh_dimensions` | `sku.kpu_architecture.{total_tiles, noc.{mesh_rows,mesh_cols}}` |
| `pes_per_tile` | dominant tile class's PE count (largest `num_tiles`; INT8-primary in all 4 SKUs) |
| `dram_bandwidth_gb_s`, `l3/l2/l1_size` | `sku.kpu_architecture.memory.*` |
| `clock_frequency_hz` | default thermal profile's `clock_mhz × 1e6` |
| `mac_energy_int8/bf16/fp32` | `node.energy_per_op_pj["balanced_logic:<precision>"]` (PDK-derived) with precision-typical fallback ratios |
| `dram_read/write_energy_per_byte` | per-memory-type table (LPDDR5 = 10 pJ/byte, HBM3 = 6 pJ/byte, etc.); write = 1.2× read |
| `l1/l2/l3_read/write_energy_per_byte` | node-agnostic v1 placeholders matching existing factories; per-node SRAM table is a follow-up |

### `_build_soc_fabric(sku, node)`

| Field | Source |
|---|---|
| `topology` | `noc.topology` string → `Topology` enum via `_NOC_TOPOLOGY_MAP` |
| `mesh_dimensions` | `(noc.mesh_rows, noc.mesh_cols)` |
| `flit_size_bytes` | `noc.flit_bytes` |
| `bisection_bandwidth_gbps` | `noc.bisection_bandwidth_gbps` (or 0.0) |
| `controller_count` | `total_tiles` (each tile is a NoC node) |
| `routing_distance_factor` | 1.2 (typical XY routing with detours) |
| `low_confidence` | `True` when topology string is unrecognized — defensive against future YAML topology values |

## Per-SKU output

```
SKU   num_tiles  pes/tile   mesh      mac_int8  mac_bf16  mac_fp32  dram_R  topo
T64       64       1024     (8, 8)    0.30 pJ   1.40 pJ   2.70 pJ   10 pJ  mesh_2d
T128     128       1024     (16, 8)   0.30      1.40      2.70      10     mesh_2d
T256     256        400     (16,16)   0.30      1.40      2.70      10     mesh_2d
T768     768        128     (32,24)   0.13      0.55      1.10       6     mesh_2d (HBM3)
```

T768 MAC energies are 2-2.5× lower than the N16 SKUs as expected for the advanced-node SKU. DRAM PHY energy reflects HBM3 (6 pJ/byte) vs LPDDR5 (10 pJ/byte).

## Tests added (37 new parametrized test runs)

- Architectural shape mapping (per-SKU): `num_tiles`, `tile_mesh_dimensions`, `dram_bandwidth_gb_s`, `l1/l2/l3_size`, `clock_frequency_hz` all match YAML
- `pes_per_tile` matches the dominant tile class
- MAC energy plausibility ranges + ordering invariant (INT8 ≤ BF16 ≤ FP32)
- DRAM read < write
- SRAM hierarchy energy ordering: L1 < L2 < L3 < DRAM
- NoC topology + mesh dimensions match YAML
- Unknown topology string falls back to `Topology.UNKNOWN` with `low_confidence=True` (no crash)
- KPUMapper still consumable on the loader-produced model

## Test plan

- [x] `python -m pytest tests/hardware/test_kpu_yaml_loader.py -q` → 79 pass (42 from Phase 4a + 37 new)
- [x] Full sweep: 217 passing (no regressions to existing factory tests since the loader is still a parallel path)

## What unblocks

| PR | Status |
|---|---|
| PR 3 (per-profile `efficiency_factor` YAML field) | unaffected; can land in any order |
| PR 4 (T64 INT8 truth + l2 convention reconciliation) | needs the 3 decisions in PR 1's snapshot doc §6 |
| PR 5 (factory collapse) | now only blocked by PR 4 — `tile_energy_model` and `soc_fabric` parity is achieved here |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hardware YAML loader now produces complete resource models with per-tile energy profiles, DRAM/SRAM per-byte energy heuristics, MAC energy estimates (with process-node–scaled fallbacks), and mapped on-chip fabric topology (marks low-confidence when topology is unknown or approximated).

* **Tests**
  * Added comprehensive tests validating tile energy values and ordering, DRAM/SRAM plausibility, topology/dimension mapping and low-confidence flags, fallback MAC-energy behavior, and compatibility with downstream hardware mapping.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/146)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->