### PR TITLE
feat(hardware): Phase 4b PR 4 -- KPU loader/factory peak_ops + l2 reconciliation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,8 @@ jobs:
           # changes need to be picked up. History:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
-          ref: 5abce59ab86403eec20266a695caeb5dee23590c
+          #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
+          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
           path: embodied-schemas
           fetch-depth: 1
 
@@ -129,7 +130,8 @@ jobs:
           # changes need to be picked up. History:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
-          ref: 5abce59ab86403eec20266a695caeb5dee23590c
+          #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
+          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
           path: embodied-schemas
           fetch-depth: 1
 
@@ -221,7 +223,8 @@ jobs:
           # changes need to be picked up. History:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
-          ref: 5abce59ab86403eec20266a695caeb5dee23590c
+          #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
+          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
           path: embodied-schemas
           fetch-depth: 1
 
@@ -310,7 +313,8 @@ jobs:
           # changes need to be picked up. History:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
-          ref: 5abce59ab86403eec20266a695caeb5dee23590c
+          #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
+          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
           path: embodied-schemas
           fetch-depth: 1
 
@@ -372,7 +376,8 @@ jobs:
           # changes need to be picked up. History:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
-          ref: 5abce59ab86403eec20266a695caeb5dee23590c
+          #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
+          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
           path: embodied-schemas
           fetch-depth: 1
 

--- a/src/graphs/hardware/models/accelerators/kpu_t128.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t128.py
@@ -266,11 +266,14 @@ def kpu_t128_resource_model() -> HardwareResourceModel:
             "18W": thermal_18w,
         },
         default_thermal_profile="12W",
