### PR TITLE
feat(hardware): Phase 4b PR 3 -- loader reads per-(profile, precision) efficiency from YAML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: branes-ai/embodied-schemas
-          # Pinned to the embodied-schemas main commit that landed PR #9
-          # (ProcessNode + CoolingSolution + KPU SKU schemas). Bump this
-          # SHA when later embodied-schemas changes need to be picked up.
-          ref: e8c6c89017dc45affa3334f8003afb1ea59a9c42
+          # Pinned to embodied-schemas main; bump when later schema
+          # changes need to be picked up. History:
+          #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
+          #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
+          ref: 5abce59ab86403eec20266a695caeb5dee23590c
           path: embodied-schemas
           fetch-depth: 1
 
@@ -124,10 +125,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: branes-ai/embodied-schemas
-          # Pinned to the embodied-schemas main commit that landed PR #9
-          # (ProcessNode + CoolingSolution + KPU SKU schemas). Bump this
-          # SHA when later embodied-schemas changes need to be picked up.
-          ref: e8c6c89017dc45affa3334f8003afb1ea59a9c42
+          # Pinned to embodied-schemas main; bump when later schema
+          # changes need to be picked up. History:
+          #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
+          #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
+          ref: 5abce59ab86403eec20266a695caeb5dee23590c
           path: embodied-schemas
           fetch-depth: 1
 
@@ -215,10 +217,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: branes-ai/embodied-schemas
-          # Pinned to the embodied-schemas main commit that landed PR #9
-          # (ProcessNode + CoolingSolution + KPU SKU schemas). Bump this
-          # SHA when later embodied-schemas changes need to be picked up.
-          ref: e8c6c89017dc45affa3334f8003afb1ea59a9c42
+          # Pinned to embodied-schemas main; bump when later schema
+          # changes need to be picked up. History:
+          #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
+          #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
+          ref: 5abce59ab86403eec20266a695caeb5dee23590c
           path: embodied-schemas
           fetch-depth: 1
 
@@ -303,10 +306,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: branes-ai/embodied-schemas
-          # Pinned to the embodied-schemas main commit that landed PR #9
-          # (ProcessNode + CoolingSolution + KPU SKU schemas). Bump this
-          # SHA when later embodied-schemas changes need to be picked up.
-          ref: e8c6c89017dc45affa3334f8003afb1ea59a9c42
+          # Pinned to embodied-schemas main; bump when later schema
+          # changes need to be picked up. History:
+          #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
+          #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
+          ref: 5abce59ab86403eec20266a695caeb5dee23590c
           path: embodied-schemas
           fetch-depth: 1
 
@@ -364,10 +368,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: branes-ai/embodied-schemas
-          # Pinned to the embodied-schemas main commit that landed PR #9
-          # (ProcessNode + CoolingSolution + KPU SKU schemas). Bump this
-          # SHA when later embodied-schemas changes need to be picked up.
-          ref: e8c6c89017dc45affa3334f8003afb1ea59a9c42
+          # Pinned to embodied-schemas main; bump when later schema
+          # changes need to be picked up. History:
+          #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
+          #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
+          ref: 5abce59ab86403eec20266a695caeb5dee23590c
           path: embodied-schemas
           fetch-depth: 1
 

--- a/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
+++ b/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
@@ -569,17 +569,21 @@ def load_kpu_resource_model_from_yaml(
             tile_specializations=profile_specializations,
         )
 
+        # Per-(profile, precision) calibration data lives on the YAML's
+        # KPUThermalProfile (Phase 4b PR 3, embodied-schemas#10). When
+        # absent, fall back to the historical placeholders -- the field
+        # is Optional precisely so external user YAMLs don't need to
+        # backfill for the loader to function.
+        eff_by_prec = profile.efficiency_factor_by_precision or {}
+        util_by_prec = profile.tile_utilization_by_precision or {}
+
         performance_specs: dict[Precision, PerformanceCharacteristics] = {}
         for precision in supported_precisions:
             performance_specs[precision] = PerformanceCharacteristics(
                 precision=precision,
                 compute_resource=profile_compute,
-                # v1: assume KPU achieves ~70% efficiency at the default
-                # profile, ~60% at the highest, ~80% at the lowest. These
-                # are placeholders -- Phase 4b will read measured
-                # efficiency factors from a calibration source.
-                efficiency_factor=0.70,
-                tile_utilization=0.95,
+                efficiency_factor=eff_by_prec.get(precision.value, 0.70),
+                tile_utilization=util_by_prec.get(precision.value, 0.95),
                 native_acceleration=True,
             )
 

