### PR TITLE
feat(hardware): Stage 8 KPU floorplanner + GEOMETRY validators (#136)

### DIFF
--- a/cli/show_floorplan.py
+++ b/cli/show_floorplan.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python
+"""
+KPU Floorplan Visualization (Stage 8)
+
+Renders the heuristic 2D floorplan of a KPU SKU as ASCII art so the
+silicon decomposition can be eyeballed. Useful for:
+
+  * Spot-checking tile pitches across classes (the geometry validators
+    flag mismatches; this tool shows them).
+  * Sanity-checking PHY / IO / control placement vs the mesh size.
+  * Generating reproducible artifacts for design reviews.
+
+The ASCII renderer is deliberately simple (no matplotlib / SVG dep).
+The same Floorplan dataclass can be fed to a future SVG renderer
+without touching this module.
+
+Usage:
+    python cli/show_floorplan.py stillwater_kpu_t256
+    python cli/show_floorplan.py stillwater_kpu_t768 --width 100
+    python cli/show_floorplan.py stillwater_kpu_t64 --output floorplan.txt
+    python cli/show_floorplan.py stillwater_kpu_t128 --json --output fp.json
+
+Exit codes:
+    0 = rendered successfully
+    2 = SKU not found / argument error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from embodied_schemas import load_kpus, load_process_nodes
+from embodied_schemas.process_node import CircuitClass
+
+from graphs.hardware.silicon_floorplan import (
+    Floorplan,
+    FloorplanBlock,
+    derive_kpu_floorplan,
+)
+
+
+# ---------------------------------------------------------------------------
+# ASCII rendering
+# ---------------------------------------------------------------------------
+
+# Per-circuit-class glyphs. Choice rationale:
+#   - I/O ring: colon (rare in identifiers, pads well at edges)
+#   - SRAM (any flavor): hash (dense visual weight matches dense storage)
+#   - Logic (HP/BAL/LP/ULL): letter giving the speed tier at a glance
+#   - Analog: tilde (suggests sinusoid / continuous signal)
+#   - Mixed: question mark (ambiguous / heterogeneous)
+_GLYPH_BY_CLASS = {
+    CircuitClass.HP_LOGIC: "H",
+    CircuitClass.BALANCED_LOGIC: "B",
+    CircuitClass.LP_LOGIC: "L",
+    CircuitClass.ULL_LOGIC: "U",
+    CircuitClass.SRAM_HD: "#",
+    CircuitClass.SRAM_HC: "#",
+    CircuitClass.SRAM_HP: "#",
+    CircuitClass.ANALOG: "~",
+    CircuitClass.IO: ":",
+    CircuitClass.MIXED: "?",
+}
+
+
+def _glyph_for(block: FloorplanBlock) -> str:
+    return _GLYPH_BY_CLASS.get(block.circuit_class, "*")
+
+
+def render_ascii(fp: Floorplan, *, char_width: int = 80) -> str:
+    """Render the floorplan as an ASCII grid.
+
+    The grid is ``char_width`` characters wide. Height scales to keep
+    the die's true aspect ratio (one character cell ~= 0.5 mm wide *
+    1.0 mm tall, since terminal characters are ~2x tall).
+    """
+    if fp.die_width_mm <= 0 or fp.die_height_mm <= 0:
+        return "(empty floorplan)"
+
+    # Char cell aspect: most terminal fonts are about 2:1 tall:wide. So
+    # vertical scaling per row covers 2x the horizontal scaling per column.
+    mm_per_col = fp.die_width_mm / char_width
+    mm_per_row = mm_per_col * 2.0
+    rows = max(1, int(fp.die_height_mm / mm_per_row + 0.5))
+
+    # Render top-down: row 0 = top of the die. Floorplan uses
+    # bottom-left origin; flip when projecting to grid coordinates.
+    grid = [[" "] * char_width for _ in range(rows)]
+    for block in fp.blocks:
+        col_lo = max(0, int(block.x_mm / mm_per_col))
+        col_hi = min(char_width, int((block.x_mm + block.width_mm) / mm_per_col + 0.5))
+        # Flip y: top of grid (row 0) corresponds to top of die (high y)
+        y_top = block.y_mm + block.height_mm
+        row_lo = max(0, int((fp.die_height_mm - y_top) / mm_per_row))
+        row_hi = min(rows, int((fp.die_height_mm - block.y_mm) / mm_per_row + 0.5))
+        glyph = _glyph_for(block)
+        for r in range(row_lo, row_hi):
+            for c in range(col_lo, col_hi):
+                grid[r][c] = glyph
+    return "\n".join("".join(row) for row in grid)
+
+
+def _glyph_legend(fp: Floorplan) -> str:
+    """One-line legend mapping glyphs back to circuit classes used in the floorplan."""
+    used = {block.circuit_class for block in fp.blocks}
+    parts = []
+    for cc, glyph in _GLYPH_BY_CLASS.items():
+        if cc in used:
+            parts.append(f"{glyph}={cc.value}")
+    return "  Legend: " + "  ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Text summary (printed alongside the ASCII grid)
+# ---------------------------------------------------------------------------
+
+def _render_summary(fp: Floorplan) -> str:
+    lines = [
+        f"Floorplan: {fp.sku_name} ({fp.sku_id})",
+        f"  die:               {fp.die_width_mm:.2f} x {fp.die_height_mm:.2f} mm "
+        f"= {fp.die_area_mm2:.1f} mm^2",
+        f"  unified pitch:     {fp.unified_pitch_mm:.3f} mm",
+        f"  whitespace:        {fp.whitespace_fraction()*100:.1f}% "
+        f"({fp.whitespace_mm2():.1f} mm^2)",
+        f"  blocks:            {len(fp.blocks)} "
+        f"(compute tiles: {len(fp.compute_tiles())})",
+        "",
+        "Per-tile-class pitches:",
+    ]
+    if fp.tile_pitches:
+        max_pitch = max(tp.pitch_mm for tp in fp.tile_pitches.values())
+        for tile_class, tp in sorted(fp.tile_pitches.items()):
+            ratio = max_pitch / tp.pitch_mm if tp.pitch_mm > 0 else float("inf")
+            mark = " <- max" if abs(tp.pitch_mm - max_pitch) < 1e-6 else (
+                f"  ({ratio:.2f}x smaller)" if ratio > 1.05 else ""
+            )
+            lines.append(
+                f"  {tile_class:18s}  PE={tp.pe_area_mm2:.4f}  "
+                f"SRAM={tp.sram_area_mm2:.4f}  total={tp.total_area_mm2:.4f} mm^2  "
+                f"pitch={tp.pitch_mm:.3f} mm{mark}"
+            )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# JSON serialization (machine-readable output)
+# ---------------------------------------------------------------------------
+
+def _floorplan_to_dict(fp: Floorplan) -> dict:
+    return {
+        "sku_id": fp.sku_id,
+        "sku_name": fp.sku_name,
+        "die_width_mm": fp.die_width_mm,
+        "die_height_mm": fp.die_height_mm,
+        "die_area_mm2": fp.die_area_mm2,
+        "unified_pitch_mm": fp.unified_pitch_mm,
+        "whitespace_mm2": fp.whitespace_mm2(),
+        "whitespace_fraction": fp.whitespace_fraction(),
+        "tile_pitches": {
+            tc: {
+                "pe_area_mm2": tp.pe_area_mm2,
+                "sram_area_mm2": tp.sram_area_mm2,
+                "total_area_mm2": tp.total_area_mm2,
+                "pitch_mm": tp.pitch_mm,
+            } for tc, tp in fp.tile_pitches.items()
+        },
+        "blocks": [
+            {
+                "name": b.name,
+                "circuit_class": b.circuit_class.value,
+                "x_mm": b.x_mm,
+                "y_mm": b.y_mm,
+                "width_mm": b.width_mm,
+                "height_mm": b.height_mm,
+                "is_compute_tile": b.is_compute_tile,
+                "tile_class": b.tile_class,
+                "notes": b.notes,
+            } for b in fp.blocks
+        ],
+        "notes": fp.notes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render a KPU SKU's heuristic floorplan as ASCII art (or JSON)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "sku_id",
+        nargs="?",
+        help="KPU SKU id (e.g., stillwater_kpu_t256). Omit with --list to list ids.",
+    )
+    parser.add_argument(
+        "--list", action="store_true",
+        help="List available KPU SKU ids and exit.",
+    )
+    parser.add_argument(
+        "--width", type=int, default=80,
+        help="ASCII grid width in characters (default 80).",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit JSON (machine-readable) instead of ASCII art.",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        help="Write to a file (extension .json/.txt selects format if --json not set).",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Print extra diagnostic information.",
+    )
+    args = parser.parse_args()
+
+    kpus = load_kpus()
+    if args.list:
+        for kid in sorted(kpus):
+            print(kid)
+        return 0
+    if not args.sku_id:
+        parser.error("sku_id is required (or pass --list)")
+        return 2
+    if args.sku_id not in kpus:
+        print(f"error: unknown SKU id {args.sku_id!r}", file=sys.stderr)
+        print(f"hint: try one of {sorted(kpus)}", file=sys.stderr)
+        return 2
+
+    sku = kpus[args.sku_id]
+    nodes = load_process_nodes()
+    if sku.process_node_id not in nodes:
+        print(
+            f"error: SKU references unknown process_node_id "
+            f"{sku.process_node_id!r}",
+            file=sys.stderr,
+        )
+        return 2
+
+    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
+
+    # Choose output format
+    use_json = args.json or (
+        args.output and args.output.lower().endswith(".json")
+    )
+
+    if use_json:
+        payload = json.dumps(_floorplan_to_dict(fp), indent=2)
+        if args.output:
+            Path(args.output).write_text(payload, encoding="utf-8")
+            print(f"info: wrote {args.output}", file=sys.stderr)
+        else:
+            print(payload)
+    else:
+        text = _render_summary(fp) + "\n\n" + render_ascii(
+            fp, char_width=args.width
+        ) + "\n" + _glyph_legend(fp)
+        if args.output:
+            Path(args.output).write_text(text, encoding="utf-8")
+            print(f"info: wrote {args.output}", file=sys.stderr)
+        else:
+            print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cli/show_floorplan.py
+++ b/cli/show_floorplan.py
@@ -2,22 +2,32 @@
 """
 KPU Floorplan Visualization (Stage 8)
 
-Renders the heuristic 2D floorplan of a KPU SKU as ASCII art so the
-silicon decomposition can be eyeballed. Useful for:
+Renders a KPU SKU's heuristic 2D floorplan as ASCII art.
 
-  * Spot-checking tile pitches across classes (the geometry validators
-    flag mismatches; this tool shows them).
-  * Sanity-checking PHY / IO / control placement vs the mesh size.
-  * Generating reproducible artifacts for design reviews.
+Two views are available:
 
-The ASCII renderer is deliberately simple (no matplotlib / SVG dep).
-The same Floorplan dataclass can be fed to a future SVG renderer
-without touching this module.
+  --view architectural (default)
+      Bins blocks by *role*: COMPUTE tile (PE+L1+L2), MEMORY tile (L3),
+      MEMORY_CONTROLLER (DRAM PHY), IO_PAD, CONTROL. Renders the
+      checkerboard layout that pairs each compute tile with a memory
+      tile. Includes a what-if table showing what the die would look
+      like if every compute tile were one class (cost of mixing
+      Matrix/BF16/INT8).
+
+  --view circuit
+      Bins blocks by *silicon library*: HP_LOGIC, BALANCED_LOGIC,
+      SRAM_HD, ANALOG, IO. Useful for seeing where dense storage vs
+      fast logic vs analog macros end up on the die. This is the
+      original Stage 8a renderer.
+
+Future work: SVG / HTML renderer that overlays the NoC topology
+(2D mesh / ring / CLOS) on top of the placed blocks.
 
 Usage:
     python cli/show_floorplan.py stillwater_kpu_t256
     python cli/show_floorplan.py stillwater_kpu_t768 --width 100
-    python cli/show_floorplan.py stillwater_kpu_t64 --output floorplan.txt
+    python cli/show_floorplan.py stillwater_kpu_t256 --view circuit
+    python cli/show_floorplan.py stillwater_kpu_t64 --output fp.txt
     python cli/show_floorplan.py stillwater_kpu_t128 --json --output fp.json
 
 Exit codes:
@@ -31,29 +41,46 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Optional
 
 from embodied_schemas import load_kpus, load_process_nodes
 from embodied_schemas.process_node import CircuitClass
 
 from graphs.hardware.silicon_floorplan import (
+    ArchitecturalFloorplan,
+    ArchTile,
     Floorplan,
     FloorplanBlock,
+    TileRole,
+    derive_kpu_architectural_floorplan,
     derive_kpu_floorplan,
 )
 
 
 # ---------------------------------------------------------------------------
-# ASCII rendering
+# Architectural view: glyphs by tile role
 # ---------------------------------------------------------------------------
 
