### PR TITLE
feat(ci): Phase 6 -- SKU catalog validation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,11 +404,71 @@ jobs:
         run: |
           python validation/composition/test_layer_composition.py --verbose
 
-  # Job 9: Summary
+  # Job 9: SKU catalog validation gate (Phase 6)
+  # Runs the full registry of SKU validators against every KPU YAML in
+  # the embodied-schemas catalog. Fails the build on any ERROR finding
+  # so a regression in a new SKU YAML (or in the validators themselves)
+  # surfaces before merge. WARNINGs (the "DVFS throttle to N%"
+  # diagnostics) are allowed; --strict would also fail on warnings.
+  sku-catalog-gate:
+    name: SKU Catalog Gate
+    runs-on: ubuntu-latest
+    env:
+      EMBODIED_SCHEMAS_DATA_DIR: ${{ github.workspace }}/embodied-schemas/src/embodied_schemas/data
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Checkout embodied-schemas (PhysicalSpec data source)
+        uses: actions/checkout@v4
+        with:
+          repository: branes-ai/embodied-schemas
+          # Pinned to embodied-schemas main; bump when later schema
+          # changes need to be picked up. History:
+          #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
+          #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
+          #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
+          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
+          path: embodied-schemas
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          pip install -e .
+          pip install -e ./embodied-schemas
+          pip install pytest
+
+      - name: Run catalog-validation gate
+        run: |
+          python cli/validate_sku.py --all
+          echo "✅ Catalog validation gate passed"
+
+      - name: Run catalog-validation pytest gate
+        run: |
+          # The pytest version of the gate auto-discovers SKUs and
+          # produces a structured per-SKU pass/fail report. Both the
+          # CLI and pytest paths must pass.
+          pytest tests/hardware/test_sku_catalog_validation.py -v
+
+  # Job 10: Summary
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [package-check, test, cli-tools, examples, lint, hardware-tests, data-hygiene, composition-check]
+    needs: [package-check, test, cli-tools, examples, lint, hardware-tests, data-hygiene, composition-check, sku-catalog-gate]
     steps:
       - name: All checks passed
         run: |
@@ -425,5 +485,6 @@ jobs:
           echo "  Hardware tests completed"
           echo "  Data hygiene verified"
           echo "  Composition check passed"
+          echo "  SKU catalog gate passed (Phase 6)"
           echo ""
           echo "Ready to merge!"

--- a/cli/validate_sku.py
+++ b/cli/validate_sku.py
@@ -10,6 +10,11 @@ The validator package self-registers a category-by-category set of
 checks at import time (consistency, electrical, area, energy, thermal,
 reliability). Use ``--category`` to focus on one risk class.
 
+Phase 6 catalog gate: pass ``--all`` (in place of an SKU id) to validate
+every KPU SKU in the embodied-schemas catalog and exit non-zero on any
+ERROR. Identical contract to ``tests/hardware/test_sku_catalog_validation.py``;
+useful for human-driven sweeps.
+
 Usage:
     python cli/validate_sku.py stillwater_kpu_t256
     python cli/validate_sku.py stillwater_kpu_t768 --category thermal
@@ -17,6 +22,8 @@ Usage:
     python cli/validate_sku.py stillwater_kpu_t256 --output findings.json
     python cli/validate_sku.py stillwater_kpu_t256 --output findings.csv
     python cli/validate_sku.py stillwater_kpu_t256 --output findings.md
+    python cli/validate_sku.py --all                  # gate every catalog SKU
+    python cli/validate_sku.py --all --strict         # also fail on warnings
 
 Exit codes:
     0 = no ERROR findings (or filtered out by --severity)
@@ -158,6 +165,76 @@ def _render_csv(findings: List[Finding], sku_id: str, validator_count: int) -> s
     return buf.getvalue()
 
 