--- a/tests/hardware/test_kpu_yaml_loader.py
+++ b/tests/hardware/test_kpu_yaml_loader.py
@@ -348,6 +348,110 @@ def test_soc_fabric_lossy_torus_mapping_marks_low_confidence(catalogs):
     assert m.soc_fabric.low_confidence is True
 
 
+# ---------------------------------------------------------------------------
+# Phase 4b PR 3: per-(profile, precision) efficiency / tile_utilization
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sku_id", SKU_IDS)
+def test_loader_reads_per_precision_efficiency_from_yaml(sku_id, catalogs):
+    """When KPUThermalProfile.efficiency_factor_by_precision is set in
+    the YAML, the loader must propagate it to the matching
+    PerformanceCharacteristics. Phase 4b PR 3 backfilled the four
+    SKU YAMLs with values from the corresponding factories."""
+    m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+    sku = catalogs["kpus"][sku_id]
+    for profile in sku.power.thermal_profiles:
+        if not profile.efficiency_factor_by_precision:
+            continue
+        top = m.thermal_operating_points[profile.name]
+        for precision_name, expected_eff in profile.efficiency_factor_by_precision.items():
+            precision = next(
+                (p for p in Precision if p.value == precision_name), None
+            )
+            if precision is None or precision not in top.performance_specs:
+                continue
+            actual = top.performance_specs[precision].efficiency_factor
+            assert actual == expected_eff, (
+                f"{sku_id} {profile.name} {precision_name}: "
+                f"loader produced efficiency_factor={actual} but YAML says {expected_eff}"
+            )
+
+
+@pytest.mark.parametrize("sku_id", SKU_IDS)
+def test_loader_reads_per_precision_tile_utilization_from_yaml(sku_id, catalogs):
+    """Same as efficiency but for tile_utilization."""
+    m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+    sku = catalogs["kpus"][sku_id]
+    for profile in sku.power.thermal_profiles:
+        if not profile.tile_utilization_by_precision:
+            continue
+        top = m.thermal_operating_points[profile.name]
+        for precision_name, expected_util in profile.tile_utilization_by_precision.items():
+            precision = next(
+                (p for p in Precision if p.value == precision_name), None
+            )
+            if precision is None or precision not in top.performance_specs:
+                continue
+            actual = top.performance_specs[precision].tile_utilization
+            assert actual == expected_util, (
+                f"{sku_id} {profile.name} {precision_name}: "
+                f"loader produced tile_utilization={actual} but YAML says {expected_util}"
+            )
+
+
+def test_loader_falls_back_to_placeholder_when_yaml_omits_efficiency(catalogs):
+    """A YAML thermal_profile without
+    ``efficiency_factor_by_precision`` should produce the historical
+    flat placeholder (0.70 / 0.95). This is the backward-compat path
+    for external user YAMLs that haven't backfilled."""
+    real = catalogs["kpus"]["stillwater_kpu_t256"]
+    profiles = [
+        p.model_copy(
+            update={
+                "efficiency_factor_by_precision": None,
+                "tile_utilization_by_precision": None,
+            }
+        )
+        for p in real.power.thermal_profiles
+    ]
+    bare_power = real.power.model_copy(update={"thermal_profiles": profiles})
+    bare_sku = real.model_copy(update={"power": bare_power})
+    m = load_kpu_resource_model_from_yaml(
+        bare_sku.id,
+        kpus={bare_sku.id: bare_sku},
+        process_nodes=catalogs["process_nodes"],
+    )
+    # All profiles should now use the placeholder.
+    for top in m.thermal_operating_points.values():
+        for ps in top.performance_specs.values():
+            assert ps.efficiency_factor == 0.70
+            assert ps.tile_utilization == 0.95
+
+
+def test_loader_efficiency_increases_with_tdp_per_yaml(catalogs):
+    """Sanity check on the catalog values: across the catalog, INT8
+    efficiency_factor should be non-decreasing as TDP rises within
+    a SKU (more thermal headroom -> less DVFS throttling -> higher
+    sustained efficiency)."""
+    for sku_id in SKU_IDS:
+        m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
+        # Sort profiles by TDP and check INT8 efficiency is monotonic.
+        sku = catalogs["kpus"][sku_id]
+        sorted_profiles = sorted(
+            sku.power.thermal_profiles, key=lambda p: p.tdp_watts
+        )
+        prev_eff = 0.0
+        for profile in sorted_profiles:
+            top = m.thermal_operating_points[profile.name]
+            int8_eff = top.performance_specs[Precision.INT8].efficiency_factor
+            assert int8_eff >= prev_eff, (
+                f"{sku_id} INT8 efficiency at {profile.name} "
+                f"({int8_eff}) is lower than at the previous TDP "
+                f"({prev_eff}) -- expected monotonic per Phase 4b PR 3 backfill"
+            )
+            prev_eff = int8_eff
+
+
 def test_tile_energy_model_mac_fallback_is_node_scaled(catalogs):
     """When a process node lacks ``balanced_logic:<precision>`` entries,
     the MAC fallback must scale with ``node.node_nm`` via


### PR DESCRIPTION
## Summary

Phase 4b PR 3 (graphs side; embodied-schemas#10 already merged). Loader now reads `KPUThermalProfile.efficiency_factor_by_precision` and `tile_utilization_by_precision` when building `PerformanceCharacteristics`, instead of using flat 0.70 / 0.95 placeholders.

## Cross-repo dependency

embodied-schemas#10 added the optional fields and backfilled the four Stillwater KPU YAMLs with values from the corresponding `kpu_t*.py` factories. CI ref re-pinned to its merge SHA `5abce59ab86403eec20266a695caeb5dee23590c`.

## Per-precision efficiency table after this PR (loader output)

```
SKU   profile  INT8   BF16   INT4
T64   3W       0.60   0.55   0.65
T64   6W       0.65   0.60   0.70
T64   10W      0.70   0.65   0.75
T128  6W       0.63   0.58   0.68
T128  12W      0.68   0.63   0.73
T128  18W      0.72   0.67   0.77
T256  15W      0.68   0.63   0.73
T256  30W      0.73   0.68   0.78
T256  50W      0.78   0.73   0.83
T768  30W      0.75   0.70   0.78
T768  60W      0.80   0.75   0.82
T768  100W     0.85   0.80   0.87
```

Pattern preserved across the catalog: efficiency rises with TDP within each SKU (more thermal margin), and rises with tier across SKUs (better-calibrated silicon at higher tiers).

## Backward compatibility

When a YAML omits the new fields (Optional, default `None`), the loader falls back to the historical 0.70 / 0.95 placeholders. External user YAMLs that haven't backfilled continue to work unchanged. Test `test_loader_falls_back_to_placeholder_when_yaml_omits_efficiency` covers this.

## Tests added (10 new)

- `test_loader_reads_per_precision_efficiency_from_yaml` (×4 SKUs) — loader propagates YAML values exactly
- `test_loader_reads_per_precision_tile_utilization_from_yaml` (×4 SKUs) — same for tile_utilization
- `test_loader_falls_back_to_placeholder_when_yaml_omits_efficiency` — backward-compat
- `test_loader_efficiency_increases_with_tdp_per_yaml` — sanity (monotonic in TDP per SKU)

## Test plan

- [ ] `python -m pytest tests/hardware/test_kpu_yaml_loader.py -q` → 91 pass (81 prior + 10 new)
- [ ] Full sweep: 229 passing (no regressions)

## What unblocks Phase 4b

| PR | Status |
|---|---|
| 4 — T64 INT8 truth + l2_cache_total reconciliation | needs decisions in PR 1 doc §6 |
| 5 — factory collapse | mechanical once PR 4 lands; this PR closes the last loader-vs-factory delta in calibration data |

🤖 Generated with [Claude Code](https://claude.com/claude-code)