+        # Precision profiles -- M0.5 values (Phase 4b PR 4 reconciled
+        # to match the YAML loader). FP16 + FP32 added; INT4 narrowed to
+        # the precision-supporting tile classes only.
         precision_profiles={
             Precision.INT8: PrecisionProfile(
                 precision=Precision.INT8,
-                # 128 tiles x 2048 INT8 ops/tile x 1.0 GHz ~= 262 TOPS peak
-                peak_ops_per_sec=128 * _INT8_OPS_PER_TILE * sustained_clock_hz,
+                # 128 tiles x 2048 INT8 ops/tile x 1.05 GHz = 275.25 TOPS
+                peak_ops_per_sec=275.3e12,
                 tensor_core_supported=True,
                 relative_speedup=2.0,
                 bytes_per_element=1,
@@ -278,14 +281,32 @@ def kpu_t128_resource_model() -> HardwareResourceModel:
             ),
             Precision.BF16: PrecisionProfile(
                 precision=Precision.BF16,
-                peak_ops_per_sec=128 * _BF16_OPS_PER_TILE * sustained_clock_hz,
+                # 128 tiles x 1024 BF16 ops/tile x 1.05 GHz = 137.63 TFLOPS
+                peak_ops_per_sec=137.6e12,
                 tensor_core_supported=True,
                 relative_speedup=1.0,
                 bytes_per_element=2,
             ),
+            # FP16 = BF16 throughput (same datapath on KPU).
+            Precision.FP16: PrecisionProfile(
+                precision=Precision.FP16,
+                peak_ops_per_sec=137.6e12,
+                tensor_core_supported=True,
+                relative_speedup=1.0,
+                bytes_per_element=2,
+            ),
+            Precision.FP32: PrecisionProfile(
+                precision=Precision.FP32,
+                # 26 BF16-primary tiles x 512 FP32 ops/tile x 1.05 GHz = 13.98 TFLOPS
+                peak_ops_per_sec=14.0e12,
+                tensor_core_supported=True,
+                relative_speedup=0.05,
+                bytes_per_element=4,
+            ),
             Precision.INT4: PrecisionProfile(
                 precision=Precision.INT4,
-                peak_ops_per_sec=128 * _INT4_OPS_PER_TILE * sustained_clock_hz,
+                # 89 INT8-primary tiles x 4096 INT4 ops/tile x 1.05 GHz = 382.77 TOPS
+                peak_ops_per_sec=382.8e12,
                 tensor_core_supported=True,
                 relative_speedup=2.5,
                 bytes_per_element=0.5,

--- a/src/graphs/hardware/models/accelerators/kpu_t256.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t256.py
@@ -430,11 +430,17 @@ def kpu_t256_resource_model() -> HardwareResourceModel:
         },
         default_thermal_profile="30W",
 
-        # Legacy precision profiles (calculated from fabrics)
+        # Precision profiles -- M0.5 values (Phase 4b PR 4 reconciled
+        # to match the YAML loader). The previous BF16 number used the
+        # ComputeFabric peak-ops helper which undercounted the BF16
+        # contribution from INT8-primary tiles by ~3.3x; the corrected
+        # value sums BF16 throughput across all tile classes that
+        # declare bf16 ops_per_tile_per_clock.
         precision_profiles={
             Precision.INT8: PrecisionProfile(
                 precision=Precision.INT8,
-                peak_ops_per_sec=total_int8_peak,  # INT8 tiles + Matrix tiles
+                # 256 tiles x 800 INT8 ops/tile x 1.4 GHz = 286.72 TOPS
+                peak_ops_per_sec=286.7e12,
                 tensor_core_supported=True,
                 relative_speedup=2.0,
                 bytes_per_element=1,
@@ -442,21 +448,32 @@ def kpu_t256_resource_model() -> HardwareResourceModel:
             ),
             Precision.BF16: PrecisionProfile(
                 precision=Precision.BF16,
-                peak_ops_per_sec=total_bf16_peak,  # BF16 tiles + Matrix tiles
+                # 256 tiles x 400 BF16 ops/tile x 1.4 GHz = 143.36 TFLOPS
+                peak_ops_per_sec=143.4e12,
+                tensor_core_supported=True,
+                relative_speedup=1.0,
+                bytes_per_element=2,
+            ),
+            # FP16 = BF16 throughput (same datapath on KPU).
+            Precision.FP16: PrecisionProfile(
+                precision=Precision.FP16,
+                peak_ops_per_sec=143.4e12,
                 tensor_core_supported=True,
                 relative_speedup=1.0,
                 bytes_per_element=2,
             ),
             Precision.FP32: PrecisionProfile(
                 precision=Precision.FP32,
-                peak_ops_per_sec=fp32_peak,  # BF16 tiles only
+                # 51 BF16-primary tiles x 200 FP32 ops/tile x 1.4 GHz = 14.28 TFLOPS
+                peak_ops_per_sec=14.3e12,
                 tensor_core_supported=False,
-                relative_speedup=0.5,
+                relative_speedup=0.05,
                 bytes_per_element=4,
             ),
             Precision.INT4: PrecisionProfile(
                 precision=Precision.INT4,
-                peak_ops_per_sec=int4_peak,  # INT8 tiles only
+                # 179 INT8-primary tiles x 1600 INT4 ops/tile x 1.4 GHz = 400.96 TOPS
+                peak_ops_per_sec=401.0e12,
                 tensor_core_supported=True,
                 relative_speedup=2.5,
                 bytes_per_element=0.5,

--- a/src/graphs/hardware/models/accelerators/kpu_t64.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t64.py
@@ -384,12 +384,16 @@ def kpu_t64_resource_model() -> HardwareResourceModel:
         },
         default_thermal_profile="6W",
 
-        # Legacy precision profiles
+        # Precision profiles -- M0.5 values (Phase 4b PR 4 reconciled
+        # to match graphs.hardware.models.accelerators.kpu_yaml_loader.
+        # The previous numbers came from a pre-M0.5 16x16 PE-array
+        # interpretation that contradicted the 32x32 ops_per_tile_per_clock
+        # already declared in this file's TileSpecialization block.
         precision_profiles={
             Precision.INT8: PrecisionProfile(
                 precision=Precision.INT8,
-                # 36,864 PEs * 2 ops * 900 MHz ~= 66.4 TOPS INT8 peak
-                peak_ops_per_sec=66.4e12,
+                # 64 tiles x 2048 INT8 ops/tile x 900 MHz = 117.96 TOPS
+                peak_ops_per_sec=118.0e12,
                 tensor_core_supported=True,
                 relative_speedup=2.0,
                 bytes_per_element=1,
@@ -397,33 +401,32 @@ def kpu_t64_resource_model() -> HardwareResourceModel:
             ),
             Precision.BF16: PrecisionProfile(
                 precision=Precision.BF16,
-                peak_ops_per_sec=33.2e12,  # 33.2 TFLOPS BF16
+                # 64 tiles x 1024 BF16 ops/tile x 900 MHz = 58.98 TFLOPS
+                peak_ops_per_sec=59.0e12,
                 tensor_core_supported=True,
                 relative_speedup=1.0,
                 bytes_per_element=2,
             ),
-            # FP16 runs on the same BF16 tile fabric (issue #53). Without an
-            # explicit entry, get_peak_ops() silently falls back to INT8 and
-            # makes -p fp16 byte-identical to -p int8 in the analyzer output.
+            # FP16 = BF16 throughput (same datapath on KPU, issue #53).
             Precision.FP16: PrecisionProfile(
                 precision=Precision.FP16,
-                peak_ops_per_sec=33.2e12,  # FP16 >= BF16 throughput on KPU
+                peak_ops_per_sec=59.0e12,
                 tensor_core_supported=True,
                 relative_speedup=1.0,
                 bytes_per_element=2,
             ),
-            # FP32 is supported but at much lower throughput; matches the
-            # 1.5 TFLOPS already reported by `mcp specs stillwater_kpu_t64`.
             Precision.FP32: PrecisionProfile(
                 precision=Precision.FP32,
-                peak_ops_per_sec=1.5e12,
+                # 13 BF16-primary tiles x 512 FP32 ops/tile x 900 MHz = 5.99 TFLOPS
+                peak_ops_per_sec=6.0e12,
                 tensor_core_supported=True,
-                relative_speedup=0.045,  # vs INT8
+                relative_speedup=0.05,
                 bytes_per_element=4,
             ),
             Precision.INT4: PrecisionProfile(
                 precision=Precision.INT4,
-                peak_ops_per_sec=132.8e12,  # 132.8 TOPS INT4
+                # 44 INT8-primary tiles x 4096 INT4 ops/tile x 900 MHz = 162.20 TOPS
+                peak_ops_per_sec=162.2e12,
                 tensor_core_supported=True,
                 relative_speedup=2.5,
                 bytes_per_element=0.5,

--- a/src/graphs/hardware/models/accelerators/kpu_t768.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t768.py
@@ -356,10 +356,17 @@ def kpu_t768_resource_model() -> HardwareResourceModel:
         },
         default_thermal_profile="60W",
 
+        # Precision profiles -- M0.5 values (Phase 4b PR 4 reconciled
+        # to match the YAML loader). The previous numbers undercounted
+        # by ~9x because the ComputeFabric helpers missed the
+        # systolic Matrix tile op density (8192 INT8 ops/tile/clock
+        # via weight-stationary accumulation; the simple tile-count
+        # x ops/tile/clock x clock model misses that).
         precision_profiles={
             Precision.INT8: PrecisionProfile(
                 precision=Precision.INT8,
-                peak_ops_per_sec=130.1e12,  # 130.1 TOPS @ 60W
+                # 537x512 + 154x512 + 77x8192 = 984,576 ops/clock x 1.2 GHz = 1181.49 TOPS
+                peak_ops_per_sec=1181.5e12,
                 tensor_core_supported=True,
                 relative_speedup=1.0,
                 bytes_per_element=1,
@@ -367,14 +374,33 @@ def kpu_t768_resource_model() -> HardwareResourceModel:
             ),
             Precision.BF16: PrecisionProfile(
                 precision=Precision.BF16,
-                peak_ops_per_sec=48.9e12,  # 48.9 TFLOPS @ 60W
+                # 537x256 + 154x256 + 77x4096 = 492,288 ops/clock x 1.2 GHz = 590.75 TFLOPS
+                peak_ops_per_sec=590.7e12,
                 tensor_core_supported=True,
                 relative_speedup=1.0,
                 bytes_per_element=2,
             ),
+            # FP16 = BF16 throughput (same datapath on KPU).
+            Precision.FP16: PrecisionProfile(
+                precision=Precision.FP16,
+                peak_ops_per_sec=590.7e12,
+                tensor_core_supported=True,
+                relative_speedup=1.0,
+                bytes_per_element=2,
+            ),
+            Precision.FP32: PrecisionProfile(
+                precision=Precision.FP32,
+                # 154 BF16-primary tiles x 128 FP32 ops/tile x 1.2 GHz = 23.65 TFLOPS
+                peak_ops_per_sec=23.7e12,
+                tensor_core_supported=False,
+                relative_speedup=0.02,
+                bytes_per_element=4,
+            ),
             Precision.INT4: PrecisionProfile(
                 precision=Precision.INT4,
-                peak_ops_per_sec=260.2e12,  # 260.2 TOPS @ 60W
+                # 537 INT8-primary tiles x 1024 INT4 ops/tile x 1.2 GHz = 659.87 TOPS
+                # Matrix tiles do not declare INT4 in ops_per_tile_per_clock.
+                peak_ops_per_sec=659.9e12,
                 tensor_core_supported=True,
                 relative_speedup=2.0,
                 bytes_per_element=0.5,

--- a/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
+++ b/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
@@ -627,14 +627,28 @@ def load_kpu_resource_model_from_yaml(
     peak_bandwidth_bps = mem.memory_bandwidth_gbps * 1e9
     main_memory_bytes = int(mem.memory_size_gb * 1024**3)
     l3_per_tile_bytes = mem.l3_kib_per_tile * 1024
-    l3_total_bytes = l3_per_tile_bytes * sku.kpu_architecture.total_tiles
     # The historical "l1_cache_per_unit" on KPU resource models is the
     # per-tile scratchpad (= L3 in the per-tile-L3 vocabulary). Map there
     # so existing consumers see the same field semantics.
     l1_cache_per_unit_bytes = l3_per_tile_bytes
-    # "l2_cache_total" historically held the chip-wide shared SRAM
-    # rolled to one number. Use total L3 in this loader for parity.
-    l2_cache_total_bytes = l3_total_bytes
+    # "l2_cache_total" on the resource_model is read by KPUMapper as
+    # ADDITIVE to ``num_tiles * l1_cache_per_unit`` to compute total
+    # on-chip capacity, so it must NOT also include the per-tile L3
+    # (that would double-count). The hand-coded factories pre-Phase-4b
+    # used per-SKU literal values matching this convention; the loader
+    # mirrors them here so PR 5 (factory collapse) is purely mechanical.
+    # Architectural note: M0.5 has no chip-wide L2 above per-tile L3;
+    # these values are legacy-architectural placeholders. Eventual
+    # cleanup tracked in docs/designs/kpu-test-contract-snapshot.md.
+    _LEGACY_L2_CACHE_TOTAL_MB = {
+        "stillwater_kpu_t64":  4,
+        "stillwater_kpu_t128": 8,
+        "stillwater_kpu_t256": 16,
+        "stillwater_kpu_t768": 32,
+    }
+    l2_cache_total_bytes = (
+        _LEGACY_L2_CACHE_TOTAL_MB.get(base_id, 0) * 1024 * 1024
+    )
 
     # Per-PE thread count proxy: the largest tile-class PE array. Used
     # by mappers that compute parallelism budgets.

--- a/tests/hardware/test_kpu_t64_precision_profiles.py
+++ b/tests/hardware/test_kpu_t64_precision_profiles.py
@@ -32,11 +32,16 @@ def test_kpu_t64_lists_precision(kpu_t64, precision):
 @pytest.mark.parametrize(
     "precision,expected_tops",
     [
-        (Precision.INT4, 132.8),
-        (Precision.INT8, 66.4),
-        (Precision.BF16, 33.2),
-        (Precision.FP16, 33.2),
-        (Precision.FP32, 1.5),
+        # Phase 4b PR 4 reconciled to M0.5 / loader values. Previous
+        # numbers came from a pre-M0.5 16x16 PE-array model that
+        # contradicted the 32x32 ops_per_tile_per_clock already declared
+        # in this file's TileSpecialization block. See
+        # docs/designs/kpu-test-contract-snapshot.md sections 1, 5.
+        (Precision.INT4, 162.2),  # 44 INT8-tiles x 4096 INT4 x 900 MHz
+        (Precision.INT8, 118.0),  # 64 tiles x 2048 INT8 x 900 MHz
+        (Precision.BF16, 59.0),   # 64 tiles x 1024 BF16 x 900 MHz
+        (Precision.FP16, 59.0),   # = BF16 throughput (same datapath)
+        (Precision.FP32, 6.0),    # 13 BF16-primary tiles x 512 FP32 x 900 MHz
     ],
 )
 def test_kpu_t64_peak_ops(kpu_t64, precision, expected_tops):


### PR DESCRIPTION
## Summary

Phase 4b PR 4 (graphs side; embodied-schemas#11 already merged for FP16 backfill). Closes the loader-vs-factory deltas catalogued in `docs/designs/kpu-test-contract-snapshot.md`. After this PR, the four KPU factories and the YAML loader produce **identical values** for every `precision_profiles` entry and for `l2_cache_total` — making PR 5 (factory collapse) purely mechanical.

## Three reconciliation decisions

### Decision 1 — T64 INT8 truth (adopted M0.5 / loader)

Factory pre-PR carried pre-M0.5 numbers that contradicted the 32×32 `ops_per_tile_per_clock` already in the same file's `TileSpecialization` block. Updated:

```
T64    INT4: 132.8 -> 162.2    INT8: 66.4 -> 118.0    BF16: 33.2 -> 59.0
       FP16: 33.2 -> 59.0      FP32: 1.5 -> 6.0
```

### Decision 3 — Cross-SKU peak ops normalization

Factory `ComputeFabric` path undercounted by **3.3×** for T256 BF16 (missed BF16-fallback contribution from INT8-primary tiles) and **9×** for T768 across the board (missed Matrix tile systolic op density of 8192 INT8 ops/tile/clock). All four SKUs now match the loader:

```
T128   INT4: 524.3 -> 382.8    INT8: 262.1 -> 275.3   BF16: 131.1 -> 137.6
T256   INT4: 401.0 -> 401.0    INT8: 286.7 -> 286.7   BF16:  43.1 -> 143.4
T768   INT4: 260.2 -> 659.9    INT8: 130.1 -> 1181.5  BF16:  48.9 -> 590.7
```

T128/T256/T768 also gain FP16 entries (factory previously had FP16 only on T64). embodied-schemas#11 backfilled `fp16: <bf16_value>` on every KPU tile class so the loader exposes FP16 in `precision_profiles`.

### Decision 2 — `l2_cache_total` convention (loader matches factory)

The Phase 4a loader set `l2_cache_total = chip-wide L3 total`, but the KPUMapper computes total on-chip as `num_tiles × l1_cache_per_unit + l2_cache_total` — and `l1_cache_per_unit` IS the per-tile L3. The Phase 4a value double-counted.

Resolution: loader now uses a per-SKU table matching the factory's hand-coded values (T64=4MB, T128=8MB, T256=16MB, T768=32MB). Architectural note: M0.5 has no chip-wide L2 above per-tile L3 — these are legacy placeholders preserved for downstream behavior continuity. Eventual cleanup tracked in the snapshot doc.

## CI ref re-pin

`embodied-schemas` ref bumped from `5abce59` (PR #10) to `bd61f3c` (PR #11) to pick up the FP16 backfill.

## Test churn

Only `tests/hardware/test_kpu_t64_precision_profiles.py` asserts literal precision peaks — 5 assertion updates. Other KPU tests assert architectural shapes or value ranges, not specific peak numbers, so they pass unchanged.

## What unblocks

PR 5 (factory collapse) is now purely mechanical — every numeric field on the four factories matches the loader output. The factories can be replaced with thin wrappers calling `load_kpu_resource_model_from_yaml(base_id)` plus the BOM cost / soc_fabric augmentation that's not in the YAML.

## Test plan

- [ ] `python -m pytest tests/hardware/ -q` → 229 pass (up from 219; new FP16 paths)
- [ ] `python cli/list_hardware_resources.py --category kpu` → real numbers (no factory regressions)
- [ ] Loader vs factory comparison: identical peaks across INT4/INT8/BF16/FP16/FP32 for all 4 SKUs

🤖 Generated with [Claude Code](https://claude.com/claude-code)