-# Per-circuit-class glyphs. Choice rationale:
-#   - I/O ring: colon (rare in identifiers, pads well at edges)
-#   - SRAM (any flavor): hash (dense visual weight matches dense storage)
-#   - Logic (HP/BAL/LP/ULL): letter giving the speed tier at a glance
-#   - Analog: tilde (suggests sinusoid / continuous signal)
-#   - Mixed: question mark (ambiguous / heterogeneous)
-_GLYPH_BY_CLASS = {
+# One glyph per architectural role. The whole point of this view is to
+# show the checkerboard structure, so compute / memory get distinct
+# easily-distinguishable glyphs.
+_ARCH_GLYPH_BY_ROLE = {
+    TileRole.COMPUTE: "C",
+    TileRole.MEMORY: "M",
+    TileRole.MEMORY_CONTROLLER: "D",  # D for DRAM controller / PHY
+    TileRole.IO_PAD: ":",
+    TileRole.CONTROL: "*",
+}
+
+
+def _arch_glyph_for(block: ArchTile) -> str:
+    return _ARCH_GLYPH_BY_ROLE.get(block.role, "?")
+
+
+# ---------------------------------------------------------------------------
+# Circuit-class view: glyphs by silicon library (Stage 8a)
+# ---------------------------------------------------------------------------
+
+_CIRCUIT_GLYPH_BY_CLASS = {
     CircuitClass.HP_LOGIC: "H",
     CircuitClass.BALANCED_LOGIC: "B",
     CircuitClass.LP_LOGIC: "L",
@@ -67,60 +94,192 @@ _GLYPH_BY_CLASS = {
 }
 
 
-def _glyph_for(block: FloorplanBlock) -> str:
-    return _GLYPH_BY_CLASS.get(block.circuit_class, "*")
+def _circuit_glyph_for(block: FloorplanBlock) -> str:
+    return _CIRCUIT_GLYPH_BY_CLASS.get(block.circuit_class, "*")
 
 
-def render_ascii(fp: Floorplan, *, char_width: int = 80) -> str:
-    """Render the floorplan as an ASCII grid.
+# ---------------------------------------------------------------------------
+# Generic ASCII grid rasterizer
+# ---------------------------------------------------------------------------
 
-    The grid is ``char_width`` characters wide. Height scales to keep
-    the die's true aspect ratio (one character cell ~= 0.5 mm wide *
-    1.0 mm tall, since terminal characters are ~2x tall).
+def _render_blocks_to_ascii(
+    blocks_with_glyphs,  # list[(rect, glyph)] where rect = (x, y, w, h)
+    die_width_mm: float,
+    die_height_mm: float,
+    *,
+    char_width: int = 80,
+) -> str:
+    """Rasterize a list of (rectangle, glyph) pairs into an ASCII grid.
+
+    Terminal characters are roughly 2:1 tall:wide; the height scales
+    accordingly so the printed die preserves its true aspect ratio.
     """
-    if fp.die_width_mm <= 0 or fp.die_height_mm <= 0:
+    if die_width_mm <= 0 or die_height_mm <= 0:
         return "(empty floorplan)"
-
-    # Char cell aspect: most terminal fonts are about 2:1 tall:wide. So
-    # vertical scaling per row covers 2x the horizontal scaling per column.
-    mm_per_col = fp.die_width_mm / char_width
+    mm_per_col = die_width_mm / char_width
     mm_per_row = mm_per_col * 2.0
-    rows = max(1, int(fp.die_height_mm / mm_per_row + 0.5))
-
-    # Render top-down: row 0 = top of the die. Floorplan uses
-    # bottom-left origin; flip when projecting to grid coordinates.
+    rows = max(1, int(die_height_mm / mm_per_row + 0.5))
     grid = [[" "] * char_width for _ in range(rows)]
-    for block in fp.blocks:
-        col_lo = max(0, int(block.x_mm / mm_per_col))
-        col_hi = min(char_width, int((block.x_mm + block.width_mm) / mm_per_col + 0.5))
-        # Flip y: top of grid (row 0) corresponds to top of die (high y)
-        y_top = block.y_mm + block.height_mm
-        row_lo = max(0, int((fp.die_height_mm - y_top) / mm_per_row))
-        row_hi = min(rows, int((fp.die_height_mm - block.y_mm) / mm_per_row + 0.5))
-        glyph = _glyph_for(block)
+    for (x, y, w, h), glyph in blocks_with_glyphs:
+        col_lo = max(0, int(x / mm_per_col))
+        col_hi = min(char_width, int((x + w) / mm_per_col + 0.5))
+        # Flip y: grid row 0 = top of die (high y)
+        y_top = y + h
+        row_lo = max(0, int((die_height_mm - y_top) / mm_per_row))
+        row_hi = min(rows, int((die_height_mm - y) / mm_per_row + 0.5))
         for r in range(row_lo, row_hi):
             for c in range(col_lo, col_hi):
                 grid[r][c] = glyph
     return "\n".join("".join(row) for row in grid)
 
 
-def _glyph_legend(fp: Floorplan) -> str:
-    """One-line legend mapping glyphs back to circuit classes used in the floorplan."""
-    used = {block.circuit_class for block in fp.blocks}
+# ---------------------------------------------------------------------------
+# Architectural view: text summary + ASCII
+# ---------------------------------------------------------------------------
+
+def _render_architectural_summary(fp: ArchitecturalFloorplan) -> str:
+    lines = [
+        f"Floorplan (architectural): {fp.sku_name} ({fp.sku_id})",
+        f"  die:               {fp.die_width_mm:.2f} x {fp.die_height_mm:.2f} mm "
+        f"= {fp.die_area_mm2:.1f} mm^2",
+        f"  unified pitch:     {fp.unified_pitch_mm:.3f} mm",
+        f"  C/M pitch ratio:   {fp.compute_memory_pitch_ratio:.2f}x"
+        f"  (compute vs memory tile pitch)",
+        f"  total whitespace:  {fp.whitespace_fraction()*100:.1f}% "
+        f"({fp.whitespace_mm2():.1f} mm^2)",
+        f"  blocks:            compute={len(fp.compute_tiles())}, "
+        f"memory={len(fp.memory_tiles())}, "
+        f"controllers={fp.num_memory_controllers}",
+        "",
+        "Compute tile classes (PE + L2 per tile):",
+    ]
+    if fp.compute_summaries:
+        max_cp = max(s.pitch_mm for s in fp.compute_summaries.values())
+        for tc, s in sorted(fp.compute_summaries.items()):
+            mark = " <- max" if abs(s.pitch_mm - max_cp) < 1e-6 else ""
+            lines.append(
+                f"  {tc:14s}  N={s.num_tiles:4d}  "
+                f"PE={s.pe_area_mm2:.4f}  L2={s.l2_area_mm2:.4f}  "
+                f"total={s.total_area_mm2:.4f} mm^2  "
+                f"pitch={s.pitch_mm:.3f} mm  "
+                f"whitespace={s.class_whitespace_mm2:.1f} mm^2{mark}"
+            )
+    lines.append("")
+    lines.append("Memory tiles (L3 per tile):")
+    s = fp.memory_summary
+    lines.append(
+        f"  {'memory':14s}  N={s.num_tiles:4d}  "
+        f"L3={s.l3_area_mm2:.4f} mm^2  "
+        f"pitch={s.pitch_mm:.3f} mm  "
+        f"whitespace={s.class_whitespace_mm2:.1f} mm^2"
+    )
+    lines.append("")
+    lines.append(
+        "What-if -- die area if every compute tile were one class:"
+    )
+    if fp.what_if:
+        # Anchor: the actual mixed-class die area
+        anchor = fp.die_area_mm2
+        for wi in sorted(fp.what_if, key=lambda w: w.die_area_mm2):
+            delta = wi.die_area_mm2 - anchor
+            pct = (delta / anchor * 100.0) if anchor > 0 else 0.0
+            sign = "+" if delta >= 0 else "-"
+            lines.append(
+                f"  if all {wi.tile_class:14s}  pitch={wi.unified_pitch_mm:.3f}  "
+                f"die={wi.die_area_mm2:.1f} mm^2  "
+                f"({sign}{abs(pct):.0f}% vs actual)  "
+                f"whitespace={wi.whitespace_fraction*100:.1f}%"
+            )
+    return "\n".join(lines)
+
+
+def _arch_glyph_legend(fp: ArchitecturalFloorplan) -> str:
+    used = {b.role for b in fp.blocks}
     parts = []
-    for cc, glyph in _GLYPH_BY_CLASS.items():
-        if cc in used:
-            parts.append(f"{glyph}={cc.value}")
+    for role, glyph in _ARCH_GLYPH_BY_ROLE.items():
+        if role in used:
+            parts.append(f"{glyph}={role.value}")
     return "  Legend: " + "  ".join(parts)
 
 
+def render_architectural_ascii(
+    fp: ArchitecturalFloorplan, *, char_width: int = 80
+) -> str:
+    pairs = [
+        ((b.x_mm, b.y_mm, b.width_mm, b.height_mm), _arch_glyph_for(b))
+        for b in fp.blocks
+    ]
+    return _render_blocks_to_ascii(
+        pairs, fp.die_width_mm, fp.die_height_mm, char_width=char_width
+    )
+
+
+def _arch_to_dict(fp: ArchitecturalFloorplan) -> dict:
+    return {
+        "view": "architectural",
+        "sku_id": fp.sku_id,
+        "sku_name": fp.sku_name,
+        "die_width_mm": fp.die_width_mm,
+        "die_height_mm": fp.die_height_mm,
+        "die_area_mm2": fp.die_area_mm2,
+        "unified_pitch_mm": fp.unified_pitch_mm,
+        "compute_memory_pitch_ratio": fp.compute_memory_pitch_ratio,
+        "whitespace_mm2": fp.whitespace_mm2(),
+        "whitespace_fraction": fp.whitespace_fraction(),
+        "num_memory_controllers": fp.num_memory_controllers,
+        "compute_summaries": {
+            tc: {
+                "num_tiles": s.num_tiles,
+                "pe_area_mm2": s.pe_area_mm2,
+                "l2_area_mm2": s.l2_area_mm2,
+                "total_area_mm2": s.total_area_mm2,
+                "pitch_mm": s.pitch_mm,
+                "whitespace_per_tile_mm2": s.whitespace_per_tile_mm2,
+                "class_whitespace_mm2": s.class_whitespace_mm2,
+            } for tc, s in fp.compute_summaries.items()
+        },
+        "memory_summary": {
+            "num_tiles": fp.memory_summary.num_tiles,
+            "l3_area_mm2": fp.memory_summary.l3_area_mm2,
+            "pitch_mm": fp.memory_summary.pitch_mm,
+            "whitespace_per_tile_mm2":
+                fp.memory_summary.whitespace_per_tile_mm2,
+            "class_whitespace_mm2": fp.memory_summary.class_whitespace_mm2,
+        },
+        "what_if": [
+            {
+                "tile_class": wi.tile_class,
+                "unified_pitch_mm": wi.unified_pitch_mm,
+                "mesh_area_mm2": wi.mesh_area_mm2,
+                "die_area_mm2": wi.die_area_mm2,
+                "whitespace_mm2": wi.whitespace_mm2,
+                "whitespace_fraction": wi.whitespace_fraction,
+            } for wi in fp.what_if
+        ],
+        "blocks": [
+            {
+                "name": b.name,
+                "role": b.role.value,
+                "x_mm": b.x_mm, "y_mm": b.y_mm,
+                "width_mm": b.width_mm, "height_mm": b.height_mm,
+                "tile_class": b.tile_class,
+                "pe_area_mm2": b.pe_area_mm2,
+                "l2_area_mm2": b.l2_area_mm2,
+                "l3_area_mm2": b.l3_area_mm2,
+                "notes": b.notes,
+            } for b in fp.blocks
+        ],
+        "notes": fp.notes,
+    }
+
+
 # ---------------------------------------------------------------------------
-# Text summary (printed alongside the ASCII grid)
+# Circuit-class view: text summary + ASCII (Stage 8a; kept as --view circuit)
 # ---------------------------------------------------------------------------
 
-def _render_summary(fp: Floorplan) -> str:
+def _render_circuit_summary(fp: Floorplan) -> str:
     lines = [
-        f"Floorplan: {fp.sku_name} ({fp.sku_id})",
+        f"Floorplan (circuit-class): {fp.sku_name} ({fp.sku_id})",
         f"  die:               {fp.die_width_mm:.2f} x {fp.die_height_mm:.2f} mm "
         f"= {fp.die_area_mm2:.1f} mm^2",
         f"  unified pitch:     {fp.unified_pitch_mm:.3f} mm",
@@ -146,12 +305,28 @@ def _render_summary(fp: Floorplan) -> str:
     return "\n".join(lines)
 
 
-# ---------------------------------------------------------------------------
-# JSON serialization (machine-readable output)
-# ---------------------------------------------------------------------------
+def render_circuit_ascii(fp: Floorplan, *, char_width: int = 80) -> str:
+    pairs = [
+        ((b.x_mm, b.y_mm, b.width_mm, b.height_mm), _circuit_glyph_for(b))
+        for b in fp.blocks
+    ]
+    return _render_blocks_to_ascii(
+        pairs, fp.die_width_mm, fp.die_height_mm, char_width=char_width
+    )
 
-def _floorplan_to_dict(fp: Floorplan) -> dict:
+
+def _circuit_glyph_legend(fp: Floorplan) -> str:
+    used = {b.circuit_class for b in fp.blocks}
+    parts = []
+    for cc, glyph in _CIRCUIT_GLYPH_BY_CLASS.items():
+        if cc in used:
+            parts.append(f"{glyph}={cc.value}")
+    return "  Legend: " + "  ".join(parts)
+
+
+def _circuit_to_dict(fp: Floorplan) -> dict:
     return {
+        "view": "circuit",
         "sku_id": fp.sku_id,
         "sku_name": fp.sku_name,
         "die_width_mm": fp.die_width_mm,
@@ -172,10 +347,8 @@ def _floorplan_to_dict(fp: Floorplan) -> dict:
             {
                 "name": b.name,
                 "circuit_class": b.circuit_class.value,
-                "x_mm": b.x_mm,
-                "y_mm": b.y_mm,
-                "width_mm": b.width_mm,
-                "height_mm": b.height_mm,
+                "x_mm": b.x_mm, "y_mm": b.y_mm,
+                "width_mm": b.width_mm, "height_mm": b.height_mm,
                 "is_compute_tile": b.is_compute_tile,
                 "tile_class": b.tile_class,
                 "notes": b.notes,
@@ -199,11 +372,24 @@ def main() -> int:
     parser.add_argument(
         "sku_id",
         nargs="?",
-        help="KPU SKU id (e.g., stillwater_kpu_t256). Omit with --list to list ids.",
+        help=(
+            "KPU SKU id (e.g., stillwater_kpu_t256). Omit with --list to "
+            "list available ids."
+        ),
     )
     parser.add_argument(
         "--list", action="store_true",
         help="List available KPU SKU ids and exit.",
+    )
+    parser.add_argument(
+        "--view", choices=["architectural", "circuit"],
+        default="architectural",
+        help=(
+            "Floorplan view. 'architectural' (default) groups blocks by "
+            "role (compute/memory/controller/io/control) and shows the "
+            "checkerboard layout + what-if die estimates. 'circuit' "
+            "groups by silicon library (HP_LOGIC/BAL/SRAM/ANALOG/IO)."
+        ),
     )
     parser.add_argument(
         "--width", type=int, default=80,
@@ -215,7 +401,10 @@ def main() -> int:
     )
     parser.add_argument(
         "--output", "-o",
-        help="Write to a file (extension .json/.txt selects format if --json not set).",
+        help=(
+            "Write to a file (extension .json selects JSON unless --json "
+            "is also passed)."
+        ),
     )
     parser.add_argument(
         "--verbose", "-v", action="store_true",
@@ -245,30 +434,40 @@ def main() -> int:
             file=sys.stderr,
         )
         return 2
+    node = nodes[sku.process_node_id]
 
-    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
-
-    # Choose output format
     use_json = args.json or (
         args.output and args.output.lower().endswith(".json")
     )
 
-    if use_json:
-        payload = json.dumps(_floorplan_to_dict(fp), indent=2)
-        if args.output:
-            Path(args.output).write_text(payload, encoding="utf-8")
-            print(f"info: wrote {args.output}", file=sys.stderr)
+    if args.view == "architectural":
+        fp_arch = derive_kpu_architectural_floorplan(sku, node)
+        if use_json:
+            payload = json.dumps(_arch_to_dict(fp_arch), indent=2)
         else:
-            print(payload)
+            payload = (
+                _render_architectural_summary(fp_arch)
+                + "\n\n"
+                + render_architectural_ascii(fp_arch, char_width=args.width)
+                + "\n" + _arch_glyph_legend(fp_arch)
+            )
+    else:  # circuit
+        fp_circ = derive_kpu_floorplan(sku, node)
+        if use_json:
+            payload = json.dumps(_circuit_to_dict(fp_circ), indent=2)
+        else:
+            payload = (
+                _render_circuit_summary(fp_circ)
+                + "\n\n"
+                + render_circuit_ascii(fp_circ, char_width=args.width)
+                + "\n" + _circuit_glyph_legend(fp_circ)
+            )
+
+    if args.output:
+        Path(args.output).write_text(payload, encoding="utf-8")
+        print(f"info: wrote {args.output}", file=sys.stderr)
     else:
-        text = _render_summary(fp) + "\n\n" + render_ascii(
-            fp, char_width=args.width
-        ) + "\n" + _glyph_legend(fp)
-        if args.output:
-            Path(args.output).write_text(text, encoding="utf-8")
-            print(f"info: wrote {args.output}", file=sys.stderr)
-        else:
-            print(text)
+        print(payload)
     return 0
 
 

--- a/cli/show_floorplan.py
+++ b/cli/show_floorplan.py
@@ -38,9 +38,13 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import csv
+import io
 import json
+import os
 import sys
 from pathlib import Path
+from typing import Optional
 
 from embodied_schemas import load_kpus, load_process_nodes
 from embodied_schemas.process_node import CircuitClass
@@ -55,6 +59,42 @@ from graphs.hardware.silicon_floorplan import (
     derive_kpu_architectural_floorplan,
     derive_kpu_floorplan,
 )
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers
+# ---------------------------------------------------------------------------
+
+def _positive_int(value: str) -> int:
+    """argparse type-checker: reject zero/negative widths early.
+
+    ``_render_blocks_to_ascii`` divides by ``char_width``; a non-positive
+    value crashes deep in the rasterizer with no actionable message.
+    """
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(
+            f"--width must be a positive integer (got {parsed})"
+        )
+    return parsed
+
+
+def _detect_format(output: Optional[str], json_flag: bool) -> str:
+    """Map ``--output`` extension to format. Mirrors validate_sku.py.
+
+    Per the project's CLI rules, every ``--output`` accepts JSON, CSV,
+    MD, and text via extension auto-detection. ``--json`` overrides
+    extension when set.
+    """
+    if json_flag:
+        return "json"
+    if not output:
+        return "text"
+    ext = os.path.splitext(output)[1].lower().lstrip(".")
+    return {
+        "json": "json", "csv": "csv", "md": "md",
+        "markdown": "md", "txt": "text",
+    }.get(ext, "text")
 
 
 # ---------------------------------------------------------------------------
@@ -454,6 +494,140 @@ def _circuit_to_dict(fp: Floorplan) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# CSV / Markdown renderers (architectural + circuit views)
+# ---------------------------------------------------------------------------
+
+def _arch_to_csv(fp: ArchitecturalFloorplan) -> str:
+    """One row per placed block + per memory channel. Header columns:
+    sku_id, kind, role/edge, name, tile_class, x_mm, y_mm, width_mm,
+    height_mm, area_mm2.
+    """
+    buf = io.StringIO()
+    writer = csv.DictWriter(
+        buf,
+        fieldnames=[
+            "sku_id", "kind", "role_or_edge", "name", "tile_class",
+            "x_mm", "y_mm", "width_mm", "height_mm", "area_mm2",
+        ],
+    )
+    writer.writeheader()
+    for b in fp.blocks:
+        writer.writerow({
+            "sku_id": fp.sku_id, "kind": "block",
+            "role_or_edge": b.role.value, "name": b.name,
+            "tile_class": b.tile_class or "",
+            "x_mm": f"{b.x_mm:.4f}", "y_mm": f"{b.y_mm:.4f}",
+            "width_mm": f"{b.width_mm:.4f}", "height_mm": f"{b.height_mm:.4f}",
+            "area_mm2": f"{b.area_mm2:.4f}",
+        })
+    for ch in fp.memory_channels:
+        writer.writerow({
+            "sku_id": fp.sku_id, "kind": "dram_channel",
+            "role_or_edge": ch.edge,
+            "name": f"channel_{ch.channel_id}",
+            "tile_class": "",
+            "x_mm": f"{ch.x_mm:.4f}", "y_mm": f"{ch.y_mm:.4f}",
+            "width_mm": f"{ch.width_mm:.4f}", "height_mm": f"{ch.height_mm:.4f}",
+            "area_mm2": f"{ch.width_mm * ch.height_mm:.4f}",
+        })
+    return buf.getvalue()
+
+
+def _arch_to_md(fp: ArchitecturalFloorplan) -> str:
+    lines = [
+        f"# Architectural floorplan: `{fp.sku_id}`", "",
+        f"- **die**: {fp.die_width_mm:.2f} x {fp.die_height_mm:.2f} mm "
+        f"= {fp.die_area_mm2:.1f} mm^2",
+        f"- **unified pitch**: {fp.unified_pitch_mm:.3f} mm",
+        f"- **C/M pitch ratio**: {fp.compute_memory_pitch_ratio:.2f}x",
+        f"- **whitespace**: {fp.whitespace_fraction()*100:.1f}%",
+        f"- **memory subsystem**: {fp.memory_type}, "
+        f"{fp.num_memory_controllers} channels @ "
+        f"{fp.per_channel_width_bits}b "
+        f"({fp.per_channel_phy_area_mm2:.2f} mm^2/channel)",
+        "",
+        "## Compute tile classes (PE + L2)",
+        "",
+        "| class | N | PE mm^2 | L2 mm^2 | total mm^2 | pitch mm | whitespace mm^2 |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for tc, s in sorted(fp.compute_summaries.items()):
+        lines.append(
+            f"| `{tc}` | {s.num_tiles} | {s.pe_area_mm2:.4f} | "
+            f"{s.l2_area_mm2:.4f} | {s.total_area_mm2:.4f} | "
+            f"{s.pitch_mm:.3f} | {s.class_whitespace_mm2:.1f} |"
+        )
+    s = fp.memory_summary
+    lines.extend([
+        "",
+        "## Memory tile (L3)",
+        "",
+        f"| N | L3 mm^2 | pitch mm | whitespace mm^2 |",
+        "|---:|---:|---:|---:|",
+        f"| {s.num_tiles} | {s.l3_area_mm2:.4f} | {s.pitch_mm:.3f} | "
+        f"{s.class_whitespace_mm2:.1f} |",
+        "",
+        "## What-if (all-class-X die area)",
+        "",
+        "| class | unified pitch mm | die mm^2 | whitespace |",
+        "|---|---:|---:|---:|",
+    ])
+    for wi in sorted(fp.what_if, key=lambda w: w.die_area_mm2):
+        lines.append(
+            f"| `{wi.tile_class}` | {wi.unified_pitch_mm:.3f} | "
+            f"{wi.die_area_mm2:.1f} | {wi.whitespace_fraction*100:.1f}% |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _circuit_to_csv(fp: Floorplan) -> str:
+    buf = io.StringIO()
+    writer = csv.DictWriter(
+        buf,
+        fieldnames=[
+            "sku_id", "name", "circuit_class", "is_compute_tile",
+            "tile_class", "x_mm", "y_mm", "width_mm", "height_mm",
+            "area_mm2",
+        ],
+    )
+    writer.writeheader()
+    for b in fp.blocks:
+        writer.writerow({
+            "sku_id": fp.sku_id, "name": b.name,
+            "circuit_class": b.circuit_class.value,
+            "is_compute_tile": b.is_compute_tile,
+            "tile_class": b.tile_class or "",
+            "x_mm": f"{b.x_mm:.4f}", "y_mm": f"{b.y_mm:.4f}",
+            "width_mm": f"{b.width_mm:.4f}", "height_mm": f"{b.height_mm:.4f}",
+            "area_mm2": f"{b.area_mm2:.4f}",
+        })
+    return buf.getvalue()
+
+
+def _circuit_to_md(fp: Floorplan) -> str:
+    lines = [
+        f"# Circuit-class floorplan: `{fp.sku_id}`", "",
+        f"- **die**: {fp.die_width_mm:.2f} x {fp.die_height_mm:.2f} mm "
+        f"= {fp.die_area_mm2:.1f} mm^2",
+        f"- **unified pitch**: {fp.unified_pitch_mm:.3f} mm",
+        f"- **whitespace**: {fp.whitespace_fraction()*100:.1f}%",
+        "",
+        "## Per-tile-class pitches",
+        "",
+        "| tile class | PE mm^2 | SRAM mm^2 | total mm^2 | pitch mm |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for tc, tp in sorted(fp.tile_pitches.items()):
+        lines.append(
+            f"| `{tc}` | {tp.pe_area_mm2:.4f} | {tp.sram_area_mm2:.4f} | "
+            f"{tp.total_area_mm2:.4f} | {tp.pitch_mm:.3f} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -487,18 +661,18 @@ def main() -> int:
         ),
     )
     parser.add_argument(
-        "--width", type=int, default=80,
-        help="ASCII grid width in characters (default 80).",
+        "--width", type=_positive_int, default=80,
+        help="ASCII grid width in characters (default 80, must be > 0).",
     )
     parser.add_argument(
         "--json", action="store_true",
-        help="Emit JSON (machine-readable) instead of ASCII art.",
+        help="Emit JSON (overrides extension auto-detect on --output).",
     )
     parser.add_argument(
         "--output", "-o",
         help=(
-            "Write to a file (extension .json selects JSON unless --json "
-            "is also passed)."
+            "Write to a file. Format auto-detected from extension: "
+            ".json/.csv/.md/.markdown/.txt; default text."
         ),
     )
     parser.add_argument(
@@ -531,14 +705,16 @@ def main() -> int:
         return 2
     node = nodes[sku.process_node_id]
 
-    use_json = args.json or (
-        args.output and args.output.lower().endswith(".json")
-    )
+    fmt = _detect_format(args.output, args.json)
 
     if args.view == "architectural":
         fp_arch = derive_kpu_architectural_floorplan(sku, node)
-        if use_json:
+        if fmt == "json":
             payload = json.dumps(_arch_to_dict(fp_arch), indent=2)
+        elif fmt == "csv":
+            payload = _arch_to_csv(fp_arch)
+        elif fmt == "md":
+            payload = _arch_to_md(fp_arch)
         else:
             payload = (
                 _render_architectural_summary(fp_arch)
@@ -548,8 +724,12 @@ def main() -> int:
             )
     else:  # circuit
         fp_circ = derive_kpu_floorplan(sku, node)
-        if use_json:
+        if fmt == "json":
             payload = json.dumps(_circuit_to_dict(fp_circ), indent=2)
+        elif fmt == "csv":
+            payload = _circuit_to_csv(fp_circ)
+        elif fmt == "md":
+            payload = _circuit_to_md(fp_circ)
         else:
             payload = (
                 _render_circuit_summary(fp_circ)

--- a/cli/show_floorplan.py
+++ b/cli/show_floorplan.py
@@ -123,24 +123,39 @@ def _render_blocks_to_ascii(
     *,
     char_width: int = 80,
 ) -> str:
-    """Rasterize a list of (rectangle, glyph) pairs into an ASCII grid.
+    """Rasterize (rectangle, glyph) pairs into an ASCII grid.
 
     Terminal characters are roughly 2:1 tall:wide; the height scales
     accordingly so the printed die preserves its true aspect ratio.
+
+    Both edge endpoints use ``floor`` (``int()``) so adjacent
+    rectangles share a boundary cell (no gaps, no overlaps) AND every
+    tile gets the same visual size. ``round`` was tried earlier but
+    produced periodic +1-cell tiles (e.g., 7 tiles of 2 rows + 1 of
+    3) because the rounding direction flipped at half-pitch boundaries.
+    With floor, tile_size = floor(N*pitch/r) - floor((N-1)*pitch/r) is
+    uniform across the mesh.
     """
     if die_width_mm <= 0 or die_height_mm <= 0:
         return "(empty floorplan)"
     mm_per_col = die_width_mm / char_width
     mm_per_row = mm_per_col * 2.0
-    rows = max(1, int(die_height_mm / mm_per_row + 0.5))
+    rows = max(1, int(die_height_mm / mm_per_row))
     grid = [[" "] * char_width for _ in range(rows)]
     for (x, y, w, h), glyph in blocks_with_glyphs:
         col_lo = max(0, int(x / mm_per_col))
-        col_hi = min(char_width, int((x + w) / mm_per_col + 0.5))
+        col_hi = min(char_width, int((x + w) / mm_per_col))
         # Flip y: grid row 0 = top of die (high y)
         y_top = y + h
         row_lo = max(0, int((die_height_mm - y_top) / mm_per_row))
-        row_hi = min(rows, int((die_height_mm - y) / mm_per_row + 0.5))
+        row_hi = min(rows, int((die_height_mm - y) / mm_per_row))
+        # Ensure non-empty rectangles render at least 1 cell -- otherwise
+        # thin blocks (IO ring at 0.3mm with mm_per_col 0.23) collapse
+        # to col_lo == col_hi and disappear.
+        if col_hi == col_lo and w > 0:
+            col_hi = min(char_width, col_lo + 1)
+        if row_hi == row_lo and h > 0:
+            row_hi = min(rows, row_lo + 1)
         for r in range(row_lo, row_hi):
             for c in range(col_lo, col_hi):
                 grid[r][c] = glyph

--- a/cli/show_floorplan.py
+++ b/cli/show_floorplan.py
@@ -50,6 +50,7 @@ from graphs.hardware.silicon_floorplan import (
     ArchTile,
     Floorplan,
     FloorplanBlock,
+    MemoryChannel,
     TileRole,
     derive_kpu_architectural_floorplan,
     derive_kpu_floorplan,
@@ -71,9 +72,22 @@ _ARCH_GLYPH_BY_ROLE = {
     TileRole.CONTROL: "*",
 }
 
+# Off-die channel glyphs by edge -- each channel is a strip of these
+# characters running parallel to its edge.
+_CHANNEL_GLYPH_BY_EDGE = {
+    "top": "=",
+    "bottom": "=",
+    "left": "|",
+    "right": "|",
+}
+
 
 def _arch_glyph_for(block: ArchTile) -> str:
     return _ARCH_GLYPH_BY_ROLE.get(block.role, "?")
+
+
+def _channel_glyph_for(ch: MemoryChannel) -> str:
+    return _CHANNEL_GLYPH_BY_EDGE.get(ch.edge, "#")
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +164,10 @@ def _render_architectural_summary(fp: ArchitecturalFloorplan) -> str:
         f"  blocks:            compute={len(fp.compute_tiles())}, "
         f"memory={len(fp.memory_tiles())}, "
         f"controllers={fp.num_memory_controllers}",
+        f"  memory subsystem:  {fp.memory_type}  "
+        f"channels={fp.num_memory_controllers}  "
+        f"width/ch={fp.per_channel_width_bits}b  "
+        f"PHY/ch={fp.per_channel_phy_area_mm2:.2f} mm^2",
         "",
         "Compute tile classes (PE + L2 per tile):",
     ]
@@ -199,18 +217,66 @@ def _arch_glyph_legend(fp: ArchitecturalFloorplan) -> str:
     for role, glyph in _ARCH_GLYPH_BY_ROLE.items():
         if role in used:
             parts.append(f"{glyph}={role.value}")
+    if fp.memory_channels:
+        # Show the off-die channel glyphs in the legend too
+        edges_used = {ch.edge for ch in fp.memory_channels}
+        ch_glyphs = sorted({_CHANNEL_GLYPH_BY_EDGE[e] for e in edges_used})
+        parts.append(
+            f"{'/'.join(ch_glyphs)}=dram_channel ({fp.memory_type} "
+            f"{fp.per_channel_width_bits}b)"
+        )
     return "  Legend: " + "  ".join(parts)
 
 
 def render_architectural_ascii(
     fp: ArchitecturalFloorplan, *, char_width: int = 80
 ) -> str:
-    pairs = [
-        ((b.x_mm, b.y_mm, b.width_mm, b.height_mm), _arch_glyph_for(b))
-        for b in fp.blocks
-    ]
+    """Render the die + off-die DRAM channels in a single canvas.
+
+    Channels live just outside the die boundary at negative or beyond-
+    die-edge coordinates. The renderer expands the canvas to include
+    them and translates everything into canvas coordinates so the
+    visual MC <-> channel association is preserved.
+    """
+    # Compute outer margins from channel placements
+    top_margin = 0.0
+    right_margin = 0.0
+    bottom_margin = 0.0
+    left_margin = 0.0
+    for ch in fp.memory_channels:
+        if ch.edge == "top":
+            top_margin = max(top_margin, ch.height_mm)
+        elif ch.edge == "bottom":
+            bottom_margin = max(bottom_margin, ch.height_mm)
+        elif ch.edge == "left":
+            left_margin = max(left_margin, ch.width_mm)
+        elif ch.edge == "right":
+            right_margin = max(right_margin, ch.width_mm)
+
+    canvas_w = fp.die_width_mm + left_margin + right_margin
+    canvas_h = fp.die_height_mm + bottom_margin + top_margin
+    if canvas_w <= 0 or canvas_h <= 0:
+        return "(empty floorplan)"
+
+    pairs = []
+    # Die blocks: translate by (left_margin, bottom_margin)
+    for b in fp.blocks:
+        pairs.append((
+            (b.x_mm + left_margin, b.y_mm + bottom_margin,
+             b.width_mm, b.height_mm),
+            _arch_glyph_for(b),
+        ))
+    # Off-die channels: translate. Channels for 'top' have y_mm >=
+    # die_height_mm; 'bottom' have y_mm < 0; etc. Translation aligns
+    # them in canvas space.
+    for ch in fp.memory_channels:
+        pairs.append((
+            (ch.x_mm + left_margin, ch.y_mm + bottom_margin,
+             ch.width_mm, ch.height_mm),
+            _channel_glyph_for(ch),
+        ))
     return _render_blocks_to_ascii(
-        pairs, fp.die_width_mm, fp.die_height_mm, char_width=char_width
+        pairs, canvas_w, canvas_h, char_width=char_width
     )
 
 
@@ -227,6 +293,20 @@ def _arch_to_dict(fp: ArchitecturalFloorplan) -> dict:
         "whitespace_mm2": fp.whitespace_mm2(),
         "whitespace_fraction": fp.whitespace_fraction(),
         "num_memory_controllers": fp.num_memory_controllers,
+        "memory_type": fp.memory_type,
+        "per_channel_width_bits": fp.per_channel_width_bits,
+        "per_channel_phy_area_mm2": fp.per_channel_phy_area_mm2,
+        "memory_channels": [
+            {
+                "channel_id": ch.channel_id,
+                "memory_type": ch.memory_type,
+                "width_bits": ch.width_bits,
+                "x_mm": ch.x_mm, "y_mm": ch.y_mm,
+                "width_mm": ch.width_mm, "height_mm": ch.height_mm,
+                "controller_name": ch.controller_name,
+                "edge": ch.edge,
+            } for ch in fp.memory_channels
+        ],
         "compute_summaries": {
             tc: {
                 "num_tiles": s.num_tiles,

--- a/docs/designs/kpu-sku-and-process-node-plan.md
+++ b/docs/designs/kpu-sku-and-process-node-plan.md
@@ -302,7 +302,7 @@ All cross-repo work landed via `embodied-schemas` PRs #9, #10, #11 and
 | 6 | CI gate: every SKU YAML in the catalog validated by the registry on every push | done (graphs #150) |
 | 7 | PDK ingestion + `PROCESS_NODE_DATA_DIR` env override | done (graphs #151) |
 | 8a | Stage 8a circuit-class floorplanner + ASCII viz + 3 GEOMETRY validators (`floorplan_pitch_match`, `floorplan_within_die_envelope`, `floorplan_aspect_ratio`) -- heuristic v1 (advisory; WARN-max thresholds) | done |
-| 8b | Stage 8b architectural-role floorplanner: COMPUTE / MEMORY / MEMORY_CONTROLLER / IO / CONTROL roles, true checkerboard layout, distributed controllers, what-if-all-class-X die estimates, and 2 new validators (`floorplan_compute_memory_pitch_match`, `floorplan_whitespace_fraction`). `cli/show_floorplan.py` defaults to the architectural view; `--view circuit` falls back to 8a. | done |
+| 8b | Stage 8b architectural-role floorplanner: COMPUTE / MEMORY / MEMORY_CONTROLLER / IO / CONTROL roles, **true 2D checkerboard** layout (every interior compute tile has 4 memory neighbours), **rectangular MCs sized by memory type + channel I/O width** (LPDDR narrow stripes, HBM squarer microbump arrays) with **count = ``memory.memory_controllers``**, **off-die DRAM channel labels** showing MC<->channel connectivity, what-if-all-class-X die estimates, and 2 new validators (`floorplan_compute_memory_pitch_match`, `floorplan_whitespace_fraction`). `cli/show_floorplan.py` defaults to the architectural view; `--view circuit` falls back to 8a. | done |
 | 8c | Stage 8 deferred (DVFS feasibility, memory headroom, yield risk, SVG/HTML viz w/ NoC overlay (mesh / ring / CLOS), NoC routability validator, calibrate floorplan thresholds against measured silicon) | deferred |
 
 ## File inventory
@@ -419,17 +419,33 @@ Re-bins the same silicon_bin areas by what the architect calls them:
 
 - **COMPUTE** tile = PE fabric + L1 + L2 (per compute tile)
 - **MEMORY** tile = L3 (per compute tile, paired 1:1 in checkerboard)
-- **MEMORY_CONTROLLER** = DRAM PHY, distributed around the periphery
-  at the arity of the memory configuration (default 4: top/right/
-  bottom/left edge midpoints; scales when silicon_bin contains
-  multiple distinct PHY blocks)
+- **MEMORY_CONTROLLER** = DRAM PHY block. Count = SKU's
+  ``memory.memory_controllers`` (16 for T256 LPDDR5, 8 for T768 HBM3,
+  etc.). Sized by memory type + per-channel I/O width: LPDDR PHYs are
+  long narrow stripes (~5:1 aspect, parallel to bump edge); HBM PHYs
+  are squarer microbump arrays (~1.5:1). Distributed as an edge ring
+  around the periphery, with corners reserved for vertical (left/
+  right) MCs to avoid layout overlap.
 - **IO_PAD** = pad ring
 - **CONTROL** = scheduler/dispatch in corner
 
-Layout: column-pair checkerboard `[C M] [C M] [C M] ...`. Unified
-pitch = `max(max_compute_pitch, memory_pitch)`. Smaller cells leave
-whitespace -- the floorplan reports the per-class breakdown so the
-architect sees which class costs the most silicon.
+External, drawn outside the die boundary:
+
+- **DRAM channels** -- one rectangle per MC, mirroring its shape
+  on the outside of the die. Visualizes MC<->channel connectivity
+  and shows how memory I/O width affects die geometry.
+
+Layout: TRUE 2D checkerboard (``mesh_rows x 2*mesh_cols`` cells with
+``(r+c) % 2 == 0`` -> COMPUTE, else MEMORY). Every interior compute
+tile has 4 memory neighbours (N/S/E/W). Unified pitch =
+``max(max_compute_pitch, memory_pitch)``. Smaller cells leave
+whitespace -- the floorplan reports the per-class breakdown.
+
+Die size is the max of (mesh extent + IO ring + MC inset) and
+(I/O perimeter required to fit the MC count). For LPDDR-heavy SKUs
+where channel count exceeds what fits along the mesh edge, the die
+expands so the MCs tile cleanly, with whitespace around the centred
+mesh.
 
 What-if analysis: for each compute tile class, recompute the die
 area assuming every compute tile in the mesh were that class. Lets

--- a/docs/designs/kpu-sku-and-process-node-plan.md
+++ b/docs/designs/kpu-sku-and-process-node-plan.md
@@ -301,8 +301,9 @@ All cross-repo work landed via `embodied-schemas` PRs #9, #10, #11 and
 | 5 | Mapper wiring -- `physical_spec` populated on every `create_kpu_t*_mapper()` | done (graphs #144) |
 | 6 | CI gate: every SKU YAML in the catalog validated by the registry on every push | done (graphs #150) |
 | 7 | PDK ingestion + `PROCESS_NODE_DATA_DIR` env override | done (graphs #151) |
-| 8a | Stage 8 floorplanner + ASCII viz + 3 GEOMETRY validators (`floorplan_pitch_match`, `floorplan_within_die_envelope`, `floorplan_aspect_ratio`) -- heuristic v1 (advisory; WARN-max thresholds) | done |
-| 8b | Stage 8 deferred (DVFS feasibility, memory headroom, yield risk, SVG viz, NoC routability validator, calibrate floorplan thresholds against measured silicon) | deferred |
+| 8a | Stage 8a circuit-class floorplanner + ASCII viz + 3 GEOMETRY validators (`floorplan_pitch_match`, `floorplan_within_die_envelope`, `floorplan_aspect_ratio`) -- heuristic v1 (advisory; WARN-max thresholds) | done |
+| 8b | Stage 8b architectural-role floorplanner: COMPUTE / MEMORY / MEMORY_CONTROLLER / IO / CONTROL roles, true checkerboard layout, distributed controllers, what-if-all-class-X die estimates, and 2 new validators (`floorplan_compute_memory_pitch_match`, `floorplan_whitespace_fraction`). `cli/show_floorplan.py` defaults to the architectural view; `--view circuit` falls back to 8a. | done |
+| 8c | Stage 8 deferred (DVFS feasibility, memory headroom, yield risk, SVG/HTML viz w/ NoC overlay (mesh / ring / CLOS), NoC routability validator, calibrate floorplan thresholds against measured silicon) | deferred |
 
 ## File inventory
 
@@ -399,27 +400,75 @@ swapped over.
 
 Implemented in this branch:
 
+### Stage 8a -- circuit-class view
+
 - `src/graphs/hardware/silicon_floorplan.py` -- `derive_kpu_floorplan(sku, node)`:
-  per-tile-class pitch derivation, unified-pitch mesh layout, PHY strip,
-  IO ring, control corner. Emits `Floorplan` (blocks + tile_pitches).
-- `cli/show_floorplan.py` -- ASCII art renderer with circuit-class
-  glyph legend; `--json` flag for machine-readable output. Auto-discovery
-  of catalog SKUs via `--list`.
-- `src/graphs/hardware/sku_validators/validators/geometry.py` -- 3 GEOMETRY
-  validators:
-  - `floorplan_pitch_match` (KPU checkerboard) -- WARN at >=1.20x ratio
+  per-tile-class pitch derivation keyed on silicon library
+  (HP_LOGIC / BAL / SRAM / ANALOG / IO), unified-pitch mesh layout,
+  PHY strip, IO ring, control corner. Emits `Floorplan`.
+- `cli/show_floorplan.py --view circuit` -- ASCII art with
+  circuit-class glyphs (`H`/`B`/`L`/`U`/`#`/`~`/`:`).
+- 3 GEOMETRY validators:
+  - `floorplan_pitch_match` (within-compute-class) -- WARN at >=1.20x ratio
   - `floorplan_within_die_envelope` -- declared vs derived die area
   - `floorplan_aspect_ratio` -- die aspect bounds
-- `tests/hardware/test_silicon_floorplan.py` -- 34 tests covering
-  structural correctness, validator registration, and CLI happy paths.
 
-Stage 8 stance: thresholds set so all 4 catalog SKUs land at WARN-max,
-not ERROR. The findings still surface real signal (T768 has 2.34x INT8/
-Matrix pitch mismatch; T64/T128 floorplan area is 1.87x the declared
-die.die_size_mm2). Tightening to ERROR-level is Stage 8b work after
-the heuristic is calibrated against measured silicon.
+### Stage 8b -- architectural-role view
 
-## Open items deferred to Stage 8b
+Re-bins the same silicon_bin areas by what the architect calls them:
+
+- **COMPUTE** tile = PE fabric + L1 + L2 (per compute tile)
+- **MEMORY** tile = L3 (per compute tile, paired 1:1 in checkerboard)
+- **MEMORY_CONTROLLER** = DRAM PHY, distributed around the periphery
+  at the arity of the memory configuration (default 4: top/right/
+  bottom/left edge midpoints; scales when silicon_bin contains
+  multiple distinct PHY blocks)
+- **IO_PAD** = pad ring
+- **CONTROL** = scheduler/dispatch in corner
+
+Layout: column-pair checkerboard `[C M] [C M] [C M] ...`. Unified
+pitch = `max(max_compute_pitch, memory_pitch)`. Smaller cells leave
+whitespace -- the floorplan reports the per-class breakdown so the
+architect sees which class costs the most silicon.
+
+What-if analysis: for each compute tile class, recompute the die
+area assuming every compute tile in the mesh were that class. Lets
+the architect see the silicon cost of the heterogeneous mix.
+
+- `derive_kpu_architectural_floorplan(sku, node)` -- new, sibling
+  function to the circuit-class one
+- `ArchitecturalFloorplan`, `ArchTile`, `TileRole`,
+  `ComputeClassSummary`, `MemoryClassSummary`,
+  `WhatIfDieEstimate` -- new dataclasses
+- `cli/show_floorplan.py` (new default `--view architectural`) --
+  ASCII art with role glyphs (`C`/`M`/`D`/`:`/`*`) + per-class
+  whitespace + what-if table
+- 2 new GEOMETRY validators:
+  - `floorplan_compute_memory_pitch_match` (the primary KPU
+    checkerboard concern: compute pitch vs memory pitch) -- WARN
+    at >=1.20x ratio
+  - `floorplan_whitespace_fraction` -- WARN at >=40% architectural
+    whitespace; message names the worst-contributor class and the
+    smallest-die what-if alternative
+
+### Stage 8 stance
+
+Thresholds set so all 4 catalog SKUs land at WARN-max, not ERROR.
+Findings surface real signal:
+
+- T768: **3.59x** compute-vs-memory pitch ratio (Matrix tile dominates,
+  memory tile is tiny); 76% architectural whitespace; an all-INT8
+  mesh would be 471 mm^2 vs the mixed 1214 mm^2 (61% smaller).
+- T256: 1.41x C/M ratio (memory dominates over INT8); 68% whitespace;
+  all-INT8 alternative would be 32% smaller.
+- T64/T128: 2.08x C/M ratio (Matrix dominates); ~77% whitespace;
+  all-INT8 alternative ~62% smaller.
+- T64/T128 floorplan area is 1.87x the declared `die.die_size_mm2`.
+
+Tightening to ERROR-level is Stage 8c work after the heuristic is
+calibrated against measured silicon.
+
+## Open items deferred to Stage 8c
 
 - SVG / PNG visualization with annotated dimensions, pitches, IO ring
   (Stage 8a ships ASCII only).

--- a/docs/designs/kpu-sku-and-process-node-plan.md
+++ b/docs/designs/kpu-sku-and-process-node-plan.md
@@ -300,8 +300,9 @@ All cross-repo work landed via `embodied-schemas` PRs #9, #10, #11 and
 | 4b | Collapse 4 hand-coded factories into thin wrappers around the loader | done (graphs #145–#149) |
 | 5 | Mapper wiring -- `physical_spec` populated on every `create_kpu_t*_mapper()` | done (graphs #144) |
 | 6 | CI gate: every SKU YAML in the catalog validated by the registry on every push | done (graphs #150) |
-| 7 | PDK ingestion + `PROCESS_NODE_DATA_DIR` env override | in progress |
-| 8 | **Stage 8 (later)**: DVFS feasibility, memory headroom, yield risk, **floorplanner + viz + geometric validators (KPU checkerboard pitch-match)** | deferred |
+| 7 | PDK ingestion + `PROCESS_NODE_DATA_DIR` env override | done (graphs #151) |
+| 8a | Stage 8 floorplanner + ASCII viz + 3 GEOMETRY validators (`floorplan_pitch_match`, `floorplan_within_die_envelope`, `floorplan_aspect_ratio`) -- heuristic v1 (advisory; WARN-max thresholds) | done |
+| 8b | Stage 8 deferred (DVFS feasibility, memory headroom, yield risk, SVG viz, NoC routability validator, calibrate floorplan thresholds against measured silicon) | deferred |
 
 ## File inventory
 
@@ -394,15 +395,46 @@ above keeps each step's blast radius small. Preserved-as-is: the
 loader doesn't change anything until the factories actually get
 swapped over.
 
-## Open items deferred to Stage 8
+## Stage 8 (delivered, heuristic v1)
 
-- Floorplanner utility: takes `silicon_bin` + topology hint, emits 2D placement.
-- Visualization tool: SVG/PNG with annotated dimensions, pitches, IO ring.
-- Geometric constraint validators: pitch-match (KPU checkerboard), aspect ratios,
-  NoC routability, IO placement.
-- Whether cooling-solution -> ceiling table moves into a per-cooling Pydantic
-  field (currently planned to live there from day one) vs validator local
-  default. Resolved: lives in CoolingSolutionEntry.
-- DVFS feasibility validator (does throttling actually let advertised TOPS land?)
+Implemented in this branch:
+
+- `src/graphs/hardware/silicon_floorplan.py` -- `derive_kpu_floorplan(sku, node)`:
+  per-tile-class pitch derivation, unified-pitch mesh layout, PHY strip,
+  IO ring, control corner. Emits `Floorplan` (blocks + tile_pitches).
+- `cli/show_floorplan.py` -- ASCII art renderer with circuit-class
+  glyph legend; `--json` flag for machine-readable output. Auto-discovery
+  of catalog SKUs via `--list`.
+- `src/graphs/hardware/sku_validators/validators/geometry.py` -- 3 GEOMETRY
+  validators:
+  - `floorplan_pitch_match` (KPU checkerboard) -- WARN at >=1.20x ratio
+  - `floorplan_within_die_envelope` -- declared vs derived die area
+  - `floorplan_aspect_ratio` -- die aspect bounds
+- `tests/hardware/test_silicon_floorplan.py` -- 34 tests covering
+  structural correctness, validator registration, and CLI happy paths.
+
+Stage 8 stance: thresholds set so all 4 catalog SKUs land at WARN-max,
+not ERROR. The findings still surface real signal (T768 has 2.34x INT8/
+Matrix pitch mismatch; T64/T128 floorplan area is 1.87x the declared
+die.die_size_mm2). Tightening to ERROR-level is Stage 8b work after
+the heuristic is calibrated against measured silicon.
+
+## Open items deferred to Stage 8b
+
+- SVG / PNG visualization with annotated dimensions, pitches, IO ring
+  (Stage 8a ships ASCII only).
+- Calibrate `_PITCH_RATIO_ERROR` and `_DIE_AREA_RATIO_ERROR` against
+  measured T256 silicon; tighten to ERROR-level once trustable.
+- Resolve T64/T128 floorplan-vs-declared-die mismatch: either rebalance
+  silicon_bin coefficients, adjust declared `die.die_size_mm2`, or
+  refine the floorplan's PHY-strip / IO-ring overhead estimate.
+- NoC routability validator (max wire length per hop, tile-fanout
+  feasibility).
+- IO-pad-pitch validator (pad ring vs IO bandwidth requirements).
+- DVFS feasibility validator (does throttling actually let advertised
+  TOPS land?).
 - Memory bandwidth headroom validator (roofline knee).
-- Process yield risk (D0 × area).
+- Process yield risk (D0 x area).
+- Whether cooling-solution -> ceiling table moves into a per-cooling
+  Pydantic field (currently planned to live there from day one) vs
+  validator local default. Resolved: lives in CoolingSolutionEntry.

--- a/src/graphs/hardware/silicon_floorplan.py
+++ b/src/graphs/hardware/silicon_floorplan.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Optional
 
 from embodied_schemas.kpu import KPUEntry, KPUTileSpec
@@ -539,3 +540,640 @@ def _place_control(
         notes=f"Aggregates {len(ctrl_blocks)} control block(s); "
               f"placed in bottom-left corner",
     )]
+
+
+# ===========================================================================
+# Architectural-view floorplan
+# ===========================================================================
+#
+# The circuit-class view above keys on silicon library (HP_LOGIC, BALANCED,
+# SRAM_HD, ANALOG, IO). That tells you what was *built*, not what it
+# *does*. The architectural view re-bins the same areas by what the
+# architect calls them:
+#
+#   * COMPUTE tile = PE fabric + L1 + L2 (the unit that does work)
+#   * MEMORY tile  = L3 (the local scratchpad that alternates with
+#                    compute in the KPU checkerboard)
+#   * MEMORY_CONTROLLER = DRAM PHY block, distributed around the
+#                    periphery at the arity of the memory configuration
+#   * IO_PAD       = pad ring (perimeter)
+#   * CONTROL      = scheduler/dispatch (corner)
+#
+# The primary geometric concern shifts from "do all compute tile classes
+# share a pitch" to "do compute tiles share a pitch with memory tiles".
+# When a checkerboard pairs a 0.335mm compute tile with a 0.471mm
+# memory tile, the layout either leaves whitespace inside the smaller
+# cell or routes detour around uneven cells -- both bad.
+#
+# This view also exposes a "what-if" lens: if every compute tile in the
+# mesh were of class X, what would the die area + whitespace be? That
+# tells the architect how much die-area cost the heterogeneous mix
+# (Matrix tiles in particular) is paying vs an all-INT8 or all-BF16
+# alternative.
+
+
+class TileRole(str, Enum):
+    """Architectural role of a placed block.
+
+    The role is what the architect calls the block, independent of which
+    silicon library implements it. A compute tile can be HP_LOGIC,
+    BALANCED_LOGIC, or both at once (PEs + L1+L2 SRAM); the role stays
+    COMPUTE.
+    """
+
+    COMPUTE = "compute"
+    MEMORY = "memory"
+    MEMORY_CONTROLLER = "memory_controller"
+    IO_PAD = "io_pad"
+    CONTROL = "control"
+
+
+@dataclass(frozen=True)
+class ArchTile:
+    """One architectural block (a tile, controller, ring segment, etc.).
+
+    Coordinates use bottom-left-origin; (0, 0) is the lower-left corner
+    of the die. All units mm.
+    """
+
+    name: str
+    role: TileRole
+    x_mm: float
+    y_mm: float
+    width_mm: float
+    height_mm: float
+
+    tile_class: Optional[str] = None
+    """For COMPUTE tiles, the architectural tile class
+    (e.g., 'INT8-primary'). None for non-compute roles."""
+
+    pe_area_mm2: Optional[float] = None
+    """For COMPUTE tiles: the PE-fabric area within this tile."""
+
+    l2_area_mm2: Optional[float] = None
+    """For COMPUTE tiles: the per-tile L2 area."""
+
+    l3_area_mm2: Optional[float] = None
+    """For MEMORY tiles: the per-tile L3 area."""
+
+    notes: str = ""
+
+    @property
+    def area_mm2(self) -> float:
+        return self.width_mm * self.height_mm
+
+    @property
+    def used_area_mm2(self) -> float:
+        """Area actually consumed by silicon inside this tile's envelope.
+
+        For COMPUTE: pe_area + l2_area. For MEMORY: l3_area. For
+        non-tile roles (IO ring, controllers, control): the full
+        ``area_mm2``. The difference (envelope - used) is whitespace
+        inside the tile cell.
+        """
+        if self.role == TileRole.COMPUTE:
+            return (self.pe_area_mm2 or 0.0) + (self.l2_area_mm2 or 0.0)
+        if self.role == TileRole.MEMORY:
+            return self.l3_area_mm2 or 0.0
+        return self.area_mm2
+
+    @property
+    def whitespace_mm2(self) -> float:
+        return max(0.0, self.area_mm2 - self.used_area_mm2)
+
+
+@dataclass(frozen=True)
+class ComputeClassSummary:
+    """Per-class compute-tile area + pitch + whitespace breakdown.
+
+    A SKU with 3 tile classes (INT8, BF16, Matrix) produces 3 of these.
+    Comparing them shows which classes are pitch-bound (smaller than
+    the unified pitch) and how much whitespace they collectively
+    contribute to the die.
+    """
+
+    tile_class: str
+    num_tiles: int
+    pe_area_mm2: float
+    l2_area_mm2: float
+    total_area_mm2: float
+    pitch_mm: float
+    """``sqrt(total_area_mm2)`` -- side length if this class were the
+    only thing in the mesh."""
+
+    whitespace_per_tile_mm2: float
+    """``unified_pitch^2 - total_area_mm2`` -- what each tile of this
+    class wastes when placed in the unified-pitch envelope."""
+
+    class_whitespace_mm2: float
+    """``num_tiles * whitespace_per_tile_mm2`` -- total die area this
+    class costs in whitespace alone."""
+
+
+@dataclass(frozen=True)
+class MemoryClassSummary:
+    """Memory-tile area + pitch + whitespace.
+
+    All memory tiles are uniform (one L3 per compute tile, same size
+    everywhere) so there's just one of these per SKU.
+    """
+
+    num_tiles: int
+    l3_area_mm2: float
+    total_area_mm2: float
+    pitch_mm: float
+    whitespace_per_tile_mm2: float
+    class_whitespace_mm2: float
+
+
+@dataclass(frozen=True)
+class WhatIfDieEstimate:
+    """What the die would look like if every compute tile were one class.
+
+    Computed independently for each compute tile class. The architect
+    can compare these against the actual mixed-class die to see the
+    cost of the heterogeneous mix.
+    """
+
+    tile_class: str
+    """The compute class assumed for every tile in this estimate."""
+
+    unified_pitch_mm: float
+    """``max(class_pitch, memory_pitch)`` for this scenario."""
+
+    mesh_area_mm2: float
+    """Total mesh rectangle (compute + memory tiles, no periphery)."""
+
+    die_area_mm2: float
+    """Including IO ring + memory controllers + control corner."""
+
+    whitespace_mm2: float
+    """Die area not covered by silicon, in this scenario."""
+
+    whitespace_fraction: float
+
+
+@dataclass(frozen=True)
+class ArchitecturalFloorplan:
+    """Architectural-role floorplan: compute tiles, memory tiles,
+    controllers, IO ring, control. Companion to the circuit-class
+    ``Floorplan`` -- both are derived from the same silicon_bin.
+    """
+
+    sku_id: str
+    sku_name: str
+    die_width_mm: float
+    die_height_mm: float
+    blocks: list[ArchTile]
+
+    compute_summaries: dict[str, ComputeClassSummary]
+    memory_summary: MemoryClassSummary
+    num_memory_controllers: int
+    unified_pitch_mm: float
+    """``max(max_compute_pitch, memory_pitch)`` -- the single mesh
+    cell side length used for both compute and memory tiles."""
+
+    what_if: list[WhatIfDieEstimate] = field(default_factory=list)
+    """Per-class 'if every compute tile were class X' die estimates."""
+
+    notes: str = ""
+
+    @property
+    def die_area_mm2(self) -> float:
+        return self.die_width_mm * self.die_height_mm
+
+    @property
+    def compute_memory_pitch_ratio(self) -> float:
+        """``max(max_compute_pitch, memory_pitch) /
+        min(max_compute_pitch, memory_pitch)``. 1.0 = perfect
+        checkerboard match; >1.2 starts wasting silicon."""
+        cps = [s.pitch_mm for s in self.compute_summaries.values()]
+        if not cps or self.memory_summary.pitch_mm <= 0:
+            return float("inf")
+        max_c = max(cps)
+        if max_c <= 0:
+            return float("inf")
+        return max(max_c, self.memory_summary.pitch_mm) / min(
+            max_c, self.memory_summary.pitch_mm
+        )
+
+    def total_used_area_mm2(self) -> float:
+        return sum(b.used_area_mm2 for b in self.blocks)
+
+    def whitespace_mm2(self) -> float:
+        return max(0.0, self.die_area_mm2 - self.total_used_area_mm2())
+
+    def whitespace_fraction(self) -> float:
+        if self.die_area_mm2 <= 0:
+            return 0.0
+        return self.whitespace_mm2() / self.die_area_mm2
+
+    def compute_tiles(self) -> list[ArchTile]:
+        return [b for b in self.blocks if b.role == TileRole.COMPUTE]
+
+    def memory_tiles(self) -> list[ArchTile]:
+        return [b for b in self.blocks if b.role == TileRole.MEMORY]
+
+    def memory_controllers(self) -> list[ArchTile]:
+        return [b for b in self.blocks if b.role == TileRole.MEMORY_CONTROLLER]
+
+
+# ---------------------------------------------------------------------------
+# Architectural derivation
+# ---------------------------------------------------------------------------
+
+# Default memory-controller arity when silicon_bin doesn't expose a
+# distinct count. 4 corresponds to one controller centered on each of
+# the four die edges -- typical of LPDDR-class accelerators. HBM-class
+# parts often want 8 (two per edge); the heuristic below upgrades to
+# match if silicon_bin contains multiple distinct PHY blocks.
+_DEFAULT_NUM_MEMORY_CONTROLLERS = 4
+
+
+def derive_kpu_architectural_floorplan(
+    sku: KPUEntry, node: ProcessNodeEntry
+) -> ArchitecturalFloorplan:
+    """Produce the architectural-role floorplan for a KPU SKU.
+
+    Layout (heuristic v1):
+
+    1. Per compute tile class: pitch = sqrt(per_tile_PE_area +
+       per_tile_L2_area).
+    2. Memory tile pitch = sqrt(per_tile_L3_area). One memory tile per
+       compute tile (1:1 pairing -- each compute tile owns its L3).
+    3. Unified pitch = max(max_compute_pitch, memory_pitch). Smaller
+       cells leave whitespace.
+    4. Physical mesh = ``mesh_rows x (2 * mesh_cols)``: every compute
+       tile is paired with a memory tile to its right (column-pair
+       checkerboard). True 2D checkerboards are also reasonable; this
+       layout was picked because it renders cleanly in ASCII and
+       preserves N/S compute-compute neighbours within the NoC.
+    5. Memory controllers: ``N`` distinct PHY blocks (or default 4) of
+       equal size, distributed around the perimeter clockwise from
+       top-center.
+    6. IO ring: thin pad ring around the perimeter.
+    7. Control: corner block.
+
+    NoC routers are not drawn -- they're embedded inside the tile
+    envelopes physically. A future SVG/HTML renderer can overlay the
+    NoC topology (mesh / ring / CLOS) on top of the placed blocks.
+    """
+    arch = sku.kpu_architecture
+    pe_by_tile_type, chip_l2_area, chip_l3_area, other_blocks = (
+        _classify_silicon_bin_blocks(sku, node)
+    )
+    total_compute_tiles = arch.total_tiles
+
+    # Per-tile L2 / L3 (shared by every compute / memory tile)
+    per_tile_l2 = (
+        chip_l2_area / total_compute_tiles if total_compute_tiles > 0 else 0.0
+    )
+    per_tile_l3 = (
+        chip_l3_area / total_compute_tiles if total_compute_tiles > 0 else 0.0
+    )
+    memory_pitch = math.sqrt(per_tile_l3) if per_tile_l3 > 0 else 0.0
+
+    # Per-class compute pitches
+    compute_pitches: dict[str, float] = {}
+    compute_pe_areas: dict[str, float] = {}
+    for tile in arch.tiles:
+        pe_area = (
+            pe_by_tile_type.get(tile.tile_type, 0.0) / tile.num_tiles
+            if tile.num_tiles > 0 else 0.0
+        )
+        total = pe_area + per_tile_l2
+        pitch = math.sqrt(total) if total > 0 else 0.0
+        compute_pitches[tile.tile_type] = pitch
+        compute_pe_areas[tile.tile_type] = pe_area
+
+    # Unified pitch dominates compute and memory
+    max_compute_pitch = max(compute_pitches.values(), default=0.0)
+    unified_pitch = max(max_compute_pitch, memory_pitch)
+    cell_area = unified_pitch * unified_pitch
+
+    # Per-class summaries with whitespace
+    compute_summaries: dict[str, ComputeClassSummary] = {}
+    for tile in arch.tiles:
+        pe_area = compute_pe_areas[tile.tile_type]
+        total = pe_area + per_tile_l2
+        ws_per_tile = max(0.0, cell_area - total)
+        compute_summaries[tile.tile_type] = ComputeClassSummary(
+            tile_class=tile.tile_type,
+            num_tiles=tile.num_tiles,
+            pe_area_mm2=pe_area,
+            l2_area_mm2=per_tile_l2,
+            total_area_mm2=total,
+            pitch_mm=compute_pitches[tile.tile_type],
+            whitespace_per_tile_mm2=ws_per_tile,
+            class_whitespace_mm2=ws_per_tile * tile.num_tiles,
+        )
+
+    memory_ws_per_tile = max(0.0, cell_area - per_tile_l3)
+    memory_summary = MemoryClassSummary(
+        num_tiles=total_compute_tiles,
+        l3_area_mm2=per_tile_l3,
+        total_area_mm2=per_tile_l3,
+        pitch_mm=memory_pitch,
+        whitespace_per_tile_mm2=memory_ws_per_tile,
+        class_whitespace_mm2=memory_ws_per_tile * total_compute_tiles,
+    )
+
+    # Mesh rectangle
+    mesh_rows = arch.noc.mesh_rows
+    mesh_cols = arch.noc.mesh_cols
+    physical_cols = 2 * mesh_cols  # compute + memory pairs per row
+    mesh_width = physical_cols * unified_pitch
+    mesh_height = mesh_rows * unified_pitch
+
+    # Memory controllers around the periphery
+    phy_blocks = [
+        (n, a, c) for (n, a, c) in other_blocks if "phy" in n.lower()
+    ]
+    phy_total_area = sum(a for _, a, _ in phy_blocks)
+    distinct_phys = len(phy_blocks)
+    num_controllers = (
+        distinct_phys if distinct_phys > 1
+        else _DEFAULT_NUM_MEMORY_CONTROLLERS
+    )
+    controller_side = (
+        math.sqrt(phy_total_area / num_controllers)
+        if num_controllers > 0 and phy_total_area > 0 else 0.0
+    )
+
+    # Die envelope: mesh + controller margin on all 4 edges + IO ring
+    edge_pad = _IO_RING_THICKNESS_MM + controller_side
+    die_width = mesh_width + 2 * edge_pad
+    die_height = mesh_height + 2 * edge_pad
+    mesh_origin_x = edge_pad
+    mesh_origin_y = edge_pad
+
+    blocks: list[ArchTile] = []
+
+    # IO ring (4 thin edge segments at the very perimeter)
+    blocks.extend(_arch_place_io_ring(die_width, die_height, other_blocks))
+
+    # Compute + memory tiles (column-pair checkerboard)
+    blocks.extend(_arch_place_checkerboard(
+        arch, mesh_origin_x, mesh_origin_y, unified_pitch,
+        per_tile_l2, per_tile_l3, compute_pe_areas,
+    ))
+
+    # Memory controllers around the periphery
+    blocks.extend(_arch_place_memory_controllers(
+        num_controllers, controller_side, phy_blocks,
+        die_width, die_height,
+        mesh_origin_x, mesh_origin_y, mesh_width, mesh_height,
+    ))
+
+    # Control logic in bottom-left corner of the mesh
+    blocks.extend(_arch_place_control(
+        other_blocks, mesh_origin_x, mesh_origin_y, die_height
+    ))
+
+    # What-if estimates: re-compute die area assuming every compute
+    # tile is class X. Periphery scales the same; mesh resizes around
+    # the new unified pitch.
+    what_if = _arch_what_if_estimates(
+        compute_pitches, memory_pitch, total_compute_tiles,
+        mesh_rows, mesh_cols, edge_pad,
+    )
+
+    return ArchitecturalFloorplan(
+        sku_id=sku.id,
+        sku_name=sku.name,
+        die_width_mm=die_width,
+        die_height_mm=die_height,
+        blocks=blocks,
+        compute_summaries=compute_summaries,
+        memory_summary=memory_summary,
+        num_memory_controllers=num_controllers,
+        unified_pitch_mm=unified_pitch,
+        what_if=what_if,
+        notes=(
+            f"Architectural v1: {mesh_rows}x{mesh_cols} compute + "
+            f"{mesh_rows}x{mesh_cols} memory in column-pair checkerboard "
+            f"@ {unified_pitch:.3f} mm pitch; {num_controllers} memory "
+            f"controllers around periphery."
+        ),
+    )
+
+
+def _arch_place_io_ring(
+    die_width_mm: float,
+    die_height_mm: float,
+    other_blocks: list[tuple[str, float, CircuitClass]],
+) -> list[ArchTile]:
+    io_area = sum(
+        a for n, a, _ in other_blocks
+        if "io" in n.lower() and "phy" not in n.lower()
+    )
+    if io_area <= 0:
+        return []
+    perimeter = 2 * (die_width_mm + die_height_mm)
+    if perimeter <= 0:
+        return []
+    thickness = min(io_area / perimeter, _IO_RING_THICKNESS_MM)
+    return [
+        ArchTile(
+            name="io_ring_bottom", role=TileRole.IO_PAD,
+            x_mm=0.0, y_mm=0.0,
+            width_mm=die_width_mm, height_mm=thickness,
+        ),
+        ArchTile(
+            name="io_ring_top", role=TileRole.IO_PAD,
+            x_mm=0.0, y_mm=die_height_mm - thickness,
+            width_mm=die_width_mm, height_mm=thickness,
+        ),
+        ArchTile(
+            name="io_ring_left", role=TileRole.IO_PAD,
+            x_mm=0.0, y_mm=thickness,
+            width_mm=thickness, height_mm=die_height_mm - 2 * thickness,
+        ),
+        ArchTile(
+            name="io_ring_right", role=TileRole.IO_PAD,
+            x_mm=die_width_mm - thickness, y_mm=thickness,
+            width_mm=thickness, height_mm=die_height_mm - 2 * thickness,
+        ),
+    ]
+
+
+def _arch_place_checkerboard(
+    arch,
+    origin_x: float,
+    origin_y: float,
+    pitch: float,
+    per_tile_l2: float,
+    per_tile_l3: float,
+    compute_pe_areas: dict[str, float],
+) -> list[ArchTile]:
+    """Lay out compute + memory tiles in a column-pair checkerboard.
+
+    Pattern (every row identical):
+        [C M] [C M] [C M] [C M] ...
+    Each row has ``mesh_cols`` compute + ``mesh_cols`` memory tiles.
+    Compute classes assigned in row-major order over compute positions.
+    """
+    mesh_rows = arch.noc.mesh_rows
+    mesh_cols = arch.noc.mesh_cols
+
+    # Tile-class assignment for compute positions (row-major)
+    compute_assignment: list[KPUTileSpec] = []
+    for tile in arch.tiles:
+        compute_assignment.extend([tile] * tile.num_tiles)
+    while len(compute_assignment) < mesh_rows * mesh_cols:
+        compute_assignment.append(arch.tiles[-1])
+    compute_assignment = compute_assignment[: mesh_rows * mesh_cols]
+
+    blocks: list[ArchTile] = []
+    compute_idx = 0
+    for r in range(mesh_rows):
+        for c_pair in range(mesh_cols):
+            # Compute tile (left half of the pair)
+            tile = compute_assignment[compute_idx]
+            compute_idx += 1
+            blocks.append(ArchTile(
+                name=f"compute[{r},{c_pair}]",
+                role=TileRole.COMPUTE,
+                x_mm=origin_x + (2 * c_pair) * pitch,
+                y_mm=origin_y + r * pitch,
+                width_mm=pitch,
+                height_mm=pitch,
+                tile_class=tile.tile_type,
+                pe_area_mm2=compute_pe_areas.get(tile.tile_type, 0.0),
+                l2_area_mm2=per_tile_l2,
+            ))
+            # Memory tile (right half of the pair)
+            blocks.append(ArchTile(
+                name=f"memory[{r},{c_pair}]",
+                role=TileRole.MEMORY,
+                x_mm=origin_x + (2 * c_pair + 1) * pitch,
+                y_mm=origin_y + r * pitch,
+                width_mm=pitch,
+                height_mm=pitch,
+                l3_area_mm2=per_tile_l3,
+            ))
+    return blocks
+
+
+def _arch_place_memory_controllers(
+    num: int,
+    side: float,
+    phy_blocks: list[tuple[str, float, CircuitClass]],
+    die_w: float, die_h: float,
+    mesh_x: float, mesh_y: float,
+    mesh_w: float, mesh_h: float,
+) -> list[ArchTile]:
+    """Distribute ``num`` controllers around the perimeter.
+
+    Walk: top edge first, then right, bottom, left, in order. Each edge
+    gets ``num // 4`` plus a remainder. Controllers sit just inside
+    the IO ring, hugging the mesh on the outer side.
+    """
+    if num <= 0 or side <= 0:
+        return []
+    # Even split with remainder absorbed by earlier edges
+    base = num // 4
+    rem = num % 4
+    counts = [base + (1 if i < rem else 0) for i in range(4)]  # T, R, B, L
+    blocks: list[ArchTile] = []
+    idx = 0
+
+    def make(name: str, x: float, y: float) -> ArchTile:
+        return ArchTile(
+            name=name, role=TileRole.MEMORY_CONTROLLER,
+            x_mm=x, y_mm=y, width_mm=side, height_mm=side,
+            notes=(
+                f"PHY block #{idx} of {num} "
+                f"(area {side * side:.2f} mm^2)"
+            ),
+        )
+
+    # Top edge: hug above the mesh
+    top_y = mesh_y + mesh_h
+    for i in range(counts[0]):
+        x = mesh_x + (i + 0.5) / counts[0] * mesh_w - side / 2
+        blocks.append(make(f"mc_top_{i}", x, top_y))
+        idx += 1
+    # Right edge: hug right of the mesh
+    right_x = mesh_x + mesh_w
+    for i in range(counts[1]):
+        y = mesh_y + (i + 0.5) / counts[1] * mesh_h - side / 2
+        blocks.append(make(f"mc_right_{i}", right_x, y))
+        idx += 1
+    # Bottom edge: hug below the mesh
+    bottom_y = mesh_y - side
+    for i in range(counts[2]):
+        x = mesh_x + (i + 0.5) / counts[2] * mesh_w - side / 2
+        blocks.append(make(f"mc_bottom_{i}", x, bottom_y))
+        idx += 1
+    # Left edge: hug left of the mesh
+    left_x = mesh_x - side
+    for i in range(counts[3]):
+        y = mesh_y + (i + 0.5) / counts[3] * mesh_h - side / 2
+        blocks.append(make(f"mc_left_{i}", left_x, y))
+        idx += 1
+    return blocks
+
+
+def _arch_place_control(
+    other_blocks: list[tuple[str, float, CircuitClass]],
+    mesh_origin_x: float, mesh_origin_y: float, die_height: float,
+) -> list[ArchTile]:
+    ctrl_blocks = [
+        (n, a, c) for n, a, c in other_blocks if "control" in n.lower()
+    ]
+    if not ctrl_blocks:
+        return []
+    total_area = sum(a for _, a, _ in ctrl_blocks)
+    side = math.sqrt(total_area) if total_area > 0 else 0.0
+    side = min(side, die_height * _CONTROL_CORNER_FRACTION)
+    if side <= 0:
+        return []
+    return [ArchTile(
+        name="control_logic", role=TileRole.CONTROL,
+        x_mm=mesh_origin_x, y_mm=mesh_origin_y,
+        width_mm=side, height_mm=side,
+        notes=f"Aggregates {len(ctrl_blocks)} control block(s)",
+    )]
+
+
+def _arch_what_if_estimates(
+    compute_pitches: dict[str, float],
+    memory_pitch: float,
+    total_compute_tiles: int,
+    mesh_rows: int,
+    mesh_cols: int,
+    edge_pad: float,
+) -> list[WhatIfDieEstimate]:
+    """One 'all-tiles-of-class-X' die estimate per compute class.
+
+    Periphery (IO ring + controller margin) is held constant -- the
+    interesting axis is how mesh size + whitespace move with the
+    chosen unified pitch.
+    """
+    out: list[WhatIfDieEstimate] = []
+    for class_name, class_pitch in compute_pitches.items():
+        unified = max(class_pitch, memory_pitch)
+        cell_area = unified * unified
+        physical_cols = 2 * mesh_cols
+        mesh_w = physical_cols * unified
+        mesh_h = mesh_rows * unified
+        mesh_area = mesh_w * mesh_h
+        # Whitespace inside compute cells + memory cells
+        compute_used = (class_pitch * class_pitch) * total_compute_tiles
+        memory_used = (memory_pitch * memory_pitch) * total_compute_tiles
+        whitespace = max(0.0, mesh_area - compute_used - memory_used)
+        die_w = mesh_w + 2 * edge_pad
+        die_h = mesh_h + 2 * edge_pad
+        die_area = die_w * die_h
+        out.append(WhatIfDieEstimate(
+            tile_class=class_name,
+            unified_pitch_mm=unified,
+            mesh_area_mm2=mesh_area,
+            die_area_mm2=die_area,
+            whitespace_mm2=whitespace,
+            whitespace_fraction=(
+                whitespace / mesh_area if mesh_area > 0 else 0.0
+            ),
+        ))
+    return out

--- a/src/graphs/hardware/silicon_floorplan.py
+++ b/src/graphs/hardware/silicon_floorplan.py
@@ -1,0 +1,541 @@
+"""KPU silicon floorplan derivation (Stage 8).
+
+Block-level transistor decomposition gives every silicon_bin entry an
+*area*. Areas live in 2D, and architecture imposes geometric constraints
+that area-only math misses:
+
+- KPU checkerboard: alternating compute and memory tiles must share a
+  pitch. If the compute-tile geometric pitch doesn't equal the
+  memory-tile pitch, the die either has whitespace (lower utilization)
+  or routes detour through dead silicon (longer wires, more energy).
+- Aspect ratios, IO ring placement, NoC routability, and chiplet-bridge
+  alignment are similar geometric constraints.
+
+This module turns a SKU's silicon_bin into a 2D layout estimate. The
+output feeds:
+
+- ``cli/show_floorplan.py`` -- ASCII / SVG visualization
+- ``sku_validators/validators/geometry.py`` -- the GEOMETRY category
+  validators (pitch-match, aspect-ratio bounds, die-envelope sanity)
+
+The KPU heuristic v1 (this module): assume every tile class shares the
+same physical pitch (the max across classes), derive per-tile area
+from PE-block area / num_tiles + per-tile L2/L3 SRAM area, place the
+mesh in the centre, memory PHYs along the right edge, and IO ring
+around the perimeter. Tile-class pitch *differences* surface as
+whitespace -- the floorplan reports them; the geometric validators
+flag them.
+
+Future work (per ``docs/designs/kpu-sku-and-process-node-plan.md``
+Stage 8): SVG visualization, NoC-routability validator, IO-ring
+validator, multi-architecture floorplanners (CPU, GPU).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+
+from embodied_schemas.kpu import KPUEntry, KPUTileSpec
+from embodied_schemas.process_node import CircuitClass, ProcessNodeEntry
+
+from .models.accelerators.kpu_yaml_loader import _DRAM_READ_PJ_PER_BYTE  # noqa: F401  (re-export not needed but keeps import group tidy)
+from .sku_validators.silicon_math import (
+    SiliconMathError,
+    resolve_block_area,
+)
+
+
+# ---------------------------------------------------------------------------
+# Floorplan dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class FloorplanBlock:
+    """One block placed in the 2D floorplan.
+
+    Coordinates use bottom-left-origin; (0, 0) is the lower-left corner
+    of the die. All units are millimetres.
+    """
+
+    name: str
+    """The silicon_bin block this rectangle represents, OR a synthetic
+    name like ``compute_tile[0,0]`` for individual mesh tiles."""
+
+    circuit_class: CircuitClass
+    """Library tag from the originating silicon_bin block (or the
+    dominant class for synthetic compute-tile blocks)."""
+
+    x_mm: float
+    y_mm: float
+    width_mm: float
+    height_mm: float
+
+    is_compute_tile: bool = False
+    """True for the per-tile rectangles in the compute mesh; False for
+    aggregate blocks (memory PHY, IO ring, control logic)."""
+
+    tile_class: Optional[str] = None
+    """For compute tiles, the tile class name (e.g., 'INT8-primary')."""
+
+    notes: str = ""
+
+    @property
+    def area_mm2(self) -> float:
+        return self.width_mm * self.height_mm
+
+    @property
+    def aspect_ratio(self) -> float:
+        """``max(w, h) / min(w, h)``. 1.0 = perfectly square; >2 is
+        commonly considered hard to route at modern nodes."""
+        wide = max(self.width_mm, self.height_mm)
+        tall = min(self.width_mm, self.height_mm)
+        return wide / tall if tall > 0 else float("inf")
+
+
+@dataclass(frozen=True)
+class TilePitch:
+    """Per-tile-class pitch summary for the geometric validators."""
+
+    tile_class: str
+    pe_area_mm2: float
+    sram_area_mm2: float
+    total_area_mm2: float
+    pitch_mm: float
+    """``sqrt(total_area_mm2)`` -- side length if the tile is square."""
+
+
+@dataclass(frozen=True)
+class Floorplan:
+    """A 2D placement of every silicon_bin block in a SKU."""
+
+    sku_id: str
+    sku_name: str
+    die_width_mm: float
+    die_height_mm: float
+    blocks: list[FloorplanBlock]
+    tile_pitches: dict[str, TilePitch] = field(default_factory=dict)
+    """Per-tile-class pitch summary (one entry per tile class)."""
+
+    unified_pitch_mm: float = 0.0
+    """The uniform pitch the floorplan uses for the mesh -- typically
+    the ``max(tile_pitches.values())`` so every tile class fits."""
+
+    notes: str = ""
+
+    @property
+    def die_area_mm2(self) -> float:
+        return self.die_width_mm * self.die_height_mm
+
+    def total_block_area_mm2(self) -> float:
+        return sum(b.area_mm2 for b in self.blocks)
+
+    def whitespace_mm2(self) -> float:
+        """Area inside the die not covered by any block. Sum of
+        ``unified_pitch - tile_class_pitch`` rectangles across tile
+        classes that don't fill the unified-pitch envelope."""
+        return max(0.0, self.die_area_mm2 - self.total_block_area_mm2())
+
+    def whitespace_fraction(self) -> float:
+        """Whitespace as a fraction of die area; 0 = perfectly tiled."""
+        if self.die_area_mm2 <= 0:
+            return 0.0
+        return self.whitespace_mm2() / self.die_area_mm2
+
+    def compute_tiles(self) -> list[FloorplanBlock]:
+        return [b for b in self.blocks if b.is_compute_tile]
+
+
+# ---------------------------------------------------------------------------
+# Per-tile area derivation
+# ---------------------------------------------------------------------------
+
+def _per_tile_pe_area_mm2(
+    sku: KPUEntry,
+    node: ProcessNodeEntry,
+    tile: KPUTileSpec,
+    pe_blocks_by_tile_type: dict[str, float],
+) -> float:
+    """PE-block area divided by num_tiles for this tile class.
+
+    The silicon_bin's pe_* blocks aggregate across all tiles in a class;
+    dividing by num_tiles gives the per-tile contribution.
+    """
+    aggregate_pe_area = pe_blocks_by_tile_type.get(tile.tile_type, 0.0)
+    if tile.num_tiles <= 0:
+        return 0.0
+    return aggregate_pe_area / tile.num_tiles
+
+
+def _per_tile_sram_area_mm2(
+    sku: KPUEntry,
+    node: ProcessNodeEntry,
+    chip_l2_area_mm2: float,
+    chip_l3_area_mm2: float,
+) -> float:
+    """Per-tile L2 + L3 SRAM area (chip-wide totals divided by num_tiles).
+
+    The KPU's M0.5 architecture has per-tile L2 (32 KiB typical) and
+    per-tile L3 (256 KiB scratchpad). silicon_bin reports them as
+    chip-wide aggregates; per-tile is aggregate / num_tiles.
+    """
+    total_tiles = sku.kpu_architecture.total_tiles
+    if total_tiles <= 0:
+        return 0.0
+    return (chip_l2_area_mm2 + chip_l3_area_mm2) / total_tiles
+
+
+def _classify_silicon_bin_blocks(
+    sku: KPUEntry, node: ProcessNodeEntry
+) -> tuple[
+    dict[str, float],         # pe_area by tile_type
+    float,                    # chip-wide L2 area
+    float,                    # chip-wide L3 area
+    list[tuple[str, float, CircuitClass]],  # other blocks: (name, area, class)
+]:
+    """Walk the silicon_bin once and bucket each block.
+
+    Buckets:
+      - PE blocks: collected per tile class (count_ref = "tile.<type>")
+      - L2 / L3 SRAM blocks: by count_ref (l2_total_kib / l3_total_kib)
+      - Everything else: passed through to the floorplan as a
+        non-mesh placed block (memory PHY, IO pads, control logic, NoC).
+    """
+    pe_area_by_tile_type: dict[str, float] = {}
+    chip_l2_area = 0.0
+    chip_l3_area = 0.0
+    other_blocks: list[tuple[str, float, CircuitClass]] = []
+
+    for block in sku.silicon_bin.blocks:
+        try:
+            ba = resolve_block_area(block, sku, node)
+        except SiliconMathError:
+            continue
+        ts = block.transistor_source
+        if ts.kind.value == "per_pe" and ts.count_ref and ts.count_ref.startswith("tile."):
+            tile_type = ts.count_ref.split(".", 1)[1]
+            pe_area_by_tile_type[tile_type] = (
+                pe_area_by_tile_type.get(tile_type, 0.0) + ba.area_mm2
+            )
+        elif ts.kind.value == "per_kib" and ts.count_ref == "l2_total_kib":
+            chip_l2_area += ba.area_mm2
+        elif ts.kind.value == "per_kib" and ts.count_ref == "l3_total_kib":
+            chip_l3_area += ba.area_mm2
+        else:
+            other_blocks.append((block.name, ba.area_mm2, block.circuit_class))
+
+    return pe_area_by_tile_type, chip_l2_area, chip_l3_area, other_blocks
+
+
+# ---------------------------------------------------------------------------
+# Floorplan derivation -- KPU M0.5
+# ---------------------------------------------------------------------------
+
+# Edge thicknesses for the IO ring + corner control region. Heuristic
+# placeholders; real silicon-floorplan tools derive these from pad pitch
+# and a chip-wide area budget. Reasonable defaults that produce sensible
+# floorplans across T64..T768.
+_IO_RING_THICKNESS_MM = 0.30
+_CONTROL_CORNER_FRACTION = 0.05  # Of die_height for the control square
+
+
+def derive_kpu_floorplan(
+    sku: KPUEntry, node: ProcessNodeEntry
+) -> Floorplan:
+    """Heuristic 2D floorplan for a KPU SKU.
+
+    Layout:
+
+    1. Compute the per-tile-class pitch:
+       ``pitch[c] = sqrt(per_tile_pe_area[c] + per_tile_sram_area)``.
+    2. Pick the unified mesh pitch as ``max(pitch[c])`` so every tile
+       class fits without overflow. Smaller-pitch classes leave
+       whitespace within their tile envelope -- the floorplan reports
+       that and the geometry validators flag it.
+    3. Place ``mesh_rows x mesh_cols`` compute tiles in a grid using
+       the unified pitch, in row-major order. Tile class assignment
+       follows the YAML's ``tile_mix`` proportions: INT8-primary fills
+       the bulk, then BF16-primary, then Matrix.
+    4. Place memory PHYs in a vertical strip on the RIGHT edge of the
+       mesh (typical KPU layout; controllers drive an LPDDR/HBM PHY
+       block adjacent to the mesh).
+    5. Place IO pads as a thin ring around the perimeter
+       (``_IO_RING_THICKNESS_MM`` thick).
+    6. Place control logic in the bottom-left corner (a small square
+       sized at ``_CONTROL_CORNER_FRACTION * die_height``).
+
+    The die rectangle is sized to fit all of the above with no
+    overlaps. NoC routers are *not* placed as separate blocks --
+    in real silicon they're embedded inside the tile envelopes.
+    """
+    arch = sku.kpu_architecture
+
+    # 1. Bucket silicon_bin blocks
+    pe_by_tile_type, chip_l2_area, chip_l3_area, other_blocks = (
+        _classify_silicon_bin_blocks(sku, node)
+    )
+
+    # 2. Per-tile-class pitch
+    per_tile_sram = _per_tile_sram_area_mm2(
+        sku, node, chip_l2_area, chip_l3_area
+    )
+    tile_pitches: dict[str, TilePitch] = {}
+    for tile in arch.tiles:
+        pe_area = _per_tile_pe_area_mm2(sku, node, tile, pe_by_tile_type)
+        total = pe_area + per_tile_sram
+        pitch = math.sqrt(total) if total > 0 else 0.0
+        tile_pitches[tile.tile_type] = TilePitch(
+            tile_class=tile.tile_type,
+            pe_area_mm2=pe_area,
+            sram_area_mm2=per_tile_sram,
+            total_area_mm2=total,
+            pitch_mm=pitch,
+        )
+
+    # 3. Unified mesh pitch
+    unified_pitch = max(
+        (tp.pitch_mm for tp in tile_pitches.values()),
+        default=0.0,
+    )
+
+    # 4. Place compute tiles in a row-major grid using tile_mix proportions.
+    #    Order: INT8-primary first, then BF16-primary, then Matrix
+    #    (matches the YAML's tile order convention).
+    mesh_rows = arch.noc.mesh_rows
+    mesh_cols = arch.noc.mesh_cols
+    mesh_width = mesh_cols * unified_pitch
+    mesh_height = mesh_rows * unified_pitch
+
+    # 5. Memory PHY strip on the right
+    total_phy_area = sum(
+        area for name, area, _ in other_blocks
+        if "phy" in name.lower() or "memory_phys" in name.lower()
+    )
+    phy_strip_width = (
+        total_phy_area / mesh_height if mesh_height > 0 else 0.0
+    )
+
+    # 6. Die dimensions: mesh + PHY strip + IO ring on all sides
+    die_width = mesh_width + phy_strip_width + 2 * _IO_RING_THICKNESS_MM
+    die_height = mesh_height + 2 * _IO_RING_THICKNESS_MM
+
+    blocks: list[FloorplanBlock] = []
+
+    # Place IO ring (4 edge rectangles)
+    blocks.extend(_place_io_ring(die_width, die_height, other_blocks))
+
+    # Place compute mesh tiles (origin offset by ring + nothing else; control
+    # corner overlays the bottom-left mesh-adjacent space)
+    mesh_origin_x = _IO_RING_THICKNESS_MM
+    mesh_origin_y = _IO_RING_THICKNESS_MM
+    blocks.extend(
+        _place_compute_mesh(
+            sku, mesh_origin_x, mesh_origin_y, unified_pitch
+        )
+    )
+
+    # Place memory PHY strip on the right
+    if phy_strip_width > 0:
+        blocks.extend(_place_memory_phys(
+            other_blocks,
+            x_mm=mesh_origin_x + mesh_width,
+            y_mm=mesh_origin_y,
+            width_mm=phy_strip_width,
+            height_mm=mesh_height,
+        ))
+
+    # Place control logic in the bottom-left corner (over the mesh,
+    # symbolizing the control bus that fans out to all tiles)
+    blocks.extend(_place_control(
+        other_blocks,
+        x_mm=mesh_origin_x,
+        y_mm=mesh_origin_y,
+        die_height=die_height,
+    ))
+
+    return Floorplan(
+        sku_id=sku.id,
+        sku_name=sku.name,
+        die_width_mm=die_width,
+        die_height_mm=die_height,
+        blocks=blocks,
+        tile_pitches=tile_pitches,
+        unified_pitch_mm=unified_pitch,
+        notes=(
+            f"Heuristic v1 floorplan: {mesh_rows}x{mesh_cols} mesh @ "
+            f"{unified_pitch:.3f} mm pitch, PHY strip + IO ring."
+        ),
+    )
+
+
+def _place_io_ring(
+    die_width_mm: float,
+    die_height_mm: float,
+    other_blocks: list[tuple[str, float, CircuitClass]],
+) -> list[FloorplanBlock]:
+    """Four edge rectangles forming the IO ring.
+
+    The ``io_pads`` silicon_bin block contributes the total IO area;
+    this function spreads it across the four edges proportional to
+    edge length. Each edge is ``_IO_RING_THICKNESS_MM`` thick.
+    """
+    io_area = sum(
+        area for name, area, _ in other_blocks
+        if "io" in name.lower() and "phy" not in name.lower()
+    )
+    if io_area <= 0:
+        return []
+    perimeter = 2 * (die_width_mm + die_height_mm)
+    if perimeter <= 0:
+        return []
+    # If the IO area exceeds what fits in the ring, the ring is "thick"
+    # and may be larger than _IO_RING_THICKNESS_MM. Solve for the actual
+    # thickness given total IO area + perimeter.
+    # area = perimeter * t - 4 * t^2  (correcting for corner overlap)
+    # For small t relative to die dimensions this is approximately
+    # area ~ perimeter * t. Use the simpler estimate; corner overlap
+    # is at most a small percentage.
+    thickness = min(io_area / perimeter, _IO_RING_THICKNESS_MM)
+
+    return [
+        # Bottom
+        FloorplanBlock(
+            name="io_ring_bottom",
+            circuit_class=CircuitClass.IO,
+            x_mm=0.0, y_mm=0.0,
+            width_mm=die_width_mm, height_mm=thickness,
+        ),
+        # Top
+        FloorplanBlock(
+            name="io_ring_top",
+            circuit_class=CircuitClass.IO,
+            x_mm=0.0, y_mm=die_height_mm - thickness,
+            width_mm=die_width_mm, height_mm=thickness,
+        ),
+        # Left
+        FloorplanBlock(
+            name="io_ring_left",
+            circuit_class=CircuitClass.IO,
+            x_mm=0.0, y_mm=thickness,
+            width_mm=thickness, height_mm=die_height_mm - 2 * thickness,
+        ),
+        # Right
+        FloorplanBlock(
+            name="io_ring_right",
+            circuit_class=CircuitClass.IO,
+            x_mm=die_width_mm - thickness, y_mm=thickness,
+            width_mm=thickness, height_mm=die_height_mm - 2 * thickness,
+        ),
+    ]
+
+
+def _place_compute_mesh(
+    sku: KPUEntry,
+    origin_x_mm: float,
+    origin_y_mm: float,
+    pitch_mm: float,
+) -> list[FloorplanBlock]:
+    """Place ``mesh_rows x mesh_cols`` compute tiles in row-major order.
+
+    Tile-class assignment cycles through ``arch.tiles`` in declaration
+    order (INT8-primary first, then BF16-primary, then Matrix), each
+    class taking ``num_tiles`` consecutive grid positions.
+    """
+    arch = sku.kpu_architecture
+    mesh_rows = arch.noc.mesh_rows
+    mesh_cols = arch.noc.mesh_cols
+    expected_total = mesh_rows * mesh_cols
+
+    # Build the tile-class assignment list
+    assignment: list[KPUTileSpec] = []
+    for tile in arch.tiles:
+        assignment.extend([tile] * tile.num_tiles)
+    # Pad with the last class if mesh has more positions than tiles declared
+    while len(assignment) < expected_total:
+        assignment.append(arch.tiles[-1])
+    # Truncate if tile_mix sums above mesh capacity
+    assignment = assignment[:expected_total]
+
+    blocks: list[FloorplanBlock] = []
+    for idx in range(expected_total):
+        row = idx // mesh_cols
+        col = idx % mesh_cols
+        tile = assignment[idx]
+        # Pick a representative circuit class for the tile (PE class)
+        cc = tile.pe_circuit_class
+        blocks.append(FloorplanBlock(
+            name=f"tile[{row},{col}]",
+            circuit_class=cc,
+            x_mm=origin_x_mm + col * pitch_mm,
+            y_mm=origin_y_mm + row * pitch_mm,
+            width_mm=pitch_mm,
+            height_mm=pitch_mm,
+            is_compute_tile=True,
+            tile_class=tile.tile_type,
+        ))
+    return blocks
+
+
+def _place_memory_phys(
+    other_blocks: list[tuple[str, float, CircuitClass]],
+    *,
+    x_mm: float,
+    y_mm: float,
+    width_mm: float,
+    height_mm: float,
+) -> list[FloorplanBlock]:
+    """Single PHY strip on the right side of the mesh.
+
+    Aggregates all memory_phys / *_phy blocks into one rectangle.
+    Future work: split into per-controller blocks for finer-grained
+    visualization.
+    """
+    phy_blocks = [
+        (name, area, cc) for name, area, cc in other_blocks
+        if "phy" in name.lower()
+    ]
+    if not phy_blocks:
+        return []
+    return [FloorplanBlock(
+        name="memory_phy_strip",
+        circuit_class=phy_blocks[0][2],  # Typically CircuitClass.ANALOG
+        x_mm=x_mm,
+        y_mm=y_mm,
+        width_mm=width_mm,
+        height_mm=height_mm,
+        notes=f"Aggregates {len(phy_blocks)} PHY block(s)",
+    )]
+
+
+def _place_control(
+    other_blocks: list[tuple[str, float, CircuitClass]],
+    *,
+    x_mm: float,
+    y_mm: float,
+    die_height: float,
+) -> list[FloorplanBlock]:
+    """Control logic in the bottom-left corner."""
+    ctrl_blocks = [
+        (name, area, cc) for name, area, cc in other_blocks
+        if "control" in name.lower()
+    ]
+    if not ctrl_blocks:
+        return []
+    total_area = sum(area for _, area, _ in ctrl_blocks)
+    side = math.sqrt(total_area) if total_area > 0 else 0.0
+    # Cap at a fraction of the die height to avoid the control block
+    # eating the mesh
+    side = min(side, die_height * _CONTROL_CORNER_FRACTION)
+    if side <= 0:
+        return []
+    return [FloorplanBlock(
+        name="control_logic",
+        circuit_class=ctrl_blocks[0][2],
+        x_mm=x_mm,
+        y_mm=y_mm,
+        width_mm=side,
+        height_mm=side,
+        notes=f"Aggregates {len(ctrl_blocks)} control block(s); "
+              f"placed in bottom-left corner",
+    )]

--- a/src/graphs/hardware/silicon_floorplan.py
+++ b/src/graphs/hardware/silicon_floorplan.py
@@ -687,6 +687,45 @@ class MemoryClassSummary:
 
 
 @dataclass(frozen=True)
+class MemoryChannel:
+    """Off-die DRAM channel + connectivity to its driving memory
+    controller.
+
+    Drawn just OUTSIDE the die boundary by the visualizer so the
+    architect can see (a) which controller drives which channel and
+    (b) how the channel-count + I/O width affect the overall die
+    geometry. Dimensions match the controller PHY block they pair
+    with; placement is exterior-aligned.
+    """
+
+    channel_id: int
+    """0..N-1 over all channels, walking the perimeter clockwise from
+    top-center."""
+
+    memory_type: str
+    """e.g., 'lpddr5', 'hbm3' -- from the KPU memory spec."""
+
+    width_bits: int
+    """Per-channel I/O width (``memory_bus_bits / memory_controllers``).
+    LPDDR5 typically 16, HBM3 stack 1024 (or 512 with two halves)."""
+
+    x_mm: float
+    y_mm: float
+    width_mm: float
+    height_mm: float
+    """Position + dimensions of the channel rectangle. Sits adjacent
+    to its controller on the outside of the die."""
+
+    controller_name: str
+    """Name of the corresponding ``ArchTile`` of role
+    ``MEMORY_CONTROLLER`` inside the die."""
+
+    edge: str
+    """'top', 'right', 'bottom', or 'left' -- which die edge this
+    channel sits beyond."""
+
+
+@dataclass(frozen=True)
 class WhatIfDieEstimate:
     """What the die would look like if every compute tile were one class.
 
@@ -736,6 +775,20 @@ class ArchitecturalFloorplan:
     what_if: list[WhatIfDieEstimate] = field(default_factory=list)
     """Per-class 'if every compute tile were class X' die estimates."""
 
+    memory_channels: list[MemoryChannel] = field(default_factory=list)
+    """Off-die DRAM channels paired 1:1 with the memory controllers
+    inside the die. Empty if the SKU's memory spec doesn't expose
+    channel info."""
+
+    memory_type: str = ""
+    """e.g., 'lpddr5', 'hbm3' from the SKU memory spec."""
+
+    per_channel_width_bits: int = 0
+    """Per-channel I/O width."""
+
+    per_channel_phy_area_mm2: float = 0.0
+    """Heuristic PHY area per channel; total MC area = num x this."""
+
     notes: str = ""
 
     @property
@@ -782,12 +835,82 @@ class ArchitecturalFloorplan:
 # Architectural derivation
 # ---------------------------------------------------------------------------
 
-# Default memory-controller arity when silicon_bin doesn't expose a
-# distinct count. 4 corresponds to one controller centered on each of
-# the four die edges -- typical of LPDDR-class accelerators. HBM-class
-# parts often want 8 (two per edge); the heuristic below upgrades to
-# match if silicon_bin contains multiple distinct PHY blocks.
+# Default memory-controller arity when the SKU memory spec doesn't
+# expose a distinct count. The architectural derivation prefers
+# ``sku.kpu_architecture.memory.memory_controllers`` when present.
 _DEFAULT_NUM_MEMORY_CONTROLLERS = 4
+
+
+# ---------------------------------------------------------------------------
+# Per-channel PHY heuristics (rectangular MCs)
+# ---------------------------------------------------------------------------
+#
+# Memory-controller PHY blocks are NOT proportional to compute-mesh
+# size -- they're proportional to the number + width of memory channels
+# they drive, and shaped by the I/O bump pattern of the package
+# interface:
+#
+#   * LPDDR{4,5,5X}: long narrow stripes parallel to the bump line
+#     (ball pitch sets the long edge; thin perpendicular dimension).
+#     Aspect ratio ~5:1.
+#   * DDR{4,5}: similar to LPDDR but slightly squarer (4:1).
+#   * GDDR6/6X: 3:1, sits next to GDDR packages on PCB.
+#   * HBM{2,2e,3,3e}: nearly square (1.5:1) microbump arrays sitting
+#     under the HBM stack via interposer.
+#
+# Per-channel area scales with channel width. Coefficients land in the
+# published-PHY-area ballpark for current-gen ~16nm logic; refine in
+# Stage 8c after PDK calibration.
+
+_PER_CHANNEL_PHY_AREA_MM2: dict = {
+    "lpddr4":  lambda w: 0.5 + 0.06 * w,    # 16b -> 1.46 mm^2
+    "lpddr4x": lambda w: 0.5 + 0.06 * w,
+    "lpddr5":  lambda w: 0.6 + 0.07 * w,    # 16b -> 1.72, 32b -> 2.84
+    "lpddr5x": lambda w: 0.6 + 0.07 * w,
+    "ddr4":    lambda w: 1.0 + 0.05 * w,    # 64b -> 4.20 mm^2
+    "ddr5":    lambda w: 1.2 + 0.06 * w,    # 64b -> 5.04
+    "gddr6":   lambda w: 0.8 + 0.06 * w,    # 32b -> 2.72
+    "gddr6x":  lambda w: 0.8 + 0.06 * w,
+    "hbm2":    lambda w: 1.5 + 0.012 * w,   # 1024b -> 13.79 (per stack)
+    "hbm2e":   lambda w: 1.5 + 0.012 * w,
+    "hbm3":    lambda w: 1.5 + 0.014 * w,   # 1024b -> 15.85, 512b -> 8.67
+    "hbm3e":   lambda w: 1.5 + 0.014 * w,
+}
+
+_PHY_ASPECT_RATIO: dict = {
+    "lpddr4":  5.0,
+    "lpddr4x": 5.0,
+    "lpddr5":  5.0,
+    "lpddr5x": 5.0,
+    "ddr4":    4.0,
+    "ddr5":    4.0,
+    "gddr6":   3.0,
+    "gddr6x":  3.0,
+    "hbm2":    1.5,
+    "hbm2e":   1.5,
+    "hbm3":    1.5,
+    "hbm3e":   1.5,
+}
+
+
+def _per_channel_phy_dims(memory_type: str, width_bits: int) -> tuple[float, float, float]:
+    """Per-channel PHY block dimensions (long_dim, short_dim, area_mm2).
+
+    long_dim is the dimension parallel to the I/O bump edge (sits along
+    the die edge); short_dim is perpendicular. For LPDDR
+    long >> short; for HBM long ~ short.
+    """
+    type_key = memory_type.lower()
+    area_fn = _PER_CHANNEL_PHY_AREA_MM2.get(
+        type_key, lambda w: 1.0 + 0.05 * w
+    )
+    aspect = _PHY_ASPECT_RATIO.get(type_key, 3.0)
+    area = area_fn(width_bits) if width_bits > 0 else 0.0
+    if area <= 0 or aspect <= 0:
+        return (0.0, 0.0, 0.0)
+    long_dim = math.sqrt(area * aspect)
+    short_dim = math.sqrt(area / aspect)
+    return (long_dim, short_dim, area)
 
 
 def derive_kpu_architectural_floorplan(
@@ -795,36 +918,36 @@ def derive_kpu_architectural_floorplan(
 ) -> ArchitecturalFloorplan:
     """Produce the architectural-role floorplan for a KPU SKU.
 
-    Layout (heuristic v1):
+    Layout (heuristic v2 -- corrected from v1):
 
     1. Per compute tile class: pitch = sqrt(per_tile_PE_area +
-       per_tile_L2_area).
-    2. Memory tile pitch = sqrt(per_tile_L3_area). One memory tile per
-       compute tile (1:1 pairing -- each compute tile owns its L3).
-    3. Unified pitch = max(max_compute_pitch, memory_pitch). Smaller
-       cells leave whitespace.
-    4. Physical mesh = ``mesh_rows x (2 * mesh_cols)``: every compute
-       tile is paired with a memory tile to its right (column-pair
-       checkerboard). True 2D checkerboards are also reasonable; this
-       layout was picked because it renders cleanly in ASCII and
-       preserves N/S compute-compute neighbours within the NoC.
-    5. Memory controllers: ``N`` distinct PHY blocks (or default 4) of
-       equal size, distributed around the perimeter clockwise from
-       top-center.
-    6. IO ring: thin pad ring around the perimeter.
-    7. Control: corner block.
-
-    NoC routers are not drawn -- they're embedded inside the tile
-    envelopes physically. A future SVG/HTML renderer can overlay the
-    NoC topology (mesh / ring / CLOS) on top of the placed blocks.
+       per_tile_L2_area). Memory tile pitch = sqrt(per_tile_L3_area).
+    2. Unified pitch = max(max_compute_pitch, memory_pitch).
+    3. **True 2D checkerboard**: physical mesh is
+       ``mesh_rows x (2 * mesh_cols)`` cells, with compute placed
+       where ``(row + col) % 2 == 0`` and memory where odd. Every
+       interior compute tile has 4 memory neighbours (N/S/E/W) and
+       vice versa.
+    4. **Memory controllers** = exactly ``memory.memory_controllers``
+       PHY blocks, sized from ``memory_type`` + ``per_channel_width``
+       (LPDDR is long narrow stripes, HBM is squarer microbump arrays;
+       see ``_per_channel_phy_dims``). Distributed as an edge ring;
+       MC area is independent of mesh size, scales only with channel
+       count + width.
+    5. **DRAM channels** placed *outside* the die boundary, each
+       paired 1:1 with its driving controller -- gives the architect
+       a visual of MC <-> channel connectivity and channel-count
+       impact on die geometry.
+    6. IO ring + control corner unchanged from v1.
     """
     arch = sku.kpu_architecture
+    mem = arch.memory
     pe_by_tile_type, chip_l2_area, chip_l3_area, other_blocks = (
         _classify_silicon_bin_blocks(sku, node)
     )
     total_compute_tiles = arch.total_tiles
 
-    # Per-tile L2 / L3 (shared by every compute / memory tile)
+    # Per-tile L2 / L3
     per_tile_l2 = (
         chip_l2_area / total_compute_tiles if total_compute_tiles > 0 else 0.0
     )
@@ -846,12 +969,11 @@ def derive_kpu_architectural_floorplan(
         compute_pitches[tile.tile_type] = pitch
         compute_pe_areas[tile.tile_type] = pe_area
 
-    # Unified pitch dominates compute and memory
     max_compute_pitch = max(compute_pitches.values(), default=0.0)
     unified_pitch = max(max_compute_pitch, memory_pitch)
     cell_area = unified_pitch * unified_pitch
 
-    # Per-class summaries with whitespace
+    # Per-class summaries
     compute_summaries: dict[str, ComputeClassSummary] = {}
     for tile in arch.tiles:
         pe_area = compute_pe_areas[tile.tile_type]
@@ -867,7 +989,6 @@ def derive_kpu_architectural_floorplan(
             whitespace_per_tile_mm2=ws_per_tile,
             class_whitespace_mm2=ws_per_tile * tile.num_tiles,
         )
-
     memory_ws_per_tile = max(0.0, cell_area - per_tile_l3)
     memory_summary = MemoryClassSummary(
         num_tiles=total_compute_tiles,
@@ -878,61 +999,99 @@ def derive_kpu_architectural_floorplan(
         class_whitespace_mm2=memory_ws_per_tile * total_compute_tiles,
     )
 
-    # Mesh rectangle
+    # Physical mesh rectangle: 2 * mesh_cols wide so total cells = 2N
+    # and a true 2D checkerboard places exactly N compute + N memory.
     mesh_rows = arch.noc.mesh_rows
     mesh_cols = arch.noc.mesh_cols
-    physical_cols = 2 * mesh_cols  # compute + memory pairs per row
+    physical_cols = 2 * mesh_cols
     mesh_width = physical_cols * unified_pitch
     mesh_height = mesh_rows * unified_pitch
 
-    # Memory controllers around the periphery
-    phy_blocks = [
-        (n, a, c) for (n, a, c) in other_blocks if "phy" in n.lower()
-    ]
-    phy_total_area = sum(a for _, a, _ in phy_blocks)
-    distinct_phys = len(phy_blocks)
+    # Memory configuration from the SKU schema (preferred) -- falls
+    # back to the silicon_bin PHY blocks + a default 4 if unset.
+    memory_type = mem.memory_type.value if mem.memory_type else "lpddr5"
     num_controllers = (
-        distinct_phys if distinct_phys > 1
+        mem.memory_controllers if mem.memory_controllers > 0
         else _DEFAULT_NUM_MEMORY_CONTROLLERS
     )
-    controller_side = (
-        math.sqrt(phy_total_area / num_controllers)
-        if num_controllers > 0 and phy_total_area > 0 else 0.0
+    bus_bits = mem.memory_bus_bits if mem.memory_bus_bits > 0 else 0
+    per_channel_width_bits = (
+        bus_bits // num_controllers if num_controllers > 0 else 0
+    )
+    long_dim, short_dim, per_channel_phy_area = _per_channel_phy_dims(
+        memory_type, per_channel_width_bits
     )
 
-    # Die envelope: mesh + controller margin on all 4 edges + IO ring
-    edge_pad = _IO_RING_THICKNESS_MM + controller_side
-    die_width = mesh_width + 2 * edge_pad
-    die_height = mesh_height + 2 * edge_pad
-    mesh_origin_x = edge_pad
-    mesh_origin_y = edge_pad
+    # Distribute channels across edges (equal split; remainder
+    # absorbed top -> right -> bottom -> left). Used both to size the
+    # die (so MCs fit their edge) and to lay them out below.
+    base_per_edge = num_controllers // 4
+    rem = num_controllers % 4
+    edge_counts_for_size = [
+        base_per_edge + (1 if i < rem else 0) for i in range(4)
+    ]
+    # Required edge length (x for top/bottom, y for left/right) =
+    # MCs-on-that-edge x long_dim. If the mesh edge is shorter than
+    # required, expand the die so the I/O perimeter actually fits --
+    # MC area is bump-pitch-driven, not mesh-driven, so the die
+    # follows the larger constraint.
+    required_horizontal_edge = (
+        max(edge_counts_for_size[0], edge_counts_for_size[2]) * long_dim
+    )
+    required_vertical_edge = (
+        max(edge_counts_for_size[1], edge_counts_for_size[3]) * long_dim
+    )
+    # Corner reservation: vertical MCs claim full die_h (corners
+    # belong to them); horizontal MCs are inset by short_dim on each
+    # x-side so they don't visually overlap vertical MCs in the corners.
+    # That means horizontal MCs need extra ``2 * short_dim`` of inner-x
+    # to fit; vertical MCs use the full inner-y.
+    extra_x = max(0.0, required_horizontal_edge + 2 * short_dim - mesh_width)
+    extra_y = max(0.0, required_vertical_edge - mesh_height)
+
+    # Die envelope: max(mesh, I/O perimeter) + IO ring + MC inset
+    mc_inset = short_dim
+    edge_pad = _IO_RING_THICKNESS_MM + mc_inset
+    die_width = mesh_width + extra_x + 2 * edge_pad
+    die_height = mesh_height + extra_y + 2 * edge_pad
+    # Mesh centered inside the (possibly-larger) inner area
+    mesh_origin_x = edge_pad + extra_x / 2
+    mesh_origin_y = edge_pad + extra_y / 2
 
     blocks: list[ArchTile] = []
 
-    # IO ring (4 thin edge segments at the very perimeter)
+    # IO ring
     blocks.extend(_arch_place_io_ring(die_width, die_height, other_blocks))
 
-    # Compute + memory tiles (column-pair checkerboard)
+    # Memory controllers (rectangular, sized by channel I/O width).
+    # Placed BEFORE the mesh so that the rasterizer's later-block-wins
+    # rule keeps mesh tiles on top at the mesh/MC boundary -- otherwise
+    # pixel quantization at shared edges paints the top mesh row with
+    # MC glyphs.
+    mc_blocks, channel_blocks = _arch_place_memory_subsystem(
+        num_channels=num_controllers,
+        memory_type=memory_type,
+        channel_width_bits=per_channel_width_bits,
+        long_dim=long_dim, short_dim=short_dim,
+        mesh_origin_x=mesh_origin_x, mesh_origin_y=mesh_origin_y,
+        mesh_width=mesh_width, mesh_height=mesh_height,
+        die_width=die_width, die_height=die_height,
+    )
+    blocks.extend(mc_blocks)
+
+    # Compute + memory tiles -- TRUE 2D checkerboard (drawn last so
+    # mesh wins shared pixels at the mesh/MC boundary).
     blocks.extend(_arch_place_checkerboard(
         arch, mesh_origin_x, mesh_origin_y, unified_pitch,
         per_tile_l2, per_tile_l3, compute_pe_areas,
     ))
 
-    # Memory controllers around the periphery
-    blocks.extend(_arch_place_memory_controllers(
-        num_controllers, controller_side, phy_blocks,
-        die_width, die_height,
-        mesh_origin_x, mesh_origin_y, mesh_width, mesh_height,
-    ))
-
-    # Control logic in bottom-left corner of the mesh
+    # Control logic
     blocks.extend(_arch_place_control(
         other_blocks, mesh_origin_x, mesh_origin_y, die_height
     ))
 
-    # What-if estimates: re-compute die area assuming every compute
-    # tile is class X. Periphery scales the same; mesh resizes around
-    # the new unified pitch.
+    # What-if estimates (periphery-aware: edge_pad held constant)
     what_if = _arch_what_if_estimates(
         compute_pitches, memory_pitch, total_compute_tiles,
         mesh_rows, mesh_cols, edge_pad,
@@ -949,11 +1108,17 @@ def derive_kpu_architectural_floorplan(
         num_memory_controllers=num_controllers,
         unified_pitch_mm=unified_pitch,
         what_if=what_if,
+        memory_channels=channel_blocks,
+        memory_type=memory_type,
+        per_channel_width_bits=per_channel_width_bits,
+        per_channel_phy_area_mm2=per_channel_phy_area,
         notes=(
-            f"Architectural v1: {mesh_rows}x{mesh_cols} compute + "
-            f"{mesh_rows}x{mesh_cols} memory in column-pair checkerboard "
-            f"@ {unified_pitch:.3f} mm pitch; {num_controllers} memory "
-            f"controllers around periphery."
+            f"Architectural v2: {mesh_rows}x{mesh_cols} mesh as true 2D "
+            f"checkerboard ({physical_cols}x{mesh_rows} cells) @ "
+            f"{unified_pitch:.3f} mm pitch; {num_controllers} {memory_type} "
+            f"channels @ {per_channel_width_bits}b each "
+            f"({per_channel_phy_area:.2f} mm^2 PHY/channel, "
+            f"{long_dim:.2f}x{short_dim:.2f} mm) distributed as edge ring."
         ),
     )
 
@@ -1006,113 +1171,216 @@ def _arch_place_checkerboard(
     per_tile_l3: float,
     compute_pe_areas: dict[str, float],
 ) -> list[ArchTile]:
-    """Lay out compute + memory tiles in a column-pair checkerboard.
+    """Lay out compute + memory tiles in a TRUE 2D checkerboard.
 
-    Pattern (every row identical):
-        [C M] [C M] [C M] [C M] ...
-    Each row has ``mesh_cols`` compute + ``mesh_cols`` memory tiles.
-    Compute classes assigned in row-major order over compute positions.
+    Physical mesh: ``mesh_rows`` rows x ``2 * mesh_cols`` cols. Cell
+    is COMPUTE iff ``(row + col) % 2 == 0``, MEMORY otherwise. Every
+    interior compute tile has 4 memory neighbours (N/S/E/W) and vice
+    versa -- the L3 scratchpad is reachable from every direction.
+
+    Pattern (rows alternate offset by one):
+        C M C M C M C M C M C M ...
+        M C M C M C M C M C M C ...
+        C M C M C M C M C M C M ...
+        M C M C M C M C M C M C ...
+
+    Compute tile-class assignment: row-major walk over the compute
+    positions only, drawing from ``arch.tiles`` in declaration order.
     """
     mesh_rows = arch.noc.mesh_rows
     mesh_cols = arch.noc.mesh_cols
+    physical_cols = 2 * mesh_cols
+    expected_compute = mesh_rows * mesh_cols  # half the physical cells
 
-    # Tile-class assignment for compute positions (row-major)
+    # Compute-class assignment (in declaration order)
     compute_assignment: list[KPUTileSpec] = []
     for tile in arch.tiles:
         compute_assignment.extend([tile] * tile.num_tiles)
-    while len(compute_assignment) < mesh_rows * mesh_cols:
+    while len(compute_assignment) < expected_compute:
         compute_assignment.append(arch.tiles[-1])
-    compute_assignment = compute_assignment[: mesh_rows * mesh_cols]
+    compute_assignment = compute_assignment[:expected_compute]
 
     blocks: list[ArchTile] = []
     compute_idx = 0
     for r in range(mesh_rows):
-        for c_pair in range(mesh_cols):
-            # Compute tile (left half of the pair)
-            tile = compute_assignment[compute_idx]
-            compute_idx += 1
-            blocks.append(ArchTile(
-                name=f"compute[{r},{c_pair}]",
-                role=TileRole.COMPUTE,
-                x_mm=origin_x + (2 * c_pair) * pitch,
-                y_mm=origin_y + r * pitch,
-                width_mm=pitch,
-                height_mm=pitch,
-                tile_class=tile.tile_type,
-                pe_area_mm2=compute_pe_areas.get(tile.tile_type, 0.0),
-                l2_area_mm2=per_tile_l2,
-            ))
-            # Memory tile (right half of the pair)
-            blocks.append(ArchTile(
-                name=f"memory[{r},{c_pair}]",
-                role=TileRole.MEMORY,
-                x_mm=origin_x + (2 * c_pair + 1) * pitch,
-                y_mm=origin_y + r * pitch,
-                width_mm=pitch,
-                height_mm=pitch,
-                l3_area_mm2=per_tile_l3,
-            ))
+        for c in range(physical_cols):
+            x = origin_x + c * pitch
+            y = origin_y + r * pitch
+            if (r + c) % 2 == 0:
+                tile = compute_assignment[compute_idx]
+                compute_idx += 1
+                blocks.append(ArchTile(
+                    name=f"compute[{r},{c}]",
+                    role=TileRole.COMPUTE,
+                    x_mm=x, y_mm=y, width_mm=pitch, height_mm=pitch,
+                    tile_class=tile.tile_type,
+                    pe_area_mm2=compute_pe_areas.get(tile.tile_type, 0.0),
+                    l2_area_mm2=per_tile_l2,
+                ))
+            else:
+                blocks.append(ArchTile(
+                    name=f"memory[{r},{c}]",
+                    role=TileRole.MEMORY,
+                    x_mm=x, y_mm=y, width_mm=pitch, height_mm=pitch,
+                    l3_area_mm2=per_tile_l3,
+                ))
     return blocks
 
 
-def _arch_place_memory_controllers(
-    num: int,
-    side: float,
-    phy_blocks: list[tuple[str, float, CircuitClass]],
-    die_w: float, die_h: float,
-    mesh_x: float, mesh_y: float,
-    mesh_w: float, mesh_h: float,
-) -> list[ArchTile]:
-    """Distribute ``num`` controllers around the perimeter.
+def _arch_place_memory_subsystem(
+    *,
+    num_channels: int,
+    memory_type: str,
+    channel_width_bits: int,
+    long_dim: float,
+    short_dim: float,
+    mesh_origin_x: float, mesh_origin_y: float,
+    mesh_width: float, mesh_height: float,
+    die_width: float, die_height: float,
+) -> tuple[list[ArchTile], list[MemoryChannel]]:
+    """Place rectangular memory controllers + their off-die channels.
 
-    Walk: top edge first, then right, bottom, left, in order. Each edge
-    gets ``num // 4`` plus a remainder. Controllers sit just inside
-    the IO ring, hugging the mesh on the outer side.
+    Walks the perimeter clockwise from top-center, distributing
+    ``num_channels`` controllers as an edge ring. Each MC has the
+    long dimension parallel to its edge (matching the I/O bump
+    pattern), short dimension perpendicular. The corresponding DRAM
+    channel sits just *outside* the die boundary, mirroring the MC's
+    shape so MC <-> channel association is visually obvious.
+
+    Distribution: equal split across 4 edges; remainder absorbed top
+    -> right -> bottom -> left so high channel counts (16 LPDDR ch
+    on T256) get a balanced ring. Future Stage 8c work: bias HBM to
+    interposer-stack edges only.
     """
-    if num <= 0 or side <= 0:
-        return []
-    # Even split with remainder absorbed by earlier edges
-    base = num // 4
-    rem = num % 4
-    counts = [base + (1 if i < rem else 0) for i in range(4)]  # T, R, B, L
-    blocks: list[ArchTile] = []
-    idx = 0
+    if num_channels <= 0 or long_dim <= 0 or short_dim <= 0:
+        return ([], [])
 
-    def make(name: str, x: float, y: float) -> ArchTile:
-        return ArchTile(
-            name=name, role=TileRole.MEMORY_CONTROLLER,
-            x_mm=x, y_mm=y, width_mm=side, height_mm=side,
-            notes=(
-                f"PHY block #{idx} of {num} "
-                f"(area {side * side:.2f} mm^2)"
-            ),
-        )
+    base = num_channels // 4
+    rem = num_channels % 4
+    edge_counts = [base + (1 if i < rem else 0) for i in range(4)]
 
-    # Top edge: hug above the mesh
-    top_y = mesh_y + mesh_h
-    for i in range(counts[0]):
-        x = mesh_x + (i + 0.5) / counts[0] * mesh_w - side / 2
-        blocks.append(make(f"mc_top_{i}", x, top_y))
-        idx += 1
-    # Right edge: hug right of the mesh
-    right_x = mesh_x + mesh_w
-    for i in range(counts[1]):
-        y = mesh_y + (i + 0.5) / counts[1] * mesh_h - side / 2
-        blocks.append(make(f"mc_right_{i}", right_x, y))
-        idx += 1
-    # Bottom edge: hug below the mesh
-    bottom_y = mesh_y - side
-    for i in range(counts[2]):
-        x = mesh_x + (i + 0.5) / counts[2] * mesh_w - side / 2
-        blocks.append(make(f"mc_bottom_{i}", x, bottom_y))
-        idx += 1
-    # Left edge: hug left of the mesh
-    left_x = mesh_x - side
-    for i in range(counts[3]):
-        y = mesh_y + (i + 0.5) / counts[3] * mesh_h - side / 2
-        blocks.append(make(f"mc_left_{i}", left_x, y))
-        idx += 1
-    return blocks
+    mc_blocks: list[ArchTile] = []
+    channel_blocks: list[MemoryChannel] = []
+    chan_id = 0
+
+    # Channel rectangle sits short_dim outside the die, mirroring the
+    # MC's cross-section so MC<->channel alignment is visually obvious.
+    channel_offset = short_dim
+
+    # Inner-edge ranges (MC distribution domain). The die may have been
+    # expanded to fit the I/O perimeter; MCs distribute over the FULL
+    # inner extent (mesh + any I/O-driven extras), not just the mesh.
+    #
+    # Corner reservation: vertical MCs (left/right) use the full inner
+    # y-range and claim the corner regions. Horizontal MCs (top/bottom)
+    # inset by short_dim on each x-side so they don't visually overlap
+    # vertical MCs in the corners.
+    edge_pad_inner = _IO_RING_THICKNESS_MM + short_dim    # = edge_pad
+    inner_x_lo_horiz = edge_pad_inner + short_dim   # inset for corner
+    inner_x_hi_horiz = die_width - edge_pad_inner - short_dim
+    inner_w_horiz = inner_x_hi_horiz - inner_x_lo_horiz
+
+    inner_y_lo_vert = edge_pad_inner   # vertical MCs span full inner
+    inner_y_hi_vert = die_height - edge_pad_inner
+    inner_h_vert = inner_y_hi_vert - inner_y_lo_vert
+
+    def _ch_note(ch_id: int) -> str:
+        return f"channel {ch_id} ({memory_type} {channel_width_bits}b)"
+
+    # Top edge: MC sits just above the mesh (y = mesh_origin_y +
+    # mesh_height); width = long_dim, height = short_dim. Inset from
+    # corners so vertical MCs claim them.
+    if edge_counts[0] > 0 and inner_w_horiz > 0:
+        n = edge_counts[0]
+        for i in range(n):
+            x = inner_x_lo_horiz + (i + 0.5) / n * inner_w_horiz - long_dim / 2
+            mc_y = mesh_origin_y + mesh_height
+            mc_name = f"mc_top_ch{chan_id}"
+            mc_blocks.append(ArchTile(
+                name=mc_name, role=TileRole.MEMORY_CONTROLLER,
+                x_mm=x, y_mm=mc_y,
+                width_mm=long_dim, height_mm=short_dim,
+                notes=_ch_note(chan_id),
+            ))
+            channel_blocks.append(MemoryChannel(
+                channel_id=chan_id, memory_type=memory_type,
+                width_bits=channel_width_bits,
+                x_mm=x, y_mm=die_height,
+                width_mm=long_dim, height_mm=channel_offset,
+                controller_name=mc_name, edge="top",
+            ))
+            chan_id += 1
+
+    # Right edge: MC sits just right of the mesh; width = short_dim,
+    # height = long_dim along the edge. Spans full inner y including
+    # corners.
+    if edge_counts[1] > 0 and inner_h_vert > 0:
+        n = edge_counts[1]
+        for i in range(n):
+            y = inner_y_lo_vert + (i + 0.5) / n * inner_h_vert - long_dim / 2
+            mc_x = mesh_origin_x + mesh_width
+            mc_name = f"mc_right_ch{chan_id}"
+            mc_blocks.append(ArchTile(
+                name=mc_name, role=TileRole.MEMORY_CONTROLLER,
+                x_mm=mc_x, y_mm=y,
+                width_mm=short_dim, height_mm=long_dim,
+                notes=_ch_note(chan_id),
+            ))
+            channel_blocks.append(MemoryChannel(
+                channel_id=chan_id, memory_type=memory_type,
+                width_bits=channel_width_bits,
+                x_mm=die_width, y_mm=y,
+                width_mm=channel_offset, height_mm=long_dim,
+                controller_name=mc_name, edge="right",
+            ))
+            chan_id += 1
+
+    # Bottom edge: MC sits just below the mesh. Inset from corners.
+    if edge_counts[2] > 0 and inner_w_horiz > 0:
+        n = edge_counts[2]
+        for i in range(n):
+            x = inner_x_lo_horiz + (i + 0.5) / n * inner_w_horiz - long_dim / 2
+            mc_y = mesh_origin_y - short_dim
+            mc_name = f"mc_bottom_ch{chan_id}"
+            mc_blocks.append(ArchTile(
+                name=mc_name, role=TileRole.MEMORY_CONTROLLER,
+                x_mm=x, y_mm=mc_y,
+                width_mm=long_dim, height_mm=short_dim,
+                notes=_ch_note(chan_id),
+            ))
+            channel_blocks.append(MemoryChannel(
+                channel_id=chan_id, memory_type=memory_type,
+                width_bits=channel_width_bits,
+                x_mm=x, y_mm=-channel_offset,
+                width_mm=long_dim, height_mm=channel_offset,
+                controller_name=mc_name, edge="bottom",
+            ))
+            chan_id += 1
+
+    # Left edge: MC sits just left of the mesh. Spans full inner y
+    # including corners.
+    if edge_counts[3] > 0 and inner_h_vert > 0:
+        n = edge_counts[3]
+        for i in range(n):
+            y = inner_y_lo_vert + (i + 0.5) / n * inner_h_vert - long_dim / 2
+            mc_x = mesh_origin_x - short_dim
+            mc_name = f"mc_left_ch{chan_id}"
+            mc_blocks.append(ArchTile(
+                name=mc_name, role=TileRole.MEMORY_CONTROLLER,
+                x_mm=mc_x, y_mm=y,
+                width_mm=short_dim, height_mm=long_dim,
+                notes=_ch_note(chan_id),
+            ))
+            channel_blocks.append(MemoryChannel(
+                channel_id=chan_id, memory_type=memory_type,
+                width_bits=channel_width_bits,
+                x_mm=-channel_offset, y_mm=y,
+                width_mm=channel_offset, height_mm=long_dim,
+                controller_name=mc_name, edge="left",
+            ))
+            chan_id += 1
+
+    return (mc_blocks, channel_blocks)
 
 
 def _arch_place_control(

--- a/src/graphs/hardware/silicon_floorplan.py
+++ b/src/graphs/hardware/silicon_floorplan.py
@@ -1086,9 +1086,11 @@ def derive_kpu_architectural_floorplan(
         per_tile_l2, per_tile_l3, compute_pe_areas,
     ))
 
-    # Control logic
+    # Control logic (bottom-left corner gap, outside the mesh)
     blocks.extend(_arch_place_control(
-        other_blocks, mesh_origin_x, mesh_origin_y, die_height
+        other_blocks,
+        mesh_origin_x=mesh_origin_x, mesh_origin_y=mesh_origin_y,
+        short_dim=short_dim, die_height=die_height,
     ))
 
     # What-if estimates (periphery-aware: edge_pad held constant)
@@ -1128,16 +1130,23 @@ def _arch_place_io_ring(
     die_height_mm: float,
     other_blocks: list[tuple[str, float, CircuitClass]],
 ) -> list[ArchTile]:
+    """Pad ring around the perimeter.
+
+    Ring thickness is fixed at ``_IO_RING_THICKNESS_MM`` (typical pad-
+    pitch depth for current packages) regardless of silicon_bin
+    io_pads area -- the pad count drives how many pads fit, not how
+    deep the ring sits. Earlier code scaled thickness by
+    ``io_area/perimeter``, which collapsed the ring below visual
+    resolution when io_pads was small (1 character cell renders only
+    when the rect is at least mm_per_col wide).
+    """
     io_area = sum(
         a for n, a, _ in other_blocks
         if "io" in n.lower() and "phy" not in n.lower()
     )
     if io_area <= 0:
         return []
-    perimeter = 2 * (die_width_mm + die_height_mm)
-    if perimeter <= 0:
-        return []
-    thickness = min(io_area / perimeter, _IO_RING_THICKNESS_MM)
+    thickness = _IO_RING_THICKNESS_MM
     return [
         ArchTile(
             name="io_ring_bottom", role=TileRole.IO_PAD,
@@ -1385,23 +1394,52 @@ def _arch_place_memory_subsystem(
 
 def _arch_place_control(
     other_blocks: list[tuple[str, float, CircuitClass]],
-    mesh_origin_x: float, mesh_origin_y: float, die_height: float,
+    *,
+    mesh_origin_x: float,
+    mesh_origin_y: float,
+    short_dim: float,
+    die_height: float,
 ) -> list[ArchTile]:
+    """Place control logic in the bottom-left corner GAP.
+
+    With the v2 layout the bottom-left corner has a small unclaimed
+    region: the bottom IO ring is at y < IO, the bottom horizontal MC
+    starts at x = IO + 2*short_dim, and the left vertical MC starts at
+    y = IO + short_dim. That leaves a rectangle of size
+    ``2*short_dim x short_dim`` at ``(IO, IO)`` available for control,
+    OUTSIDE the mesh. The previous version sat inside the mesh and
+    overlapped the bottom-left compute tile.
+    """
     ctrl_blocks = [
         (n, a, c) for n, a, c in other_blocks if "control" in n.lower()
     ]
     if not ctrl_blocks:
         return []
     total_area = sum(a for _, a, _ in ctrl_blocks)
-    side = math.sqrt(total_area) if total_area > 0 else 0.0
-    side = min(side, die_height * _CONTROL_CORNER_FRACTION)
-    if side <= 0:
+    if total_area <= 0:
+        return []
+    # Available corner gap: max width = 2*short_dim, max height = short_dim.
+    # Scale the silicon_bin's control block to fit inside this envelope
+    # with the same aspect ratio.
+    gap_w = 2 * short_dim
+    gap_h = short_dim
+    if gap_w <= 0 or gap_h <= 0:
+        return []
+    # Square-ish control block (side derived from area, capped by gap)
+    side = math.sqrt(total_area)
+    width = min(side, gap_w)
+    height = min(side, gap_h)
+    if width <= 0 or height <= 0:
         return []
     return [ArchTile(
         name="control_logic", role=TileRole.CONTROL,
-        x_mm=mesh_origin_x, y_mm=mesh_origin_y,
-        width_mm=side, height_mm=side,
-        notes=f"Aggregates {len(ctrl_blocks)} control block(s)",
+        x_mm=_IO_RING_THICKNESS_MM,
+        y_mm=_IO_RING_THICKNESS_MM,
+        width_mm=width, height_mm=height,
+        notes=(
+            f"Aggregates {len(ctrl_blocks)} control block(s); "
+            f"placed in bottom-left corner gap (outside mesh)"
+        ),
     )]
 
 

--- a/src/graphs/hardware/silicon_floorplan.py
+++ b/src/graphs/hardware/silicon_floorplan.py
@@ -33,15 +33,18 @@ validator, multi-architecture floorplanners (CPU, GPU).
 
 from __future__ import annotations
 
+import logging
 import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
 
+
+_logger = logging.getLogger(__name__)
+
 from embodied_schemas.kpu import KPUEntry, KPUTileSpec
 from embodied_schemas.process_node import CircuitClass, ProcessNodeEntry
 
-from .models.accelerators.kpu_yaml_loader import _DRAM_READ_PJ_PER_BYTE  # noqa: F401  (re-export not needed but keeps import group tidy)
 from .sku_validators.silicon_math import (
     SiliconMathError,
     resolve_block_area,
@@ -211,7 +214,18 @@ def _classify_silicon_bin_blocks(
     for block in sku.silicon_bin.blocks:
         try:
             ba = resolve_block_area(block, sku, node)
-        except SiliconMathError:
+        except SiliconMathError as exc:
+            # Don't silently drop -- log so the missing area surfaces in
+            # the floorplan output, but keep going so a single bad
+            # silicon_bin block doesn't kill the whole visualizer for
+            # an otherwise-valid SKU. The GEOMETRY validators (which
+            # care about correctness) call resolve_block_area
+            # independently and will surface the same failure as a
+            # finding.
+            _logger.warning(
+                "silicon_floorplan: skipping block %r in sku %r: %s",
+                block.name, sku.id, exc,
+            )
             continue
         ts = block.transistor_source
         if ts.kind.value == "per_pe" and ts.count_ref and ts.count_ref.startswith("tile."):
@@ -377,9 +391,12 @@ def _place_io_ring(
 ) -> list[FloorplanBlock]:
     """Four edge rectangles forming the IO ring.
 
-    The ``io_pads`` silicon_bin block contributes the total IO area;
-    this function spreads it across the four edges proportional to
-    edge length. Each edge is ``_IO_RING_THICKNESS_MM`` thick.
+    Uses ``_IO_RING_THICKNESS_MM`` (typical pad-pitch depth) regardless
+    of silicon_bin io_pads area -- pad count and pad-ring depth are
+    different concerns. ``derive_kpu_floorplan`` reserves
+    ``2 * _IO_RING_THICKNESS_MM`` of die margin on each axis assuming
+    this same thickness; using the area-derived value here would
+    create a moat between the ring and the rest of the die.
     """
     io_area = sum(
         area for name, area, _ in other_blocks
@@ -387,17 +404,7 @@ def _place_io_ring(
     )
     if io_area <= 0:
         return []
-    perimeter = 2 * (die_width_mm + die_height_mm)
-    if perimeter <= 0:
-        return []
-    # If the IO area exceeds what fits in the ring, the ring is "thick"
-    # and may be larger than _IO_RING_THICKNESS_MM. Solve for the actual
-    # thickness given total IO area + perimeter.
-    # area = perimeter * t - 4 * t^2  (correcting for corner overlap)
-    # For small t relative to die dimensions this is approximately
-    # area ~ perimeter * t. Use the simpler estimate; corner overlap
-    # is at most a small percentage.
-    thickness = min(io_area / perimeter, _IO_RING_THICKNESS_MM)
+    thickness = _IO_RING_THICKNESS_MM
 
     return [
         # Bottom
@@ -444,6 +451,11 @@ def _place_compute_mesh(
     class taking ``num_tiles`` consecutive grid positions.
     """
     arch = sku.kpu_architecture
+    if not arch.tiles:
+        raise ValueError(
+            f"sku {sku.id!r}: kpu_architecture.tiles is empty; cannot "
+            f"place a compute mesh"
+        )
     mesh_rows = arch.noc.mesh_rows
     mesh_cols = arch.noc.mesh_cols
     expected_total = mesh_rows * mesh_cols
@@ -1196,6 +1208,11 @@ def _arch_place_checkerboard(
     Compute tile-class assignment: row-major walk over the compute
     positions only, drawing from ``arch.tiles`` in declaration order.
     """
+    if not arch.tiles:
+        raise ValueError(
+            "kpu_architecture.tiles is empty; architectural floorplan "
+            "needs at least one tile class"
+        )
     mesh_rows = arch.noc.mesh_rows
     mesh_cols = arch.noc.mesh_cols
     physical_cols = 2 * mesh_cols
@@ -1296,14 +1313,22 @@ def _arch_place_memory_subsystem(
     def _ch_note(ch_id: int) -> str:
         return f"channel {ch_id} ({memory_type} {channel_width_bits}b)"
 
-    # Top edge: MC sits just above the mesh (y = mesh_origin_y +
-    # mesh_height); width = long_dim, height = short_dim. Inset from
-    # corners so vertical MCs claim them.
+    # Top edge: MC anchored to die top (just inside top IO ring), NOT
+    # to mesh top -- otherwise when extra_y > 0 the MC floats inside
+    # the die instead of hugging the edge. Same for the other 3 edges
+    # below.
+    mc_top_y = die_height - _IO_RING_THICKNESS_MM - short_dim
+    mc_bottom_y = _IO_RING_THICKNESS_MM
+    mc_right_x = die_width - _IO_RING_THICKNESS_MM - short_dim
+    mc_left_x = _IO_RING_THICKNESS_MM
+
+    # Top edge: MC sits just inside the top IO ring; width = long_dim,
+    # height = short_dim. Inset from corners so vertical MCs claim them.
     if edge_counts[0] > 0 and inner_w_horiz > 0:
         n = edge_counts[0]
         for i in range(n):
             x = inner_x_lo_horiz + (i + 0.5) / n * inner_w_horiz - long_dim / 2
-            mc_y = mesh_origin_y + mesh_height
+            mc_y = mc_top_y
             mc_name = f"mc_top_ch{chan_id}"
             mc_blocks.append(ArchTile(
                 name=mc_name, role=TileRole.MEMORY_CONTROLLER,
@@ -1320,14 +1345,14 @@ def _arch_place_memory_subsystem(
             ))
             chan_id += 1
 
-    # Right edge: MC sits just right of the mesh; width = short_dim,
-    # height = long_dim along the edge. Spans full inner y including
-    # corners.
+    # Right edge: MC anchored to die right (just inside right IO ring);
+    # width = short_dim, height = long_dim. Spans full inner y
+    # including corners.
     if edge_counts[1] > 0 and inner_h_vert > 0:
         n = edge_counts[1]
         for i in range(n):
             y = inner_y_lo_vert + (i + 0.5) / n * inner_h_vert - long_dim / 2
-            mc_x = mesh_origin_x + mesh_width
+            mc_x = mc_right_x
             mc_name = f"mc_right_ch{chan_id}"
             mc_blocks.append(ArchTile(
                 name=mc_name, role=TileRole.MEMORY_CONTROLLER,
@@ -1344,12 +1369,13 @@ def _arch_place_memory_subsystem(
             ))
             chan_id += 1
 
-    # Bottom edge: MC sits just below the mesh. Inset from corners.
+    # Bottom edge: MC anchored to die bottom (just above bottom IO
+    # ring). Inset from corners.
     if edge_counts[2] > 0 and inner_w_horiz > 0:
         n = edge_counts[2]
         for i in range(n):
             x = inner_x_lo_horiz + (i + 0.5) / n * inner_w_horiz - long_dim / 2
-            mc_y = mesh_origin_y - short_dim
+            mc_y = mc_bottom_y
             mc_name = f"mc_bottom_ch{chan_id}"
             mc_blocks.append(ArchTile(
                 name=mc_name, role=TileRole.MEMORY_CONTROLLER,
@@ -1366,13 +1392,13 @@ def _arch_place_memory_subsystem(
             ))
             chan_id += 1
 
-    # Left edge: MC sits just left of the mesh. Spans full inner y
-    # including corners.
+    # Left edge: MC anchored to die left (just inside left IO ring).
+    # Spans full inner y including corners.
     if edge_counts[3] > 0 and inner_h_vert > 0:
         n = edge_counts[3]
         for i in range(n):
             y = inner_y_lo_vert + (i + 0.5) / n * inner_h_vert - long_dim / 2
-            mc_x = mesh_origin_x - short_dim
+            mc_x = mc_left_x
             mc_name = f"mc_left_ch{chan_id}"
             mc_blocks.append(ArchTile(
                 name=mc_name, role=TileRole.MEMORY_CONTROLLER,
@@ -1460,7 +1486,6 @@ def _arch_what_if_estimates(
     out: list[WhatIfDieEstimate] = []
     for class_name, class_pitch in compute_pitches.items():
         unified = max(class_pitch, memory_pitch)
-        cell_area = unified * unified
         physical_cols = 2 * mesh_cols
         mesh_w = physical_cols * unified
         mesh_h = mesh_rows * unified

--- a/src/graphs/hardware/sku_validators/validators/__init__.py
+++ b/src/graphs/hardware/sku_validators/validators/__init__.py
@@ -13,8 +13,15 @@ Phase 2b validator modules:
                composite_density_envelope (AREA)
 - energy:      tops_per_watt_envelope (ENERGY)
 
-Stage-2c / 2d / Stage-8 modules will be appended here as new validators
-arrive.
+Phase 2c/2d additions:
+
+- thermal:     thermal_hotspot (THERMAL)
+- reliability: electromigration (RELIABILITY)
+
+Stage 8 additions (heuristic-v1 floorplan; advisory until calibrated):
+
+- geometry:    floorplan_pitch_match, floorplan_within_die_envelope,
+               floorplan_aspect_ratio (GEOMETRY)
 """
 
 # Importing each module triggers the @register_class decorators inside.
@@ -22,5 +29,6 @@ from . import area  # noqa: F401
 from . import consistency  # noqa: F401
 from . import electrical  # noqa: F401
 from . import energy  # noqa: F401
+from . import geometry  # noqa: F401
 from . import reliability  # noqa: F401
 from . import thermal  # noqa: F401

--- a/src/graphs/hardware/sku_validators/validators/__init__.py
+++ b/src/graphs/hardware/sku_validators/validators/__init__.py
@@ -18,10 +18,17 @@ Phase 2c/2d additions:
 - thermal:     thermal_hotspot (THERMAL)
 - reliability: electromigration (RELIABILITY)
 
-Stage 8 additions (heuristic-v1 floorplan; advisory until calibrated):
+Stage 8a additions (circuit-class floorplan; advisory until calibrated):
 
 - geometry:    floorplan_pitch_match, floorplan_within_die_envelope,
                floorplan_aspect_ratio (GEOMETRY)
+
+Stage 8b additions (architectural-role floorplan; advisory):
+
+- geometry:    floorplan_compute_memory_pitch_match (the primary KPU
+               checkerboard concern), floorplan_whitespace_fraction
+               (with what-if-all-class-X die-area shrink suggestion)
+               (GEOMETRY)
 """
 
 # Importing each module triggers the @register_class decorators inside.

--- a/src/graphs/hardware/sku_validators/validators/geometry.py
+++ b/src/graphs/hardware/sku_validators/validators/geometry.py
@@ -28,7 +28,10 @@ from __future__ import annotations
 
 from typing import List
 
-from ...silicon_floorplan import derive_kpu_floorplan
+from ...silicon_floorplan import (
+    derive_kpu_architectural_floorplan,
+    derive_kpu_floorplan,
+)
 from .. import ValidatorCategory, ValidatorContext, default_registry
 from ..framework import Finding, Severity
 
@@ -71,6 +74,27 @@ _DIE_ASPECT_ERROR = 5.0
 # uncalibrated. Tighten to ~2.0x after first measured-silicon callibration.
 _DIE_AREA_RATIO_WARNING = 1.5
 _DIE_AREA_RATIO_ERROR = 3.0
+
+# Compute-vs-memory tile-pitch mismatch in the KPU checkerboard. The
+# *primary* geometric concern: every compute tile is paired 1:1 with a
+# memory tile (L3) in the alternating layout. If their pitches differ
+# significantly, the die pays whitespace inside the smaller cell.
+#
+# Bands match the within-class pitch validator: WARN at >=1.20x
+# (notable design imbalance), ERROR at >=5.0x (broken layout). For
+# Stage 8 the ERROR threshold is set high so all 4 catalog SKUs land
+# at WARN-max while the heuristic is uncalibrated. Tighten to ~2.0x
+# after measured-silicon calibration.
+_CM_PITCH_RATIO_WARNING = 1.20
+_CM_PITCH_RATIO_ERROR = 5.00
+
+# Whitespace-fraction warning band for the architectural floorplan.
+# A KPU mesh with >50% mesh-area whitespace is paying a lot of silicon
+# for nothing (typically because Matrix tiles set the unified pitch
+# while the bulk of tiles are smaller INT8). WARN at >=40%, ERROR at
+# >=80% (essentially "the design is half air").
+_WHITESPACE_FRACTION_WARNING = 0.40
+_WHITESPACE_FRACTION_ERROR = 0.80
 
 
 # ---------------------------------------------------------------------------
@@ -239,5 +263,159 @@ class FloorplanAspectRatio:
             citation=(
                 f"silicon_floorplan v1 heuristic; aspect threshold "
                 f"WARN={_DIE_ASPECT_WARNING} ERR={_DIE_ASPECT_ERROR}"
+            ),
+        )]
+
+
+# ---------------------------------------------------------------------------
+# floorplan_compute_memory_pitch_match  (architectural view)
+# ---------------------------------------------------------------------------
+
+@default_registry.register_class
+class FloorplanComputeMemoryPitchMatch:
+    """Flag compute-vs-memory tile-pitch mismatch in the KPU checkerboard.
+
+    The KPU's M0.5 layout pairs every compute tile (PE + L1 + L2) with
+    a memory tile (L3) in a checkerboard. For the layout to tile
+    densely, ``compute_pitch ~= memory_pitch``. When they diverge, the
+    smaller tile leaves whitespace inside its cell -- the larger pitch
+    sets the cell size.
+
+    This is a different concern from ``floorplan_pitch_match``, which
+    catches mismatches *within* compute classes (INT8 vs Matrix). Both
+    fire because they describe different geometric problems.
+    """
+
+    name = "floorplan_compute_memory_pitch_match"
+    category = ValidatorCategory.GEOMETRY
+
+    def check(self, ctx: ValidatorContext) -> List[Finding]:
+        try:
+            fp = derive_kpu_architectural_floorplan(
+                ctx.sku, ctx.process_node
+            )
+        except Exception as exc:
+            return [Finding(
+                validator=self.name,
+                category=self.category,
+                severity=Severity.ERROR,
+                message=(
+                    f"could not derive architectural floorplan: "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+                citation="graphs.hardware.silicon_floorplan",
+            )]
+        if not fp.compute_summaries or fp.memory_summary.pitch_mm <= 0:
+            return []
+
+        memory_pitch = fp.memory_summary.pitch_mm
+        out: List[Finding] = []
+        for class_name, summary in fp.compute_summaries.items():
+            cp = summary.pitch_mm
+            if cp <= 0:
+                continue
+            ratio = max(cp, memory_pitch) / min(cp, memory_pitch)
+            if ratio < _CM_PITCH_RATIO_WARNING:
+                continue
+            sev = (
+                Severity.ERROR if ratio >= _CM_PITCH_RATIO_ERROR
+                else Severity.WARNING
+            )
+            larger = "compute" if cp > memory_pitch else "memory"
+            out.append(Finding(
+                validator=self.name,
+                category=self.category,
+                severity=sev,
+                message=(
+                    f"compute tile {class_name!r} pitch {cp:.3f} mm vs "
+                    f"memory pitch {memory_pitch:.3f} mm = {ratio:.2f}x "
+                    f"({larger} side dominates); checkerboard pairing "
+                    f"will leave whitespace in the smaller cell "
+                    f"(class waste {summary.class_whitespace_mm2:.1f} mm^2)"
+                ),
+                block=f"tile_class:{class_name}",
+                citation=(
+                    f"silicon_floorplan v1 heuristic; C/M pitch threshold "
+                    f"WARN={_CM_PITCH_RATIO_WARNING}x "
+                    f"ERR={_CM_PITCH_RATIO_ERROR}x"
+                ),
+            ))
+        return out
+
+
+# ---------------------------------------------------------------------------
+# floorplan_whitespace_fraction
+# ---------------------------------------------------------------------------
+
+@default_registry.register_class
+class FloorplanWhitespaceFraction:
+    """Flag SKUs whose architectural die has too much whitespace.
+
+    A high whitespace fraction means the chosen tile-class mix is
+    paying silicon area for nothing -- typically because the largest
+    class (Matrix) sets the unified pitch while the bulk of compute
+    tiles are smaller. Useful as a top-level "die efficiency" alarm.
+
+    The companion what-if estimates show the architect what the die
+    would cost if every tile were of one class.
+    """
+
+    name = "floorplan_whitespace_fraction"
+    category = ValidatorCategory.GEOMETRY
+
+    def check(self, ctx: ValidatorContext) -> List[Finding]:
+        try:
+            fp = derive_kpu_architectural_floorplan(
+                ctx.sku, ctx.process_node
+            )
+        except Exception:
+            return []  # The pitch validator already reports derivation errors
+
+        ws_frac = fp.whitespace_fraction()
+        if ws_frac < _WHITESPACE_FRACTION_WARNING:
+            return []
+        sev = (
+            Severity.ERROR if ws_frac >= _WHITESPACE_FRACTION_ERROR
+            else Severity.WARNING
+        )
+        # Find the smallest compute class (most whitespace contributor) and
+        # the all-X what-if that would shrink the die the most.
+        worst_class = max(
+            fp.compute_summaries.values(),
+            key=lambda s: s.class_whitespace_mm2,
+            default=None,
+        )
+        best_what_if = min(
+            fp.what_if, key=lambda w: w.die_area_mm2, default=None,
+        )
+        what_if_msg = ""
+        if best_what_if and best_what_if.die_area_mm2 < fp.die_area_mm2:
+            shrink = (
+                1.0 - best_what_if.die_area_mm2 / fp.die_area_mm2
+            ) * 100.0
+            what_if_msg = (
+                f"; an all-{best_what_if.tile_class!r} mesh would be "
+                f"{best_what_if.die_area_mm2:.1f} mm^2 ({shrink:.0f}% smaller)"
+            )
+        worst_msg = ""
+        if worst_class:
+            worst_msg = (
+                f"; biggest contributor is {worst_class.tile_class!r} "
+                f"({worst_class.class_whitespace_mm2:.1f} mm^2 whitespace "
+                f"across {worst_class.num_tiles} tiles)"
+            )
+        return [Finding(
+            validator=self.name,
+            category=self.category,
+            severity=sev,
+            message=(
+                f"architectural die whitespace {ws_frac*100:.0f}% "
+                f"({fp.whitespace_mm2():.1f} mm^2 of "
+                f"{fp.die_area_mm2:.1f} mm^2){worst_msg}{what_if_msg}"
+            ),
+            citation=(
+                f"silicon_floorplan v1 architectural; whitespace "
+                f"threshold WARN={_WHITESPACE_FRACTION_WARNING*100:.0f}% "
+                f"ERR={_WHITESPACE_FRACTION_ERROR*100:.0f}%"
             ),
         )]

--- a/src/graphs/hardware/sku_validators/validators/geometry.py
+++ b/src/graphs/hardware/sku_validators/validators/geometry.py
@@ -1,0 +1,243 @@
+"""GEOMETRY-category validators (Stage 8).
+
+These run on top of the heuristic floorplan derived in
+``graphs.hardware.silicon_floorplan``. They surface 2D layout problems
+that area-only math can't see:
+
+- ``floorplan_pitch_match``: alternating compute / memory tiles in the
+  KPU mesh must share a pitch. If two tile classes have geometric
+  pitches that differ by more than a small fraction, the SKU either
+  needs whitespace (lower silicon utilization) or a non-uniform
+  layout (longer wires, more energy). The validator reports the
+  pitch mismatch so the architect can rebalance per-PE coefficients
+  or reduce PEs in the over-area class.
+- ``floorplan_within_die_envelope``: total floorplan rectangle fits
+  inside the SKU's declared die_size_mm2 + reasonable slop. Catches
+  cases where silicon_bin block coefficients drifted past what the
+  declared die can hold.
+- ``floorplan_aspect_ratio``: die-level aspect ratio bounds. Modern
+  reticle limits and packaging typically constrain dies to
+  aspect <= 2.5; severely elongated rectangles get flagged.
+
+The geometry findings reference ``block=tile_class:<name>`` for
+per-tile-class pitch findings so the offending class lands in the
+report exactly where downstream tooling can find it.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from ...silicon_floorplan import derive_kpu_floorplan
+from .. import ValidatorCategory, ValidatorContext, default_registry
+from ..framework import Finding, Severity
+
+
+# ---------------------------------------------------------------------------
+# Tunable bounds
+# ---------------------------------------------------------------------------
+
+# Maximum acceptable pitch ratio between tile classes before the KPU
+# checkerboard layout requires wasteful whitespace. 1.20 = the smaller
+# pitch is at most 20% smaller than the largest. Beyond that, alternating
+# rows / columns between tile classes leaves visible gaps.
+#
+# Rationale: at 20% pitch mismatch, a row of small tiles occupies 80% of
+# the unified-pitch row width; the remaining 20% becomes IO / wire-routing
+# whitespace that adds little function. Beyond that, the architect should
+# either rebalance per-PE coefficients (so all tiles land in the same
+# area envelope) or accept a non-uniform mesh (more complex NoC routing).
+#
+# Stage 8 stance: emit WARN at >=1.20x (real signal). The ERROR threshold
+# is set high (>=5.0x) so today's heuristic-v1 floorplan can flag real
+# design imbalances without ERROR-failing the Phase 6 catalog CI gate
+# during Stage 8 development. Tighten to ~2.0x once the heuristic is
+# calibrated against measured silicon.
+_PITCH_RATIO_WARNING = 1.20
+_PITCH_RATIO_ERROR = 5.00
+
+# Maximum die aspect ratio. Above 3.0 routing becomes painful and
+# packaging gets expensive (asymmetric reticles, mask costs). Above 5.0
+# we assume the floorplanner heuristic is producing nonsense.
+_DIE_ASPECT_WARNING = 3.0
+_DIE_ASPECT_ERROR = 5.0
+
+# Allowed slack between heuristic floorplan area and the SKU's declared
+# ``die.die_size_mm2``. The floorplan is a heuristic; treat 1.5x as the
+# fuzzy "we're in the same ballpark" bound. ERROR threshold set high
+# (>=3.0x) for Stage 8 -- a 2x derived/declared mismatch is real signal
+# (silicon_bin coefficients, declared die size, or floorplan overhead)
+# but should not ERROR-fail the catalog gate while the heuristic is
+# uncalibrated. Tighten to ~2.0x after first measured-silicon callibration.
+_DIE_AREA_RATIO_WARNING = 1.5
+_DIE_AREA_RATIO_ERROR = 3.0
+
+
+# ---------------------------------------------------------------------------
+# floorplan_pitch_match
+# ---------------------------------------------------------------------------
+
+@default_registry.register_class
+class FloorplanPitchMatch:
+    """Flag tile-class pitch mismatches in the KPU checkerboard layout.
+
+    For an M0.5 KPU with ``mesh_rows x mesh_cols`` tiles drawn from
+    multiple tile classes (INT8-primary, BF16-primary, Matrix), the
+    physical pitch of every tile class should be within
+    ``_PITCH_RATIO_WARNING`` of the largest. The validator emits a
+    WARNING per-class above that threshold, ERROR above
+    ``_PITCH_RATIO_ERROR``.
+    """
+
+    name = "floorplan_pitch_match"
+    category = ValidatorCategory.GEOMETRY
+
+    def check(self, ctx: ValidatorContext) -> List[Finding]:
+        try:
+            fp = derive_kpu_floorplan(ctx.sku, ctx.process_node)
+        except Exception as exc:
+            return [Finding(
+                validator=self.name,
+                category=self.category,
+                severity=Severity.ERROR,
+                message=(
+                    f"could not derive floorplan: {type(exc).__name__}: {exc}"
+                ),
+                citation="graphs.hardware.silicon_floorplan",
+            )]
+
+        if not fp.tile_pitches:
+            return []
+
+        max_pitch = max(tp.pitch_mm for tp in fp.tile_pitches.values())
+        if max_pitch <= 0:
+            return []
+
+        out: List[Finding] = []
+        for tile_class, tp in fp.tile_pitches.items():
+            if tp.pitch_mm <= 0:
+                continue
+            ratio = max_pitch / tp.pitch_mm
+            if ratio < _PITCH_RATIO_WARNING:
+                continue  # Tile fits within the unified pitch tolerance
+            sev = (
+                Severity.ERROR if ratio >= _PITCH_RATIO_ERROR
+                else Severity.WARNING
+            )
+            out.append(Finding(
+                validator=self.name,
+                category=self.category,
+                severity=sev,
+                message=(
+                    f"tile class {tile_class!r} pitch {tp.pitch_mm:.3f} mm "
+                    f"is {ratio:.2f}x smaller than max-class pitch "
+                    f"{max_pitch:.3f} mm; KPU checkerboard will leave "
+                    f"whitespace or require non-uniform NoC routing "
+                    f"(tile area {tp.total_area_mm2:.4f} mm^2)"
+                ),
+                block=f"tile_class:{tile_class}",
+                citation=(
+                    f"silicon_floorplan v1 heuristic; pitch threshold "
+                    f"WARN={_PITCH_RATIO_WARNING}x ERR={_PITCH_RATIO_ERROR}x"
+                ),
+            ))
+        return out
+
+
+# ---------------------------------------------------------------------------
+# floorplan_within_die_envelope
+# ---------------------------------------------------------------------------
+
+@default_registry.register_class
+class FloorplanWithinDieEnvelope:
+    """Check the heuristic floorplan area is in the same ballpark as the
+    SKU's declared ``die.die_size_mm2``.
+
+    The floorplanner is a heuristic; small disagreements with the
+    declared die size are expected. But a 2x+ disagreement means either
+    (a) the silicon_bin coefficients drifted, (b) the declared die_size
+    is wrong, or (c) the floorplanner heuristic is broken for this SKU.
+    """
+
+    name = "floorplan_within_die_envelope"
+    category = ValidatorCategory.GEOMETRY
+
+    def check(self, ctx: ValidatorContext) -> List[Finding]:
+        try:
+            fp = derive_kpu_floorplan(ctx.sku, ctx.process_node)
+        except Exception:
+            return []  # Pitch-match validator already reports derivation errors
+        declared = ctx.sku.die.die_size_mm2
+        derived = fp.die_area_mm2
+        if declared <= 0 or derived <= 0:
+            return []
+        ratio = max(declared, derived) / min(declared, derived)
+        if ratio < _DIE_AREA_RATIO_WARNING:
+            return []
+        sev = (
+            Severity.ERROR if ratio >= _DIE_AREA_RATIO_ERROR
+            else Severity.WARNING
+        )
+        return [Finding(
+            validator=self.name,
+            category=self.category,
+            severity=sev,
+            message=(
+                f"heuristic floorplan area {derived:.1f} mm^2 differs "
+                f"from declared die.die_size_mm2 {declared:.1f} mm^2 by "
+                f"{ratio:.2f}x; check silicon_bin coefficients or die size"
+            ),
+            citation=(
+                f"silicon_floorplan v1 heuristic; envelope threshold "
+                f"WARN={_DIE_AREA_RATIO_WARNING}x ERR={_DIE_AREA_RATIO_ERROR}x"
+            ),
+        )]
+
+
+# ---------------------------------------------------------------------------
+# floorplan_aspect_ratio
+# ---------------------------------------------------------------------------
+
+@default_registry.register_class
+class FloorplanAspectRatio:
+    """Flag dies with extreme aspect ratios.
+
+    Floorplan with aspect > _DIE_ASPECT_WARNING (currently 3.0) is
+    awkward to route and package; > _DIE_ASPECT_ERROR (5.0) usually
+    means the heuristic is off (e.g., the PHY strip on the right edge
+    has dwarfed the mesh).
+    """
+
+    name = "floorplan_aspect_ratio"
+    category = ValidatorCategory.GEOMETRY
+
+    def check(self, ctx: ValidatorContext) -> List[Finding]:
+        try:
+            fp = derive_kpu_floorplan(ctx.sku, ctx.process_node)
+        except Exception:
+            return []
+        if fp.die_width_mm <= 0 or fp.die_height_mm <= 0:
+            return []
+        wide = max(fp.die_width_mm, fp.die_height_mm)
+        tall = min(fp.die_width_mm, fp.die_height_mm)
+        ar = wide / tall
+        if ar < _DIE_ASPECT_WARNING:
+            return []
+        sev = (
+            Severity.ERROR if ar >= _DIE_ASPECT_ERROR
+            else Severity.WARNING
+        )
+        return [Finding(
+            validator=self.name,
+            category=self.category,
+            severity=sev,
+            message=(
+                f"die aspect ratio {ar:.2f} ({fp.die_width_mm:.2f} x "
+                f"{fp.die_height_mm:.2f} mm) is awkward for routing/"
+                f"packaging; consider rebalancing PHY placement or mesh shape"
+            ),
+            citation=(
+                f"silicon_floorplan v1 heuristic; aspect threshold "
+                f"WARN={_DIE_ASPECT_WARNING} ERR={_DIE_ASPECT_ERROR}"
+            ),
+        )]

--- a/tests/hardware/test_silicon_floorplan.py
+++ b/tests/hardware/test_silicon_floorplan.py
@@ -506,6 +506,164 @@ def test_show_floorplan_cli_view_circuit_falls_back_to_old():
     assert "H=hp_logic" in out or "B=balanced_logic" in out
 
 
+# ---------------------------------------------------------------------------
+# Architectural view v2 -- true 2D checkerboard + memory-spec-driven MCs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_arch_true_2d_checkerboard_interior_compute_has_4_memory_neighbors(
+    sku_id, kpus, nodes
+):
+    """True 2D checkerboard: every interior compute tile has exactly
+    4 memory tile neighbours (N/S/E/W). Catches regressions to
+    column-pair (1 neighbour) or row-pair patterns.
+    """
+    sku = kpus[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    compute_tiles = fp.compute_tiles()
+    memory_tiles = fp.memory_tiles()
+    assert compute_tiles and memory_tiles
+
+    pitch = fp.unified_pitch_mm
+    if pitch <= 0:
+        return
+
+    # Pick an interior compute tile by parsing its checkerboard
+    # coordinates ``compute[r,c]`` (encoded into the name). Interior
+    # = at least one row/col away from every mesh edge.
+    mesh_rows = sku.kpu_architecture.noc.mesh_rows
+    mesh_cols_phys = 2 * sku.kpu_architecture.noc.mesh_cols
+    target = None
+    import re
+    for ct in compute_tiles:
+        m = re.match(r"compute\[(\d+),(\d+)\]", ct.name)
+        if not m:
+            continue
+        r, c = int(m.group(1)), int(m.group(2))
+        if 1 <= r <= mesh_rows - 2 and 1 <= c <= mesh_cols_phys - 2:
+            target = ct
+            break
+    assert target is not None, (
+        f"{sku_id}: no interior compute tile found "
+        f"(mesh {mesh_rows}x{mesh_cols_phys})"
+    )
+
+    eps = 0.01
+    neighbours = 0
+    for m in memory_tiles:
+        same_row = abs(m.y_mm - target.y_mm) < eps
+        same_col = abs(m.x_mm - target.x_mm) < eps
+        horiz_adj = abs(abs(m.x_mm - target.x_mm) - pitch) < eps
+        vert_adj = abs(abs(m.y_mm - target.y_mm) - pitch) < eps
+        if (same_row and horiz_adj) or (same_col and vert_adj):
+            neighbours += 1
+    assert neighbours == 4, (
+        f"{sku_id}: interior compute tile {target.name} has "
+        f"{neighbours} memory neighbours, expected 4 for true 2D "
+        f"checkerboard"
+    )
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_mc_count_equals_memory_controllers_field(sku_id, kpus, nodes):
+    """MC count comes from ``memory.memory_controllers``, not from a
+    silicon_bin estimate or default. T256 (16 LPDDR ch), T128 (8),
+    T64 (4), T768 (8 HBM stacks)."""
+    sku = kpus[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    declared = sku.kpu_architecture.memory.memory_controllers
+    assert fp.num_memory_controllers == declared, (
+        f"{sku_id}: floorplan placed {fp.num_memory_controllers} MCs, "
+        f"YAML declares {declared}"
+    )
+    assert len(fp.memory_controllers()) == declared
+    assert len(fp.memory_channels) == declared
+
+
+def test_lpddr_mc_is_long_narrow_stripe(kpus, nodes):
+    """LPDDR PHY blocks are narrow stripes (~5:1 aspect)."""
+    sku = kpus["stillwater_kpu_t256"]  # LPDDR5
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    for mc in fp.memory_controllers():
+        long = max(mc.width_mm, mc.height_mm)
+        short = min(mc.width_mm, mc.height_mm)
+        ar = long / short
+        assert ar >= 3.0, (
+            f"LPDDR MC {mc.name} aspect ratio {ar:.2f} is not "
+            f"narrow-stripe-like; LPDDR PHYs run along bump edge"
+        )
+
+
+def test_hbm_mc_is_squarer_than_lpddr(kpus, nodes):
+    """HBM PHY blocks are squarer (~1.5:1 aspect) than LPDDR (~5:1)."""
+    lpddr_sku = kpus["stillwater_kpu_t256"]
+    hbm_sku = kpus["stillwater_kpu_t768"]
+    fp_lpddr = derive_kpu_architectural_floorplan(
+        lpddr_sku, nodes[lpddr_sku.process_node_id]
+    )
+    fp_hbm = derive_kpu_architectural_floorplan(
+        hbm_sku, nodes[hbm_sku.process_node_id]
+    )
+    def aspect(mc):
+        long = max(mc.width_mm, mc.height_mm)
+        short = min(mc.width_mm, mc.height_mm)
+        return long / short if short > 0 else float("inf")
+    lpddr_ar = aspect(fp_lpddr.memory_controllers()[0])
+    hbm_ar = aspect(fp_hbm.memory_controllers()[0])
+    assert hbm_ar < lpddr_ar, (
+        f"HBM aspect {hbm_ar:.2f} should be smaller than LPDDR "
+        f"aspect {lpddr_ar:.2f} (HBM PHYs are squarer microbump arrays)"
+    )
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_dram_channels_placed_outside_die(sku_id, kpus, nodes):
+    """Every memory channel sits beyond the die boundary on its
+    respective edge; channels are not inside the die."""
+    sku = kpus[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    for ch in fp.memory_channels:
+        if ch.edge == "top":
+            assert ch.y_mm >= fp.die_height_mm - 1e-6, (
+                f"{sku_id}: top channel {ch.channel_id} at y={ch.y_mm} "
+                f"is not above die top (die_h={fp.die_height_mm})"
+            )
+        elif ch.edge == "bottom":
+            assert ch.y_mm + ch.height_mm <= 1e-6, (
+                f"{sku_id}: bottom channel {ch.channel_id} extends "
+                f"into die at y={ch.y_mm}"
+            )
+        elif ch.edge == "right":
+            assert ch.x_mm >= fp.die_width_mm - 1e-6
+        elif ch.edge == "left":
+            assert ch.x_mm + ch.width_mm <= 1e-6
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_mc_dimensions_independent_of_mesh_size(sku_id, kpus, nodes):
+    """MC area is determined by memory type + channel width, NOT by
+    compute mesh size. Catch regressions to the v1 behaviour where
+    MC side = sqrt(total_phy_area / num_controllers) shrunk with
+    smaller meshes.
+    """
+    sku = kpus[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    mem = sku.kpu_architecture.memory
+    if mem.memory_controllers <= 0 or mem.memory_bus_bits <= 0:
+        return
+    # PHY/channel area should match the memory-type lookup; if the
+    # MC area scales with mesh size instead, this disagrees.
+    ch_width = mem.memory_bus_bits // mem.memory_controllers
+    assert fp.per_channel_phy_area_mm2 > 0
+    # All MCs should have the same area (uniform per-channel sizing)
+    mcs = fp.memory_controllers()
+    areas = {round(mc.area_mm2, 4) for mc in mcs}
+    assert len(areas) == 1, (
+        f"{sku_id}: MCs have multiple distinct sizes {areas}; "
+        f"expected uniform per-channel sizing"
+    )
+
+
 def test_show_floorplan_cli_arch_json_output(tmp_path: Path):
     """Architectural JSON has the new top-level fields."""
     out = tmp_path / "fp.json"

--- a/tests/hardware/test_silicon_floorplan.py
+++ b/tests/hardware/test_silicon_floorplan.py
@@ -1,0 +1,330 @@
+"""Stage 8: silicon floorplanner + GEOMETRY-category validators.
+
+Covers:
+  * ``derive_kpu_floorplan`` heuristic correctness across the catalog
+  * GEOMETRY validators register, run, and produce the expected
+    findings on real SKUs (pitch_match flagged on T768 etc.)
+  * The CLI ``cli/show_floorplan.py`` happy path
+
+Stage 8 stance: the heuristic floorplan is *advisory* until calibrated
+against measured silicon. Tests assert structural properties (no
+overlaps in the same layer, every tile has a class assigned, output
+dimensions positive) rather than pixel-exact dimensions, so threshold
+tuning doesn't churn this test file.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from embodied_schemas import (
+    load_cooling_solutions,
+    load_kpus,
+    load_process_nodes,
+)
+
+from graphs.hardware.silicon_floorplan import (
+    Floorplan,
+    FloorplanBlock,
+    derive_kpu_floorplan,
+)
+from graphs.hardware.sku_validators import (
+    Severity,
+    ValidatorCategory,
+    ValidatorContext,
+    default_registry,
+    load_validators,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHOW_FLOORPLAN_CLI = REPO_ROOT / "cli" / "show_floorplan.py"
+
+# Auto-discovery: test against every KPU SKU in the catalog. New SKUs
+# get covered automatically, matching the Phase 6 catalog gate pattern.
+ALL_KPU_IDS = sorted(load_kpus().keys())
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def kpus():
+    return load_kpus()
+
+
+@pytest.fixture(scope="module")
+def nodes():
+    return load_process_nodes()
+
+
+@pytest.fixture(scope="module")
+def cooling():
+    return load_cooling_solutions()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _register():
+    """Make sure validators (including geometry) are registered."""
+    load_validators()
+
+
+# ---------------------------------------------------------------------------
+# derive_kpu_floorplan: structural properties
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_floorplan_has_positive_dimensions(sku_id, kpus, nodes):
+    """Every SKU produces a die with positive width / height / area.
+
+    Catches the case where a missing silicon_bin block (no PHY, no IO,
+    etc.) would zero-out a die dimension.
+    """
+    sku = kpus[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
+    assert fp.die_width_mm > 0, f"{sku_id} has non-positive die width"
+    assert fp.die_height_mm > 0, f"{sku_id} has non-positive die height"
+    assert fp.die_area_mm2 > 0
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_floorplan_compute_tile_count_matches_mesh(sku_id, kpus, nodes):
+    """``mesh_rows x mesh_cols`` compute tiles must be placed.
+
+    The KPU NoC mesh is what defines the tile count -- if the
+    floorplanner places fewer than that, the YAML's tile_mix counts
+    don't sum to the mesh capacity (real bug) or the layout heuristic
+    silently dropped tiles (also a bug).
+    """
+    sku = kpus[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
+    arch = sku.kpu_architecture
+    expected = arch.noc.mesh_rows * arch.noc.mesh_cols
+    assert len(fp.compute_tiles()) == expected, (
+        f"{sku_id}: placed {len(fp.compute_tiles())} compute tiles, "
+        f"expected {expected} ({arch.noc.mesh_rows}x{arch.noc.mesh_cols})"
+    )
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_floorplan_every_compute_tile_has_class(sku_id, kpus, nodes):
+    """Every compute tile must carry a tile_class label so geometry
+    validators can group findings by class."""
+    sku = kpus[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
+    declared_classes = {t.tile_type for t in sku.kpu_architecture.tiles}
+    for block in fp.compute_tiles():
+        assert block.tile_class is not None, (
+            f"{sku_id}: compute tile {block.name} missing tile_class"
+        )
+        assert block.tile_class in declared_classes, (
+            f"{sku_id}: compute tile {block.name} has tile_class "
+            f"{block.tile_class!r} not in YAML's declared {declared_classes}"
+        )
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_floorplan_compute_tiles_dont_overlap(sku_id, kpus, nodes):
+    """Compute tiles in the mesh must be axis-aligned, non-overlapping.
+
+    Uses the mesh row/col ordering implicit in the tile name format
+    ``tile[r,c]`` and checks neighbouring tiles share an edge.
+    """
+    sku = kpus[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
+    tiles = fp.compute_tiles()
+
+    # All tiles share the same width and height (unified pitch)
+    pitches = {(round(b.width_mm, 4), round(b.height_mm, 4)) for b in tiles}
+    assert len(pitches) == 1, (
+        f"{sku_id}: tiles have multiple distinct pitch sizes: {pitches}"
+    )
+    w, h = next(iter(pitches))
+    assert abs(w - h) < 1e-6, (
+        f"{sku_id}: tile pitch is non-square ({w} x {h})"
+    )
+
+    # Pairwise: no two compute tiles overlap by more than ULP-level
+    # float noise. Adjacent tiles share an edge at exactly
+    # ``origin + N * pitch`` where N differs by 1 -- that's not overlap,
+    # it's adjacency. ``eps`` ignores < 1 micron differences.
+    eps = 1e-3  # 1 micron, well below any real tile pitch
+    sample = tiles[:20]
+    for i, a in enumerate(sample):
+        for b in sample[i + 1:]:
+            x_overlap = (
+                a.x_mm + eps < b.x_mm + b.width_mm
+                and b.x_mm + eps < a.x_mm + a.width_mm
+            )
+            y_overlap = (
+                a.y_mm + eps < b.y_mm + b.height_mm
+                and b.y_mm + eps < a.y_mm + a.height_mm
+            )
+            assert not (x_overlap and y_overlap), (
+                f"{sku_id}: compute tiles {a.name} and {b.name} overlap"
+            )
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_floorplan_unified_pitch_dominates_tile_class_pitches(
+    sku_id, kpus, nodes
+):
+    """The unified mesh pitch is the max across tile classes -- no
+    class can have a pitch greater than the unified pitch (otherwise
+    larger tiles would overflow the mesh cell)."""
+    sku = kpus[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
+    for tile_class, tp in fp.tile_pitches.items():
+        assert tp.pitch_mm <= fp.unified_pitch_mm + 1e-6, (
+            f"{sku_id}: tile class {tile_class!r} pitch {tp.pitch_mm} "
+            f"exceeds unified pitch {fp.unified_pitch_mm}"
+        )
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_floorplan_total_block_area_close_to_die_area(sku_id, kpus, nodes):
+    """Total placed-block area must be at most the die area.
+
+    Whitespace is allowed; overlap is not. ``total_block_area > die_area``
+    means the floorplanner placed overlapping rectangles or computed
+    the die envelope incorrectly.
+    """
+    sku = kpus[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
+    # Allow 1% slop for floating-point rounding in the IO ring corners
+    assert fp.total_block_area_mm2() <= fp.die_area_mm2 * 1.01, (
+        f"{sku_id}: blocks total {fp.total_block_area_mm2():.2f} mm^2 "
+        f"exceeds die {fp.die_area_mm2:.2f} mm^2 (overlap or wrong envelope)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GEOMETRY validators
+# ---------------------------------------------------------------------------
+
+def test_geometry_validators_registered():
+    """The three Stage 8 validators are registered under GEOMETRY."""
+    expected = {
+        "floorplan_pitch_match",
+        "floorplan_within_die_envelope",
+        "floorplan_aspect_ratio",
+    }
+    names = set(default_registry.names())
+    assert expected.issubset(names), f"missing: {expected - names}"
+    for name in expected:
+        validator = default_registry.get(name)
+        assert validator is not None
+        assert validator.category == ValidatorCategory.GEOMETRY
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_geometry_validators_dont_error_on_real_skus(
+    sku_id, kpus, nodes, cooling
+):
+    """Stage 8 stance: WARN-max during heuristic-v1 development.
+
+    All 4 catalog SKUs must run clean of ERROR findings under the
+    geometry validators -- otherwise the Phase 6 catalog gate fails.
+    Tighten thresholds to ERROR-level once the heuristic is calibrated.
+    """
+    sku = kpus[sku_id]
+    ctx = ValidatorContext(
+        sku=sku,
+        process_node=nodes[sku.process_node_id],
+        cooling_solutions=cooling,
+    )
+    findings = default_registry.run_category(ctx, ValidatorCategory.GEOMETRY)
+    errors = [f for f in findings if f.severity == Severity.ERROR]
+    assert not errors, (
+        f"{sku_id}: GEOMETRY validators emitted ERROR findings: "
+        + "; ".join(f.render_one_line() for f in errors)
+    )
+
+
+def test_pitch_match_warns_on_t768(kpus, nodes, cooling):
+    """T768 has the most aggressive per-class pitch differences in the
+    catalog -- the floorplan_pitch_match validator must fire on it.
+
+    Locks in the validator's signal: if a future YAML rebalancing
+    accidentally hides the T768 pitch mismatch (e.g., by inflating
+    INT8 per-PE area), this test fails so we notice.
+    """
+    sku = kpus["stillwater_kpu_t768"]
+    ctx = ValidatorContext(
+        sku=sku,
+        process_node=nodes[sku.process_node_id],
+        cooling_solutions=cooling,
+    )
+    findings = default_registry.run_one("floorplan_pitch_match", ctx)
+    pitch_findings = [f for f in findings if f.severity != Severity.INFO]
+    assert pitch_findings, (
+        "T768 has known per-class pitch mismatch but pitch_match "
+        "validator emitted no findings -- thresholds drifted?"
+    )
+    # Both INT8 and BF16 classes should fire (smaller than Matrix)
+    classes_flagged = {
+        f.block.split(":", 1)[1] for f in pitch_findings if f.block
+    }
+    assert "INT8-primary" in classes_flagged
+    assert "BF16-primary" in classes_flagged
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke test
+# ---------------------------------------------------------------------------
+
+def test_show_floorplan_cli_renders_t256():
+    """Happy path: CLI prints a non-empty ASCII grid + a summary."""
+    result = subprocess.run(
+        [sys.executable, str(SHOW_FLOORPLAN_CLI), "stillwater_kpu_t256"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    # The summary lists the SKU name + die dimensions
+    assert "Stillwater KPU-T256" in result.stdout
+    assert "Per-tile-class pitches" in result.stdout
+    # The legend confirms the ASCII renderer ran
+    assert "Legend:" in result.stdout
+
+
+def test_show_floorplan_cli_json_output(tmp_path: Path):
+    """JSON mode: structured output with the right top-level keys."""
+    out = tmp_path / "fp.json"
+    result = subprocess.run(
+        [sys.executable, str(SHOW_FLOORPLAN_CLI),
+         "stillwater_kpu_t64", "--output", str(out)],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(out.read_text())
+    assert payload["sku_id"] == "stillwater_kpu_t64"
+    assert payload["die_area_mm2"] > 0
+    assert "tile_pitches" in payload
+    assert len(payload["blocks"]) > 0
+
+
+def test_show_floorplan_cli_unknown_sku():
+    result = subprocess.run(
+        [sys.executable, str(SHOW_FLOORPLAN_CLI), "stillwater_kpu_t999"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "unknown SKU" in result.stderr
+
+
+def test_show_floorplan_cli_list_mode():
+    """--list returns the catalog ids, one per line."""
+    result = subprocess.run(
+        [sys.executable, str(SHOW_FLOORPLAN_CLI), "--list"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    ids = result.stdout.strip().split("\n")
+    assert "stillwater_kpu_t256" in ids
+    assert "stillwater_kpu_t768" in ids

--- a/tests/hardware/test_silicon_floorplan.py
+++ b/tests/hardware/test_silicon_floorplan.py
@@ -29,8 +29,12 @@ from embodied_schemas import (
 )
 
 from graphs.hardware.silicon_floorplan import (
+    ArchitecturalFloorplan,
+    ArchTile,
     Floorplan,
     FloorplanBlock,
+    TileRole,
+    derive_kpu_architectural_floorplan,
     derive_kpu_floorplan,
 )
 from graphs.hardware.sku_validators import (
@@ -209,11 +213,15 @@ def test_floorplan_total_block_area_close_to_die_area(sku_id, kpus, nodes):
 # ---------------------------------------------------------------------------
 
 def test_geometry_validators_registered():
-    """The three Stage 8 validators are registered under GEOMETRY."""
+    """All five Stage 8 GEOMETRY validators are registered."""
     expected = {
+        # Stage 8a (circuit-class view)
         "floorplan_pitch_match",
         "floorplan_within_die_envelope",
         "floorplan_aspect_ratio",
+        # Stage 8b (architectural view)
+        "floorplan_compute_memory_pitch_match",
+        "floorplan_whitespace_fraction",
     }
     names = set(default_registry.names())
     assert expected.issubset(names), f"missing: {expected - names}"
@@ -280,21 +288,28 @@ def test_pitch_match_warns_on_t768(kpus, nodes, cooling):
 # ---------------------------------------------------------------------------
 
 def test_show_floorplan_cli_renders_t256():
-    """Happy path: CLI prints a non-empty ASCII grid + a summary."""
+    """Happy path: CLI prints a non-empty ASCII grid + a summary.
+
+    Default view is architectural (Stage 8b); coverage of the
+    architectural-specific output lives in
+    ``test_show_floorplan_cli_default_is_architectural``.
+    """
     result = subprocess.run(
         [sys.executable, str(SHOW_FLOORPLAN_CLI), "stillwater_kpu_t256"],
         cwd=REPO_ROOT, capture_output=True, text=True,
     )
     assert result.returncode == 0, result.stderr
-    # The summary lists the SKU name + die dimensions
     assert "Stillwater KPU-T256" in result.stdout
-    assert "Per-tile-class pitches" in result.stdout
     # The legend confirms the ASCII renderer ran
     assert "Legend:" in result.stdout
 
 
 def test_show_floorplan_cli_json_output(tmp_path: Path):
-    """JSON mode: structured output with the right top-level keys."""
+    """JSON mode: structured output with the right top-level keys.
+
+    Default view is architectural; the circuit-class JSON shape is
+    covered separately by ``test_show_floorplan_cli_view_circuit_*``.
+    """
     out = tmp_path / "fp.json"
     result = subprocess.run(
         [sys.executable, str(SHOW_FLOORPLAN_CLI),
@@ -305,7 +320,6 @@ def test_show_floorplan_cli_json_output(tmp_path: Path):
     payload = json.loads(out.read_text())
     assert payload["sku_id"] == "stillwater_kpu_t64"
     assert payload["die_area_mm2"] > 0
-    assert "tile_pitches" in payload
     assert len(payload["blocks"]) > 0
 
 
@@ -328,3 +342,187 @@ def test_show_floorplan_cli_list_mode():
     ids = result.stdout.strip().split("\n")
     assert "stillwater_kpu_t256" in ids
     assert "stillwater_kpu_t768" in ids
+
+
+# ---------------------------------------------------------------------------
+# Architectural view: structural properties (Stage 8b)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_arch_floorplan_has_positive_dimensions(sku_id, kpus, nodes):
+    sku = kpus[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    assert fp.die_width_mm > 0
+    assert fp.die_height_mm > 0
+    assert fp.die_area_mm2 > 0
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_arch_floorplan_compute_memory_one_to_one(sku_id, kpus, nodes):
+    """Architectural pairing: 1 memory tile per compute tile (each
+    compute tile owns its L3). The checkerboard layout depends on
+    this 1:1 invariant."""
+    sku = kpus[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    assert len(fp.compute_tiles()) == sku.kpu_architecture.total_tiles
+    assert len(fp.memory_tiles()) == sku.kpu_architecture.total_tiles
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_arch_floorplan_distributes_memory_controllers(sku_id, kpus, nodes):
+    """Memory controllers must be placed (default 4) and distributed
+    around the periphery (no two on top of each other)."""
+    sku = kpus[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    ctrls = fp.memory_controllers()
+    assert len(ctrls) >= 1, f"{sku_id}: no memory controllers placed"
+    # Each controller has positive area
+    for c in ctrls:
+        assert c.area_mm2 > 0
+    # Controllers don't overlap each other (pairwise)
+    eps = 1e-3
+    for i, a in enumerate(ctrls):
+        for b in ctrls[i + 1:]:
+            x_ov = (
+                a.x_mm + eps < b.x_mm + b.width_mm
+                and b.x_mm + eps < a.x_mm + a.width_mm
+            )
+            y_ov = (
+                a.y_mm + eps < b.y_mm + b.height_mm
+                and b.y_mm + eps < a.y_mm + a.height_mm
+            )
+            assert not (x_ov and y_ov), (
+                f"{sku_id}: controllers {a.name} and {b.name} overlap"
+            )
+
+
+@pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
+def test_arch_floorplan_what_if_one_per_class(sku_id, kpus, nodes):
+    """What-if estimates: one entry per declared compute tile class."""
+    sku = kpus[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    declared_classes = {t.tile_type for t in sku.kpu_architecture.tiles}
+    estimated_classes = {wi.tile_class for wi in fp.what_if}
+    assert estimated_classes == declared_classes, (
+        f"{sku_id}: what-if covers {estimated_classes}, "
+        f"expected {declared_classes}"
+    )
+
+
+def test_arch_what_if_all_int8_smaller_than_all_matrix(kpus, nodes):
+    """The whole point of the what-if: an all-INT8 mesh should be
+    notably smaller than an all-Matrix mesh, because INT8 PE area
+    is much less than Matrix PE area. If this stops being true, the
+    silicon_bin coefficients have drifted in a way the architect
+    should know about.
+    """
+    sku = kpus["stillwater_kpu_t768"]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    by_class = {wi.tile_class: wi for wi in fp.what_if}
+    assert "INT8-primary" in by_class
+    assert "Matrix" in by_class
+    int8_die = by_class["INT8-primary"].die_area_mm2
+    mat_die = by_class["Matrix"].die_area_mm2
+    assert int8_die < mat_die, (
+        f"all-INT8 die {int8_die:.1f} mm^2 is not smaller than "
+        f"all-Matrix die {mat_die:.1f} mm^2 -- silicon_bin drifted?"
+    )
+
+
+def test_compute_memory_pitch_match_warns_on_t768(kpus, nodes, cooling):
+    """T768's compute tiles range from 0.175 mm (INT8) to 0.508 mm
+    (Matrix); memory pitch is ~0.142 mm. The C/M pitch validator
+    must fire on at least one tile class for T768."""
+    sku = kpus["stillwater_kpu_t768"]
+    ctx = ValidatorContext(
+        sku=sku, process_node=nodes[sku.process_node_id],
+        cooling_solutions=cooling,
+    )
+    findings = default_registry.run_one(
+        "floorplan_compute_memory_pitch_match", ctx
+    )
+    pitch_findings = [f for f in findings if f.severity != Severity.INFO]
+    assert pitch_findings, (
+        "T768 has known compute-vs-memory pitch mismatch but the "
+        "validator emitted no findings -- thresholds drifted?"
+    )
+
+
+def test_whitespace_validator_warns_on_t768(kpus, nodes, cooling):
+    """T768 has 76% architectural whitespace (Matrix tiles dominate
+    the unified pitch). Whitespace validator must fire."""
+    sku = kpus["stillwater_kpu_t768"]
+    ctx = ValidatorContext(
+        sku=sku, process_node=nodes[sku.process_node_id],
+        cooling_solutions=cooling,
+    )
+    findings = default_registry.run_one("floorplan_whitespace_fraction", ctx)
+    assert findings, (
+        "T768 has 76% whitespace but whitespace validator emitted "
+        "nothing -- threshold drifted?"
+    )
+    # The message should reference the all-X what-if scenario
+    msg = findings[0].message
+    assert "all-" in msg or "what-if" in msg.lower() or "smaller" in msg, (
+        f"whitespace finding doesn't mention the what-if alternative: {msg}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI: --view flag
+# ---------------------------------------------------------------------------
+
+def test_show_floorplan_cli_default_is_architectural():
+    """The architectural view is the default. Output should mention
+    'architectural', the per-class compute summary, and the what-if
+    table."""
+    result = subprocess.run(
+        [sys.executable, str(SHOW_FLOORPLAN_CLI), "stillwater_kpu_t256"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "architectural" in out.lower()
+    assert "Compute tile classes" in out
+    assert "Memory tiles" in out
+    assert "What-if" in out
+    # Architectural glyphs in the legend
+    assert "C=compute" in out
+    assert "M=memory" in out
+
+
+def test_show_floorplan_cli_view_circuit_falls_back_to_old():
+    """--view circuit reproduces the Stage 8a renderer output."""
+    result = subprocess.run(
+        [sys.executable, str(SHOW_FLOORPLAN_CLI),
+         "stillwater_kpu_t256", "--view", "circuit"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "circuit-class" in out.lower()
+    assert "Per-tile-class pitches" in out
+    # Circuit glyphs in legend
+    assert "H=hp_logic" in out or "B=balanced_logic" in out
+
+
+def test_show_floorplan_cli_arch_json_output(tmp_path: Path):
+    """Architectural JSON has the new top-level fields."""
+    out = tmp_path / "fp.json"
+    result = subprocess.run(
+        [sys.executable, str(SHOW_FLOORPLAN_CLI),
+         "stillwater_kpu_t768", "--output", str(out)],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(out.read_text())
+    assert payload["view"] == "architectural"
+    assert payload["sku_id"] == "stillwater_kpu_t768"
+    assert "compute_summaries" in payload
+    assert "memory_summary" in payload
+    assert "what_if" in payload
+    assert payload["num_memory_controllers"] >= 1
+    # what-if has one entry per declared compute class
+    assert len(payload["what_if"]) >= 1
+    for wi in payload["what_if"]:
+        assert wi["die_area_mm2"] > 0

--- a/tests/hardware/test_silicon_floorplan.py
+++ b/tests/hardware/test_silicon_floorplan.py
@@ -29,11 +29,6 @@ from embodied_schemas import (
 )
 
 from graphs.hardware.silicon_floorplan import (
-    ArchitecturalFloorplan,
-    ArchTile,
-    Floorplan,
-    FloorplanBlock,
-    TileRole,
     derive_kpu_architectural_floorplan,
     derive_kpu_floorplan,
 )
@@ -653,7 +648,6 @@ def test_mc_dimensions_independent_of_mesh_size(sku_id, kpus, nodes):
         return
     # PHY/channel area should match the memory-type lookup; if the
     # MC area scales with mesh size instead, this disagrees.
-    ch_width = mem.memory_bus_bits // mem.memory_controllers
     assert fp.per_channel_phy_area_mm2 > 0
     # All MCs should have the same area (uniform per-channel sizing)
     mcs = fp.memory_controllers()

--- a/tests/hardware/test_sku_validators_phase2cd.py
+++ b/tests/hardware/test_sku_validators_phase2cd.py
@@ -208,9 +208,11 @@ def test_run_category_reliability_only(ctx):
 
 def test_total_validator_count_after_phase2cd_and_stage8():
     """Validator count tracker:
-    - Phase 2b: 7 (consistency x2, electrical x1, area x3, energy x1)
+    - Phase 2b:   7 (consistency x2, electrical x1, area x3, energy x1)
     - Phase 2c+d: +2 (thermal_hotspot, electromigration)
-    - Stage 8:   +3 (floorplan_pitch_match, floorplan_within_die_envelope,
-                     floorplan_aspect_ratio)
+    - Stage 8a:   +3 (floorplan_pitch_match, floorplan_within_die_envelope,
+                       floorplan_aspect_ratio)
+    - Stage 8b:   +2 (floorplan_compute_memory_pitch_match,
+                       floorplan_whitespace_fraction)
     """
-    assert len(default_registry) == 12
+    assert len(default_registry) == 14

--- a/tests/hardware/test_sku_validators_phase2cd.py
+++ b/tests/hardware/test_sku_validators_phase2cd.py
@@ -206,7 +206,11 @@ def test_run_category_reliability_only(ctx):
     assert all(f.category == ValidatorCategory.RELIABILITY for f in findings)
 
 
-def test_total_validator_count_is_nine_after_phase2cd():
-    """Phase 2c added thermal_hotspot, Phase 2d added electromigration --
-    we should have 9 validators total (7 from Phase 2b + 2 from 2c+d)."""
-    assert len(default_registry) == 9
+def test_total_validator_count_after_phase2cd_and_stage8():
+    """Validator count tracker:
+    - Phase 2b: 7 (consistency x2, electrical x1, area x3, energy x1)
+    - Phase 2c+d: +2 (thermal_hotspot, electromigration)
+    - Stage 8:   +3 (floorplan_pitch_match, floorplan_within_die_envelope,
+                     floorplan_aspect_ratio)
+    """
+    assert len(default_registry) == 12


### PR DESCRIPTION
## Summary

Heuristic-v1 silicon floorplanner the plan-doc reserved for Stage 8. Turns each KPU SKU's `silicon_bin` into a 2D placement, surfaces tile-class pitch mismatches that area-only math misses, and renders the result as ASCII art for design review.

* **Floorplanner** (`src/graphs/hardware/silicon_floorplan.py`) — `derive_kpu_floorplan(sku, node)` returns a `Floorplan` with per-tile-class `TilePitch`, unified-pitch mesh, PHY strip, IO ring, and control corner.
* **GEOMETRY validators** (`sku_validators/validators/geometry.py`) — three new validators registered under `ValidatorCategory.GEOMETRY`:
  * `floorplan_pitch_match` — KPU checkerboard pitch-match across tile classes
  * `floorplan_within_die_envelope` — declared vs derived die area
  * `floorplan_aspect_ratio` — die aspect bounds
  * Validator count: 9 → 12.
* **CLI** (`cli/show_floorplan.py`) — ASCII art renderer with circuit-class glyph legend; `--list`, `--json`, `--output`.
* **Tests** (`tests/hardware/test_silicon_floorplan.py`) — 34 tests parametrized over the catalog (structural correctness, validator registration, CLI happy paths).

## Stage 8 stance

ERROR thresholds set high so all 4 catalog SKUs land at WARN-max during heuristic-v1 development. The Phase 6 catalog CI gate stays green. The findings still surface real signal:

* **T768**: INT8-primary pitch 0.225 mm vs Matrix 0.528 mm — **2.34× ratio** (the case the validator was designed to flag).
* **T64/T128**: floorplan area is **1.87× the declared `die.die_size_mm2`** — silicon_bin coefficients, declared die size, or PHY/IO overhead estimate need reconciliation.

Tightening to ERROR-level is Stage 8b after the heuristic is calibrated against measured silicon. Plan-doc updated to reflect 8a done / 8b deferred.

## Sample output

```
$ python cli/show_floorplan.py stillwater_kpu_t256 --width 90
Floorplan: Stillwater KPU-T256 (stillwater_kpu_t256)
  die:               15.04 x 13.13 mm = 197.5 mm^2
  unified pitch:     0.783 mm
  whitespace:        5.5% (10.8 mm^2)
  blocks:            262 (compute tiles: 256)

Per-tile-class pitches:
  BF16-primary    PE=0.1684  SRAM=0.2496  total=0.4180  pitch=0.647 mm  (1.21x smaller)
  INT8-primary    PE=0.0842  SRAM=0.2496  total=0.3338  pitch=0.578 mm  (1.36x smaller)
  Matrix          PE=0.3636  SRAM=0.2496  total=0.6132  pitch=0.783 mm <- max
```

## Test plan

- [x] `pytest tests/hardware/test_silicon_floorplan.py` — 34 passed
- [x] `pytest tests/hardware/` — 496 passed (no regression in existing validators / mappers / catalog gate)
- [x] `pytest tests/validation_model_v4/` — V4 harness passes
- [x] `python cli/show_floorplan.py stillwater_kpu_t256` — renders ASCII grid + legend
- [x] `python cli/show_floorplan.py --list` — lists 4 catalog SKUs
- [x] `python cli/show_floorplan.py stillwater_kpu_t64 --output fp.json` — writes valid JSON
- [x] `python cli/validate_sku.py --all` (Phase 6 gate) — all 4 SKUs pass with WARN-max GEOMETRY findings; no ERRORs

## Follow-ups (Stage 8b)

Documented in `docs/designs/kpu-sku-and-process-node-plan.md`:
- Calibrate `_PITCH_RATIO_ERROR` / `_DIE_AREA_RATIO_ERROR` against measured T256 silicon.
- Resolve T64/T128 floorplan-vs-declared-die mismatch.
- SVG / PNG renderer with annotated dimensions.
- NoC routability validator + IO-pad-pitch validator.
- DVFS feasibility, memory-bandwidth headroom, yield-risk validators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI to render KPU SKU floorplans in ASCII or JSON with architectural and circuit views, legends, and "what-if" estimates; supports off‑die memory channel visualization and adjustable output sizing.
  * Added automated floorplan derivation producing compute/memory tile layouts, checkerboard architectural meshes, memory‑controller placement and per‑tile pitch summaries.
  * Added five geometry validators for pitch, die envelope, aspect ratio, compute-vs-memory pitch, and whitespace fraction.

* **Documentation**
  * Updated design doc to mark Stage 8 delivery and validator plan.

* **Tests**
  * Expanded comprehensive test suite and CLI smoke tests for floorplanning and validators.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/152)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->