+def _run_catalog_sweep(args: argparse.Namespace, validator_count: int) -> int:
+    """Phase 6 catalog gate -- iterate over every KPU SKU and report
+    a per-SKU table to stdout. Returns non-zero on any ERROR finding
+    (or any WARNING if ``--strict``).
+    """
+    from embodied_schemas import load_kpus
+    try:
+        kpus = load_kpus()
+    except Exception as exc:
+        print(f"error: failed to load KPU catalog: {exc}", file=sys.stderr)
+        return 2
+
+    if not kpus:
+        print("error: KPU catalog is empty", file=sys.stderr)
+        return 2
+
+    print(f"=== SKU catalog gate ({len(kpus)} SKUs, "
+          f"{validator_count} validators) ===")
+    print(f"  {'sku_id':32s} {'errors':>6s} {'warnings':>9s} {'info':>5s}  status")
+
+    overall_errors = 0
+    overall_warnings = 0
+    failed_skus: List[str] = []
+
+    for sku_id in sorted(kpus):
+        try:
+            ctx = build_context_for_kpu(sku_id)
+        except ContextError as exc:
+            print(f"  {sku_id:32s} {'-':>6s} {'-':>9s} {'-':>5s}  context-error: {exc}")
+            failed_skus.append(sku_id)
+            continue
+
+        if args.category:
+            cat = ValidatorCategory(args.category)
+            findings = default_registry.run_category(ctx, cat)
+        else:
+            findings = default_registry.run_all(ctx)
+        if args.severity:
+            findings = filter_findings(
+                findings, min_severity=Severity(args.severity)
+            )
+
+        n_err = sum(1 for f in findings if f.severity == Severity.ERROR)
+        n_warn = sum(1 for f in findings if f.severity == Severity.WARNING)
+        n_info = sum(1 for f in findings if f.severity == Severity.INFO)
+        overall_errors += n_err
+        overall_warnings += n_warn
+
+        status = "ok"
+        if n_err > 0:
+            status = "FAIL"
+            failed_skus.append(sku_id)
+        elif args.strict and n_warn > 0:
+            status = "FAIL (--strict)"
+            failed_skus.append(sku_id)
+
+        print(f"  {sku_id:32s} {n_err:>6d} {n_warn:>9d} {n_info:>5d}  {status}")
+
+    print()
+    print(f"Catalog summary: {overall_errors} error(s), "
+          f"{overall_warnings} warning(s) across {len(kpus)} SKU(s)")
+
+    if failed_skus:
+        print(f"\nFailing SKUs ({len(failed_skus)}):")
+        for sku in failed_skus:
+            print(f"  - {sku}")
+        return 1
+    return 0
+
+
 def _detect_format(output: Optional[str]) -> str:
     if not output:
         return "text"
@@ -172,7 +249,17 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Run SKU validators against a KPU SKU and report findings."
     )
