### PR TITLE
feat(hardware): Phase 7 -- PDK ingestion CLI + PROCESS_NODE_DATA_DIR overlay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,8 @@ jobs:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
-          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
+          #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
+          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
           path: embodied-schemas
           fetch-depth: 1
 
@@ -131,7 +132,8 @@ jobs:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
-          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
+          #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
+          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
           path: embodied-schemas
           fetch-depth: 1
 
@@ -224,7 +226,8 @@ jobs:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
-          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
+          #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
+          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
           path: embodied-schemas
           fetch-depth: 1
 
@@ -314,7 +317,8 @@ jobs:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
-          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
+          #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
+          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
           path: embodied-schemas
           fetch-depth: 1
 
@@ -377,7 +381,8 @@ jobs:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
-          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
+          #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
+          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
           path: embodied-schemas
           fetch-depth: 1
 
@@ -428,7 +433,8 @@ jobs:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
-          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
+          #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
+          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -91,7 +91,8 @@ jobs:
           #   PR #9  (e8c6c89) ProcessNode + CoolingSolution + KPU SKU schemas
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
-          ref: bd61f3c0b53e4b1c8aa92a9139a7dbc8f0dc50cd
+          #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
+          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
           path: embodied-schemas
           fetch-depth: 1
 

--- a/cli/import_pdk.py
+++ b/cli/import_pdk.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+"""
+PDK Ingestion Tool (Phase 7)
+
+Converts a structured "PDK summary" file (YAML or JSON, shaped like a
+``ProcessNodeEntry``) into a validated catalog YAML, ready to drop
+into ``${PROCESS_NODE_DATA_DIR}/<id>.yaml`` or
+``embodied-schemas/data/process-nodes/<foundry>/<id>.yaml``.
+
+Vendor PDK file formats vary widely (TSMC, Samsung, GlobalFoundries
+each ship different LEF/LIB/CAD characterization data); this tool
+does NOT parse vendor-native PDK files directly. The expected
+workflow is:
+
+  1. Vendor-specific extraction script -> structured PDK summary
+     (YAML or JSON; shape matches ``ProcessNodeEntry``).
+  2. ``cli/import_pdk.py --input <summary>`` -> validated catalog
+     YAML with ``confidence: calibrated`` and a citation.
+  3. Drop the result into ``${PROCESS_NODE_DATA_DIR}`` (a private
+     directory outside this repo), and the
+     ``embodied_schemas.load_process_nodes()`` overlay path picks
+     it up automatically. CALIBRATED entries supersede the public
+     THEORETICAL estimates.
+
+What this tool guarantees:
+
+- The input is a valid ``ProcessNodeEntry`` (Pydantic validation).
+- The output's ``confidence`` is ``calibrated`` by default (PDK data
+  shouldn't masquerade as THEORETICAL after ingestion). Override
+  with ``--confidence`` if interpolating from PDK data.
+- The output's ``source`` is set to the PDK rev / citation passed
+  in via ``--source``, ensuring downstream provenance is traceable.
+
+Usage:
+
+    # Basic: validate + emit catalog YAML
+    python cli/import_pdk.py \\
+        --input pdk_summary.yaml \\
+        --source "TSMC N16FF+ PDK rev 2024Q1" \\
+        --output /private/process-nodes/tsmc_n16_calibrated.yaml
+
+    # Auto-place under PROCESS_NODE_DATA_DIR if set
+    export PROCESS_NODE_DATA_DIR=/private/process-nodes
+    python cli/import_pdk.py --input pdk_summary.yaml \\
+        --source "TSMC N16FF+ PDK rev 2024Q1"
+    # -> writes to ${PROCESS_NODE_DATA_DIR}/<id>.yaml
+
+    # JSON input also accepted (auto-detected from extension)
+    python cli/import_pdk.py --input pdk_summary.json \\
+        --source "..." --output node.yaml
+
+Exit codes:
+    0 = wrote the catalog YAML successfully
+    1 = validation failed (input doesn't conform to ProcessNodeEntry)
+    2 = I/O / argument error
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from embodied_schemas import ProcessNodeEntry
+from embodied_schemas.process_node import DataConfidence
+
+
+def _load_input(path: Path) -> dict[str, Any]:
+    """Load a YAML or JSON input file. Format is detected by extension."""
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return json.loads(text)
+    if suffix in (".yaml", ".yml"):
+        return yaml.safe_load(text)
+    raise ValueError(
+        f"Unrecognized input extension {suffix!r}. Expected .yaml, .yml, "
+        f"or .json."
+    )
+
+
+def _resolve_output_path(
+    args: argparse.Namespace, entry: ProcessNodeEntry
+) -> Path:
+    """Pick an output path.
+
+    Priority: explicit ``--output`` -> ``$PROCESS_NODE_DATA_DIR/<id>.yaml``
+    -> ``./<id>.yaml`` in cwd.
+    """
+    if args.output:
+        return Path(args.output)
+    overlay_dir = os.environ.get("PROCESS_NODE_DATA_DIR")
+    if overlay_dir:
+        d = Path(overlay_dir)
+        if not d.is_dir():
+            print(
+                f"warning: PROCESS_NODE_DATA_DIR={overlay_dir!r} is not "
+                f"an existing directory. Writing to cwd.",
+                file=sys.stderr,
+            )
+            return Path(f"{entry.id}.yaml")
+        return d / f"{entry.id}.yaml"
+    return Path(f"{entry.id}.yaml")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert a structured PDK summary (YAML/JSON shaped like "
+            "ProcessNodeEntry) into a validated catalog YAML with "
+            "confidence: calibrated."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to the PDK summary input (YAML or JSON).",
+    )
+    parser.add_argument(
+        "--source",
+        required=True,
+        help=(
+            "Source citation -- PDK rev, characterization run id, or "
+            "internal reference. Written to ``source:`` in the output "
+            "and propagated as ProcessNodeEntry provenance."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        help=(
+            "Output catalog YAML path. Defaults to "
+            "${PROCESS_NODE_DATA_DIR}/<id>.yaml when the env var is set, "
+            "else <id>.yaml in cwd."
+        ),
+    )
+    parser.add_argument(
+        "--confidence",
+        choices=[c.value for c in DataConfidence],
+        default=DataConfidence.CALIBRATED.value,
+        help=(
+            "Override the output's ``confidence:``. Default 'calibrated' "
+            "for PDK-derived data. Use 'interpolated' if the input is "
+            "extrapolated between PDK characterization points."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing output file.",
+    )
+    args = parser.parse_args()
+
+    in_path = Path(args.input)
+    if not in_path.exists():
+        print(f"error: input not found: {in_path}", file=sys.stderr)
+        return 2
+
+    try:
+        raw = _load_input(in_path)
+    except Exception as exc:
+        print(f"error: failed to parse input: {exc}", file=sys.stderr)
+        return 2
+
+    if not isinstance(raw, dict):
+        print(
+            f"error: input must be a mapping/object at the top level, "
+            f"got {type(raw).__name__}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Force confidence + source before validation so the resulting
+    # ProcessNodeEntry has the right provenance.
+    raw["confidence"] = args.confidence
+    raw["source"] = args.source
+
+    try:
+        entry = ProcessNodeEntry.model_validate(raw)
+    except Exception as exc:
+        print(
+            f"error: input does not validate as ProcessNodeEntry:\n{exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    out_path = _resolve_output_path(args, entry)
+    if out_path.exists() and not args.force:
+        print(
+            f"error: output already exists: {out_path}. Pass --force to "
+            f"overwrite.",
+            file=sys.stderr,
+        )
+        return 2
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = entry.model_dump(mode="json", exclude_none=True)
+    out_path.write_text(
+        yaml.safe_dump(payload, sort_keys=False, default_flow_style=False),
+        encoding="utf-8",
+    )
+
+    print(f"info: wrote {out_path}", file=sys.stderr)
+    print(f"  id:         {entry.id}")
+    print(f"  foundry:    {entry.foundry.value}")
+    print(f"  node:       {entry.node_name} ({entry.node_nm} nm)")
+    print(f"  topology:   {entry.transistor_topology.value}")
+    print(f"  libraries:  {len(entry.densities)}")
+    print(f"  confidence: {entry.confidence.value}")
+    print(f"  source:     {entry.source}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/designs/kpu-sku-and-process-node-plan.md
+++ b/docs/designs/kpu-sku-and-process-node-plan.md
@@ -299,8 +299,8 @@ All cross-repo work landed via `embodied-schemas` PRs #9, #10, #11 and
 | 4a | KPU resource-model loader (`load_kpu_resource_model_from_yaml`) | done (graphs #144) |
 | 4b | Collapse 4 hand-coded factories into thin wrappers around the loader | done (graphs #145–#149) |
 | 5 | Mapper wiring -- `physical_spec` populated on every `create_kpu_t*_mapper()` | done (graphs #144) |
-| 6 | CI gate: every SKU YAML in the catalog validated by the registry on every push | in progress |
-| 7 | PDK ingestion + `PROCESS_NODE_DATA_DIR` env override | not started |
+| 6 | CI gate: every SKU YAML in the catalog validated by the registry on every push | done (graphs #150) |
+| 7 | PDK ingestion + `PROCESS_NODE_DATA_DIR` env override | in progress |
 | 8 | **Stage 8 (later)**: DVFS feasibility, memory headroom, yield risk, **floorplanner + viz + geometric validators (KPU checkerboard pitch-match)** | deferred |
 
 ## File inventory

--- a/tests/hardware/test_pdk_ingestion.py
+++ b/tests/hardware/test_pdk_ingestion.py
@@ -1,0 +1,343 @@
+"""Phase 7 PDK ingestion tests.
+
+Covers:
+  * ``cli/import_pdk.py`` happy paths + error paths
+  * ``PROCESS_NODE_DATA_DIR`` overlay end-to-end through the graphs
+    consumers (validator framework, KPU YAML loader)
+
+The overlay path is implemented in ``embodied_schemas.load_process_nodes``
+(Phase 7 PR in embodied-schemas); these tests live in graphs because
+that's where the downstream consumers (sku_validators, kpu_yaml_loader)
+exercise it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from embodied_schemas import load_process_nodes
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IMPORT_PDK = REPO_ROOT / "cli" / "import_pdk.py"
+
+
+# ---------------------------------------------------------------------------
+# import_pdk.py -- happy paths
+# ---------------------------------------------------------------------------
+
+def _minimal_pdk_summary() -> dict:
+    """A valid ProcessNodeEntry payload for the import tool to validate."""
+    return {
+        "id": "test_node_pdk",
+        "foundry": "tsmc",
+        "node_name": "N16-test",
+        "node_nm": 16,
+        "transistor_topology": "finfet",
+        "nominal_vdd_v": 0.8,
+        "densities": {
+            "balanced_logic": {
+                "circuit_class": "balanced_logic",
+                "mtx_per_mm2": 30.5,
+                "library_name": "test-lib",
+                "confidence": "calibrated",
+                "source": "test PDK",
+            }
+        },
+        "last_updated": "2026-05-10",
+    }
+
+
+def _run_cli(args: list[str], cwd: Path = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(IMPORT_PDK), *args],
+        cwd=cwd or REPO_ROOT,
+        capture_output=True, text=True, env={**os.environ},
+    )
+
+
+def test_import_pdk_yaml_input_writes_calibrated_output(tmp_path: Path):
+    """Default flow: YAML in, YAML out, confidence forced to calibrated,
+    source set to the --source argument."""
+    summary = tmp_path / "summary.yaml"
+    summary.write_text(yaml.safe_dump(_minimal_pdk_summary()))
+    out = tmp_path / "out.yaml"
+
+    result = _run_cli([
+        "--input", str(summary),
+        "--source", "TSMC N16FF+ PDK rev 2024Q1",
+        "--output", str(out),
+    ])
+    assert result.returncode == 0, result.stderr
+    assert out.exists()
+    written = yaml.safe_load(out.read_text())
+    assert written["confidence"] == "calibrated"
+    assert written["source"] == "TSMC N16FF+ PDK rev 2024Q1"
+    assert written["id"] == "test_node_pdk"
+
+
+def test_import_pdk_json_input_supported(tmp_path: Path):
+    """JSON inputs auto-detected by extension."""
+    summary = tmp_path / "summary.json"
+    summary.write_text(json.dumps(_minimal_pdk_summary()))
+    out = tmp_path / "out.yaml"
+
+    result = _run_cli([
+        "--input", str(summary),
+        "--source", "JSON-source",
+        "--output", str(out),
+    ])
+    assert result.returncode == 0, result.stderr
+    assert yaml.safe_load(out.read_text())["source"] == "JSON-source"
+
+
+def test_import_pdk_overrides_confidence_to_calibrated(tmp_path: Path):
+    """Even if the input says confidence=theoretical, the tool stamps
+    calibrated by default. PDK-derived data shouldn't masquerade as
+    theoretical after ingestion."""
+    payload = _minimal_pdk_summary()
+    payload["confidence"] = "theoretical"  # try to slip through
+    summary = tmp_path / "summary.yaml"
+    summary.write_text(yaml.safe_dump(payload))
+    out = tmp_path / "out.yaml"
+
+    result = _run_cli([
+        "--input", str(summary),
+        "--source", "PDK rev X",
+        "--output", str(out),
+    ])
+    assert result.returncode == 0, result.stderr
+    assert yaml.safe_load(out.read_text())["confidence"] == "calibrated"
+
+
+def test_import_pdk_explicit_interpolated_confidence(tmp_path: Path):
+    """Allow explicit override to interpolated (PDK-extrapolated values)."""
+    summary = tmp_path / "summary.yaml"
+    summary.write_text(yaml.safe_dump(_minimal_pdk_summary()))
+    out = tmp_path / "out.yaml"
+
+    result = _run_cli([
+        "--input", str(summary),
+        "--source", "extrapolated between PDK points",
+        "--confidence", "interpolated",
+        "--output", str(out),
+    ])
+    assert result.returncode == 0, result.stderr
+    assert yaml.safe_load(out.read_text())["confidence"] == "interpolated"
+
+
+def test_import_pdk_uses_process_node_data_dir_when_no_output(tmp_path: Path):
+    """If --output is omitted and PROCESS_NODE_DATA_DIR is set, write to
+    that dir using <id>.yaml. Lets a CI / workflow drop PDK YAMLs into
+    the overlay path without computing output paths by hand."""
+    summary = tmp_path / "summary.yaml"
+    summary.write_text(yaml.safe_dump(_minimal_pdk_summary()))
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+
+    env = {**os.environ, "PROCESS_NODE_DATA_DIR": str(overlay)}
+    result = subprocess.run(
+        [sys.executable, str(IMPORT_PDK),
+         "--input", str(summary), "--source", "auto-place test"],
+        cwd=REPO_ROOT, capture_output=True, text=True, env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    expected = overlay / "test_node_pdk.yaml"
+    assert expected.exists()
+
+
+# ---------------------------------------------------------------------------
+# import_pdk.py -- error paths
+# ---------------------------------------------------------------------------
+
+def test_import_pdk_invalid_input_fails_validation(tmp_path: Path):
+    """Input missing required ProcessNodeEntry fields must fail with
+    exit=1 (validation error), not silently produce a half-baked YAML."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(yaml.safe_dump({"id": "no_required_fields"}))
+    out = tmp_path / "out.yaml"
+
+    result = _run_cli([
+        "--input", str(bad), "--source", "x", "--output", str(out),
+    ])
+    assert result.returncode == 1
+    assert "does not validate" in result.stderr
+    assert not out.exists()
+
+
+def test_import_pdk_existing_output_requires_force(tmp_path: Path):
+    """Refuse to overwrite without --force."""
+    summary = tmp_path / "summary.yaml"
+    summary.write_text(yaml.safe_dump(_minimal_pdk_summary()))
+    out = tmp_path / "out.yaml"
+    out.write_text("existing")
+
+    result = _run_cli([
+        "--input", str(summary), "--source", "x", "--output", str(out),
+    ])
+    assert result.returncode == 2
+    assert "already exists" in result.stderr
+    # Original content preserved
+    assert out.read_text() == "existing"
+
+    # With --force, overwrite is allowed
+    result2 = _run_cli([
+        "--input", str(summary), "--source", "x",
+        "--output", str(out), "--force",
+    ])
+    assert result2.returncode == 0
+    assert out.read_text() != "existing"
+
+
+def test_import_pdk_missing_input_fails_cleanly(tmp_path: Path):
+    """Non-existent input path returns exit=2 with a clear message."""
+    result = _run_cli([
+        "--input", str(tmp_path / "nope.yaml"),
+        "--source", "x",
+        "--output", str(tmp_path / "out.yaml"),
+    ])
+    assert result.returncode == 2
+    assert "input not found" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# PROCESS_NODE_DATA_DIR overlay end-to-end
+# ---------------------------------------------------------------------------
+
+def test_overlay_calibrated_supersedes_theoretical_baseline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A CALIBRATED overlay entry for an id that already exists in the
+    public catalog as THEORETICAL must win. The downstream graphs
+    consumers (validator framework, KPU YAML loader) then see the
+    sharper PDK-derived values.
+    """
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    cal_yaml = overlay / "tsmc_n16_calibrated.yaml"
+    cal_yaml.write_text(yaml.safe_dump({
+        "id": "tsmc_n16",
+        "foundry": "tsmc",
+        "node_name": "N16",
+        "node_nm": 16,
+        "transistor_topology": "finfet",
+        "nominal_vdd_v": 0.8,
+        "densities": {
+            "balanced_logic": {
+                "circuit_class": "balanced_logic",
+                "mtx_per_mm2": 32.0,  # PDK-measured (vs 28.5 baseline)
+                "confidence": "calibrated",
+                "source": "PDK rev 2024Q1",
+            }
+        },
+        "source": "PDK rev 2024Q1 (private overlay)",
+        "confidence": "calibrated",
+        "last_updated": "2026-05-10",
+    }))
+
+    monkeypatch.setenv("PROCESS_NODE_DATA_DIR", str(overlay))
+    nodes = load_process_nodes()
+    n16 = nodes["tsmc_n16"]
+    assert n16.confidence.value == "calibrated"
+    assert n16.densities[
+        next(c for c in n16.densities if c.value == "balanced_logic")
+    ].mtx_per_mm2 == 32.0
+
+
+def test_overlay_theoretical_does_not_downgrade_existing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A THEORETICAL overlay entry must NOT supersede an existing
+    THEORETICAL baseline (or higher). Same-rank collisions keep the
+    existing entry; lower-rank overlays are ignored.
+    """
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "stale.yaml").write_text(yaml.safe_dump({
+        "id": "tsmc_n16",
+        "foundry": "tsmc",
+        "node_name": "N16",
+        "node_nm": 16,
+        "transistor_topology": "finfet",
+        "nominal_vdd_v": 0.8,
+        "densities": {
+            "balanced_logic": {
+                "circuit_class": "balanced_logic",
+                "mtx_per_mm2": 999.0,  # nonsense override that must be ignored
+                "confidence": "theoretical",
+                "source": "stale overlay",
+            }
+        },
+        "source": "stale theoretical overlay",
+        "confidence": "theoretical",
+        "last_updated": "2026-05-10",
+    }))
+
+    monkeypatch.setenv("PROCESS_NODE_DATA_DIR", str(overlay))
+    nodes = load_process_nodes()
+    n16 = nodes["tsmc_n16"]
+    # Density is the public catalog's value, NOT the overlay's 999
+    bl = n16.densities[
+        next(c for c in n16.densities if c.value == "balanced_logic")
+    ]
+    assert bl.mtx_per_mm2 < 999.0
+    assert n16.source != "stale theoretical overlay"
+
+
+def test_overlay_adds_new_node_without_collision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A new id (not in public catalog) should be added to the result."""
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "future.yaml").write_text(yaml.safe_dump({
+        "id": "tsmc_n2_future",
+        "foundry": "tsmc",
+        "node_name": "N2-future",
+        "node_nm": 2,
+        "transistor_topology": "gaa",
+        "nominal_vdd_v": 0.6,
+        "densities": {
+            "balanced_logic": {
+                "circuit_class": "balanced_logic",
+                "mtx_per_mm2": 320.0,
+                "confidence": "calibrated",
+                "source": "private",
+            }
+        },
+        "source": "private",
+        "confidence": "calibrated",
+        "last_updated": "2026-05-10",
+    }))
+
+    monkeypatch.setenv("PROCESS_NODE_DATA_DIR", str(overlay))
+    nodes = load_process_nodes()
+    assert "tsmc_n2_future" in nodes
+    assert nodes["tsmc_n2_future"].confidence.value == "calibrated"
+
+
+def test_overlay_unset_uses_public_catalog_only(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Without the env var set, the loader behaves exactly as before."""
+    monkeypatch.delenv("PROCESS_NODE_DATA_DIR", raising=False)
+    nodes = load_process_nodes()
+    assert "tsmc_n16" in nodes
+    assert nodes["tsmc_n16"].confidence.value == "theoretical"
+
+
+def test_overlay_pointing_at_nonexistent_dir_does_not_crash(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A bogus PROCESS_NODE_DATA_DIR must warn and continue, not crash."""
+    monkeypatch.setenv("PROCESS_NODE_DATA_DIR", "/nonexistent/path/xyz")
+    # Should still return the public catalog
+    nodes = load_process_nodes()
+    assert "tsmc_n16" in nodes


### PR DESCRIPTION
## Summary

Phase 7 (graphs side; embodied-schemas#12 already merged for the loader env-overlay). Closes the original plan's last open item — PDK-derived ProcessNode entries can now live in a private overlay directory, with a CLI tool to validate + format them for the catalog.

## What lands

### `cli/import_pdk.py`

Converts a structured "PDK summary" file (YAML/JSON shaped like `ProcessNodeEntry`) into a validated catalog YAML with `confidence: calibrated`. Vendor PDK file formats vary widely; this tool intentionally doesn't parse vendor-native files. The expected workflow:

1. **Vendor-specific extraction** (out of scope) → structured PDK summary
2. **`cli/import_pdk.py --input <summary> --source "..."`** → validated catalog YAML
3. **Drop into `${PROCESS_NODE_DATA_DIR}`** → loader's overlay picks it up automatically

Guarantees:
- Pydantic validation against `ProcessNodeEntry` (refuses malformed input)
- Forces `confidence: calibrated` by default — PDK data shouldn't slip through as THEORETICAL
- Sets `source` from `--source` so provenance is traceable
- Auto-places into `$PROCESS_NODE_DATA_DIR` when `--output` is omitted

### CI re-pin

Both `ci.yml` and `v4-validation.yml` now pin to embodied-schemas#12 merge SHA `3509e68`.

### `tests/hardware/test_pdk_ingestion.py` (13 tests)

CLI:
- Happy paths: YAML in → catalog YAML out; JSON in → same; explicit `--confidence interpolated`; auto-placement via `$PROCESS_NODE_DATA_DIR`; confidence-override (input claims theoretical → output is calibrated)
- Error paths: invalid input → exit 1; existing output → exit 2 (overridable with `--force`); missing input → exit 2

Overlay end-to-end (via `embodied_schemas.load_process_nodes`):
- CALIBRATED overlay supersedes THEORETICAL baseline (sharper PDK data wins)
- THEORETICAL overlay does NOT downgrade the baseline (stale private overlays kept out)
- New id added to result without colliding with baseline
- Env var unset → baseline-only (default behavior preserved)
- Env var pointing at nonexistent dir → warns, no crash

## Why this is useful

Once a real PDK arrives:

```bash
# Run vendor-specific extractor (TSMC / Samsung / GF; out of scope)
./extract_n5_pdk.sh --rev 2024Q1 --out /private/n5_summary.yaml

# Validate + format for the catalog
python cli/import_pdk.py \
    --input /private/n5_summary.yaml \
    --source "TSMC N5 PDK rev 2024Q1" \
    --output /private/process-nodes/tsmc_n5.yaml

# Point downstream tools at the overlay
export PROCESS_NODE_DATA_DIR=/private/process-nodes

# Now every consumer (validators, generator, KPU YAML loader) sees the
# CALIBRATED PDK data instead of the public THEORETICAL estimate.
```

Zero downstream code changes — the validator framework, generator, and KPU YAML loader all already key on `(process_node_id, circuit_class)` lookups.

## Test plan

- [ ] `python -m pytest tests/hardware/test_pdk_ingestion.py -v` → 13 pass
- [ ] `python cli/import_pdk.py --help` → usage text shows
- [ ] Full CI green (Phase 6 catalog gate still passes after the re-pin)

## Phase status after this lands

| # | Phase | State |
|---|---|---|
| 0–6, 4b | All done | merged via #144 + #145–#149 + #150 |
| **7** | **PDK ingestion + overlay** | **CI green, awaiting merge** |
| 8 | Stage 8 (deferred) | DVFS feasibility, memory headroom, yield risk, floorplanner |

After this merges, all numbered phases of the original plan are complete. Stage 8 items are documented but explicitly deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)