-    parser.add_argument("sku_id", help="SKU id, e.g., stillwater_kpu_t256")
+    sku_group = parser.add_mutually_exclusive_group(required=True)
+    sku_group.add_argument(
+        "sku_id", nargs="?", help="SKU id, e.g., stillwater_kpu_t256"
+    )
+    sku_group.add_argument(
+        "--all",
+        action="store_true",
+        help="Phase 6 catalog gate: validate every KPU SKU in the "
+        "embodied-schemas catalog. Exit non-zero on any ERROR finding "
+        "across the whole catalog.",
+    )
     parser.add_argument(
         "--category",
         choices=sorted(c.value for c in ValidatorCategory),
@@ -186,7 +273,7 @@ def main() -> int:
     parser.add_argument(
         "--output",
         help="Output file. Format auto-detected from extension (.json/.md/.txt). "
-        "Default: stdout text.",
+        "Default: stdout text. Ignored in --all mode.",
     )
     parser.add_argument(
         "--strict",
@@ -197,6 +284,10 @@ def main() -> int:
 
     # Trigger validator self-registration.
     validator_count = load_validators()
+
+    # ---- --all mode: catalog sweep ----
+    if args.all:
+        return _run_catalog_sweep(args, validator_count)
 
     # Build context.
     try:

--- a/docs/designs/kpu-sku-and-process-node-plan.md
+++ b/docs/designs/kpu-sku-and-process-node-plan.md
@@ -280,25 +280,28 @@ different leakage model, lower peak density but wider DVFS range).
 
 ## Phasing
 
+All cross-repo work landed via `embodied-schemas` PRs #9, #10, #11 and
+`graphs` PRs #144, #145, #146, #147, #148, #149.
+
 | # | Phase | Status |
 |---|---|---|
-| 0 | Cross-repo schema slots: `kpus/`, `process-nodes/`, `cooling-solutions/` directories in embodied-schemas | in progress |
-| 0a | `ProcessNodeEntry` / `CircuitClass` / `TransistorTopology` schema (Pydantic) | in progress |
-| 0a | `CoolingSolutionEntry` schema (Pydantic) | in progress |
-| 0b | Hand-authored 8 ProcessNode YAMLs + 7 CoolingSolution YAMLs | in progress |
-| 0c | Inspection CLIs (5 tools) | pending |
-| 1 | KPU SKU YAML schema (silicon_bin + process_node_id + cooling refs) | pending |
-| 2a | Validator framework (registry, Finding, base classes) | pending |
-| 2b | Initial validators (consistency, density, library, energy) | pending |
-| 2c | Thermal hotspot validator | pending |
-| 2d | EM validator | pending |
-| 3 | Generator (`generate_kpu_sku`) | pending |
-| 4a | KPU resource-model loader (`load_kpu_resource_model_from_yaml`) | done (2026-05-09) |
-| 4b | Collapse 4 hand-coded factories into thin wrappers around the loader | pending |
-| 5 | Mapper wiring (4 × 2 lines in `accelerators/kpu.py`) | pending |
-| 6 | CI gate: every SKU YAML validated | pending |
-| 7 | PDK ingestion + `PROCESS_NODE_DATA_DIR` override | pending |
-| 8 | **Stage 8 (later)**: DVFS feasibility, memory headroom, yield risk, **floorplanner + viz + geometric validators (KPU checkerboard pitch-match)** | pending |
+| 0 | Cross-repo schema slots: `kpus/`, `process-nodes/`, `cooling-solutions/` directories in embodied-schemas | done (#9) |
+| 0a | `ProcessNodeEntry` / `CircuitClass` / `TransistorTopology` schema (Pydantic) | done (#9) |
+| 0a | `CoolingSolutionEntry` schema (Pydantic) | done (#9) |
+| 0b | Hand-authored 8 ProcessNode YAMLs + 7 CoolingSolution YAMLs | done (#9) |
+| 0c | Inspection CLIs (`list_process_nodes`, `show_process_node`, `list_circuit_classes`, `list_cooling_solutions`, `show_cooling_solution`) | done (graphs #144) |
+| 1 | KPU SKU YAML schema (silicon_bin + process_node_id + cooling refs) + 4 Stillwater SKUs | done (#9, graphs #144) |
+| 2a | Validator framework (registry, `Finding`, `Severity`, `ValidatorCategory`, `ValidatorContext`) | done (graphs #144) |
+| 2b | Initial 7 validators (tile_mix_consistency, cross_ref_consistency, power_profile_monotonicity, block_library_validity, area_self_consistency, composite_density_envelope, tops_per_watt_envelope) | done (graphs #144) |
+| 2c | `thermal_hotspot` validator with explicit DVFS-throttle messaging | done (graphs #144) |
+| 2d | `electromigration` validator (sustained current vs PDN capacity at hottest Tj) | done (graphs #144) |
+| 3 | Generator (`generate_kpu_sku`) + `KPUSKUInputSpec` + `cli/generate_kpu_sku.py` | done (graphs #144) |
+| 4a | KPU resource-model loader (`load_kpu_resource_model_from_yaml`) | done (graphs #144) |
+| 4b | Collapse 4 hand-coded factories into thin wrappers around the loader | done (graphs #145–#149) |
+| 5 | Mapper wiring -- `physical_spec` populated on every `create_kpu_t*_mapper()` | done (graphs #144) |
+| 6 | CI gate: every SKU YAML in the catalog validated by the registry on every push | in progress |
+| 7 | PDK ingestion + `PROCESS_NODE_DATA_DIR` env override | not started |
+| 8 | **Stage 8 (later)**: DVFS feasibility, memory headroom, yield risk, **floorplanner + viz + geometric validators (KPU checkerboard pitch-match)** | deferred |
 
 ## File inventory
 

--- a/tests/hardware/test_sku_catalog_validation.py
+++ b/tests/hardware/test_sku_catalog_validation.py
@@ -1,0 +1,104 @@
+"""Phase 6 CI gate: every SKU YAML in the catalog must validate cleanly.
+
+The Phase 2 validator framework + Phase 4b factories tested specific
+SKUs by id (T64/T128/T256/T768) -- a future ``stillwater_kpu_t1024``
+or third-party KPU SKU added to the catalog wouldn't trip those tests.
+
+This module parametrizes over ``load_kpus().keys()`` so every SKU in
+the embodied-schemas catalog is automatically gated. A new SKU lands
+without touching the test list; a regression in a new SKU surfaces
+on its own commit.
+
+What's enforced:
+  * Every SKU resolves: ``process_node_id`` -> a known ProcessNode,
+    ``cooling_solution_id`` (per thermal profile) -> a known
+    CoolingSolution.
+  * Every validator in ``default_registry`` runs cleanly: no ERROR
+    findings.
+  * KPUMapper construction succeeds (the live mapper-factory path,
+    so e.g. mapper-specific attributes the loader doesn't set are
+    still populated).
+
+WARNING-severity findings are allowed (most are the actionable "DVFS
+throttle to N%" messages from the thermal-hotspot validator). The
+gate fails only on ERROR. Use ``--strict`` on the CLI to also fail
+on warnings if you need that locally.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from embodied_schemas import load_kpus
+
+from graphs.hardware.sku_validators import (
+    Severity,
+    build_context_for_kpu,
+    default_registry,
+    load_validators,
+)
+
+
+# Auto-load validators once per test session.
+load_validators()
+
+
+def _all_kpu_sku_ids() -> list[str]:
+    """Discover every KPU SKU id in the embodied-schemas catalog.
+
+    Cached at module import so the parametrize list is stable across
+    a single test session.
+    """
+    return sorted(load_kpus().keys())
+
+
+@pytest.mark.parametrize("sku_id", _all_kpu_sku_ids())
+def test_kpu_catalog_entry_has_no_validator_errors(sku_id):
+    """Every KPU YAML in ``embodied-schemas:data/kpus/**`` must pass
+    every registered validator with zero ERROR findings.
+
+    The Phase 6 catalog gate. New SKU YAMLs auto-discover; the test
+    list does not need maintenance.
+    """
+    ctx = build_context_for_kpu(sku_id)
+    findings = default_registry.run_all(ctx)
+    errors = [f for f in findings if f.severity == Severity.ERROR]
+    assert not errors, (
+        f"{sku_id} produced ERROR findings (Phase 6 catalog gate):\n"
+        + "\n".join(f.render_one_line() for f in errors)
+    )
+
+
+@pytest.mark.parametrize("sku_id", _all_kpu_sku_ids())
+def test_kpu_catalog_entry_constructs_mapper(sku_id):
+    """Every catalog entry must produce a working KPUMapper. Catches
+    cases where the YAML validates against the schema but a downstream
+    consumer (the mapper, the energy model, the validator framework's
+    ``ValidatorContext``) still chokes on it.
+    """
+    from graphs.hardware.mappers.accelerators.kpu import KPUMapper
+    from graphs.hardware.models.accelerators.kpu_yaml_loader import (
+        load_kpu_resource_model_from_yaml,
+    )
+
+    rm = load_kpu_resource_model_from_yaml(sku_id)
+    mapper = KPUMapper(rm)
+    assert mapper.num_tiles > 0
+    assert mapper.scratchpad_per_tile > 0
+
+
+def test_kpu_catalog_is_non_empty():
+    """Sanity check: at least one SKU YAML lives in the catalog. If
+    this fails the parametrized tests above run zero cases and
+    silently pass (pytest treats empty parametrize as a skip)."""
+    sku_ids = _all_kpu_sku_ids()
+    assert sku_ids, "embodied-schemas catalog has zero KPU SKUs"
+    # Sanity: the four Stillwater SKUs Phase 4b authored should be present.
+    for required in (
+        "stillwater_kpu_t64", "stillwater_kpu_t128",
+        "stillwater_kpu_t256", "stillwater_kpu_t768",
+    ):
+        assert required in sku_ids, (
+            f"{required!r} missing from catalog -- Phase 4b SKUs must "
+            f"remain in the catalog. Available: {sku_ids}"
+        )


### PR DESCRIPTION
## Summary

Phase 6 from the original plan: every KPU SKU YAML in the embodied-schemas catalog is gated by the validator registry on every push. A new SKU YAML auto-discovers; a regression in an existing SKU surfaces on its own commit.

## What lands

### Test (`tests/hardware/test_sku_catalog_validation.py`)
Pytest gate parametrizing over `load_kpus().keys()`:
- `test_kpu_catalog_entry_has_no_validator_errors[<sku_id>]` — every registered validator runs cleanly (no ERROR)
- `test_kpu_catalog_entry_constructs_mapper[<sku_id>]` — the loader-produced model can drive `KPUMapper`
- `test_kpu_catalog_is_non_empty` — the catalog isn't silently empty (would otherwise pass-by-vacuous-truth on the parametrized tests)

### CLI (`cli/validate_sku.py --all`)
Phase 6 catalog gate as a one-shot:
```
$ python cli/validate_sku.py --all
=== SKU catalog gate (4 SKUs, 9 validators) ===
  sku_id                           errors  warnings  info  status
  stillwater_kpu_t128                   0         6     1  ok
  stillwater_kpu_t256                   0         5     2  ok
  stillwater_kpu_t64                    0         7     2  ok
  stillwater_kpu_t768                   0         4     1  ok

Catalog summary: 0 error(s), 22 warning(s) across 4 SKU(s)
```

`--strict` flips warnings to failures (useful when you want a zero-warning catalog gate locally).

### CI workflow (`.github/workflows/ci.yml`)
New `SKU Catalog Gate` job runs both the CLI and the pytest version. Added to `ci-success`'s `needs` list so the build fails on any error from either path.

### Plan doc
`docs/designs/kpu-sku-and-process-node-plan.md` status table reflects actual reality — Phases 0–5 + Phase 4b all marked done with PR citations (graphs #144 + #145–#149, embodied-schemas #9/#10/#11). Only Phase 7 (PDK ingestion) and Stage 8 (deferred) remain open.

## Test plan

- [ ] `python -m pytest tests/hardware/test_sku_catalog_validation.py -v` → 9 pass
- [ ] `python cli/validate_sku.py --all` → exit 0, all SKUs `ok`
- [ ] CI: new `SKU Catalog Gate` check passes; `ci-success` waits on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI validator now supports `--all` mode to validate the complete SKU catalog at once, with optional filtering by category and severity levels.

* **Tests**
  * Added automated validation tests for the SKU catalog, including validator checks, resource mapper construction, and catalog completeness verification.

* **Chores**
  * Enhanced CI pipeline with new SKU catalog validation gate.

* **Documentation**
  * Updated design documentation to reflect recent cross-repository implementation progress.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/150)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->