### PR TITLE
feat(hardware): derived TDP from V/f/workload + PE-array sweep CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
-          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
+          #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
+          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
           path: embodied-schemas
           fetch-depth: 1
 
@@ -133,7 +134,8 @@ jobs:
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
-          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
+          #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
+          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
           path: embodied-schemas
           fetch-depth: 1
 
@@ -227,7 +229,8 @@ jobs:
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
-          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
+          #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
+          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
           path: embodied-schemas
           fetch-depth: 1
 
@@ -318,7 +321,8 @@ jobs:
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
-          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
+          #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
+          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
           path: embodied-schemas
           fetch-depth: 1
 
@@ -382,7 +386,8 @@ jobs:
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
-          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
+          #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
+          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
           path: embodied-schemas
           fetch-depth: 1
 
@@ -434,7 +439,8 @@ jobs:
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
-          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
+          #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
+          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -92,7 +92,8 @@ jobs:
           #   PR #10 (5abce59) per-(profile, precision) efficiency on KPUThermalProfile
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
-          ref: 3509e683a234ff1a83bb88bce993bed2375e54cd
+          #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
+          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
           path: embodied-schemas
           fetch-depth: 1
 

--- a/cli/generate_kpu_sku.py
+++ b/cli/generate_kpu_sku.py
@@ -24,6 +24,13 @@ Two modes:
     python cli/generate_kpu_sku.py --from-sku stillwater_kpu_t256 \\
         --output regenerated_t256.yaml --validate
 
+3. Roadmap sweep -- override PE-array size while keeping everything else:
+
+    for pe in 16x16 24x24 32x32 40x40; do
+      python cli/generate_kpu_sku.py --from-sku stillwater_kpu_t256 \\
+          --pe-array $pe --output t256_$pe.yaml
+    done
+
 Exit codes:
     0 = generation succeeded (and --validate, if used, found no ERROR)
     1 = validator produced ERROR finding(s) on the generated SKU
@@ -42,6 +49,7 @@ from embodied_schemas import load_cooling_solutions, load_kpus, load_process_nod
 
 from graphs.hardware.kpu_sku_generator import (
     GeneratorError,
+    apply_pe_array_override,
     generate_kpu_sku,
     input_spec_from_kpu_entry,
 )
@@ -99,6 +107,15 @@ def main() -> int:
         "(.yaml / .yml / .json). Default: stdout YAML.",
     )
     parser.add_argument(
+        "--pe-array",
+        metavar="ROWSxCOLS",
+        help="Override PE-array dimensions across every tile class "
+        "(e.g., '32x32', '16x16'). ops_per_tile_per_clock and pipeline "
+        "fill/drain cycles are scaled to match. Use for roadmap sweeps: "
+        "`--from-sku stillwater_kpu_t256 --pe-array 16x16` regenerates "
+        "T256 with smaller PEs to compare cost / capability.",
+    )
+    parser.add_argument(
         "--validate",
         action="store_true",
         help="Run the validator registry against the generated SKU. "
@@ -144,6 +161,24 @@ def main() -> int:
             )
             return 2
         spec = input_spec_from_kpu_entry(existing)
+
+    # Apply PE-array override (after spec load, before generation).
+    if args.pe_array:
+        try:
+            rows_str, cols_str = args.pe_array.lower().split("x", 1)
+            rows, cols = int(rows_str), int(cols_str)
+        except (ValueError, AttributeError):
+            print(
+                f"error: --pe-array must be ROWSxCOLS (e.g., '32x32'); "
+                f"got {args.pe_array!r}",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            spec = apply_pe_array_override(spec, rows, cols)
+        except ValueError as exc:
+            print(f"error: --pe-array: {exc}", file=sys.stderr)
+            return 2
 
     # Generate.
     try:

--- a/cli/show_compute_product.py
+++ b/cli/show_compute_product.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+"""
+ComputeProduct Hierarchy Inspector
+
+Prints the full assembled ComputeProduct view for one KPU SKU:
+the SKU layer, the referenced ProcessNode, and every CoolingSolution
+referenced by a thermal profile. Adds a thermal cross-check panel that
+flags TDP-vs-cooling and power-density-vs-cooling violations.
+
+ComputeProduct = ProcessNode + CoolingSolution(s) + SKU. The peer
+inspectors print one layer each (show_kpu, show_process_node,
+show_cooling_solution); this one composes them.
+
+Today only KPU SKUs are supported -- extend when other product types
+need the same composed view.
+
+Usage:
+    python cli/show_compute_product.py stillwater_kpu_t256
+    python cli/show_compute_product.py stillwater_kpu_t768 --output t768.json
+    python cli/show_compute_product.py stillwater_kpu_t64  --output t64.md
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+from embodied_schemas import load_cooling_solutions, load_kpus, load_process_nodes
+from embodied_schemas.cooling_solution import CoolingSolutionEntry
+from embodied_schemas.kpu import KPUEntry
+from embodied_schemas.process_node import ProcessNodeEntry
+
+# Reuse the layer renderers from sibling inspectors so the composed view
+# stays formatting-identical to the per-layer tools.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from show_cooling_solution import _render_md as _render_cool_md  # noqa: E402
+from show_cooling_solution import _render_text as _render_cool_text  # noqa: E402
+from show_kpu import _render_text as _render_kpu_text  # noqa: E402
+from show_process_node import _render_md as _render_node_md  # noqa: E402
+from show_process_node import _render_text as _render_node_text  # noqa: E402
+
+
+# --- Cross-checks -------------------------------------------------------
+
+def _thermal_check_rows(
+    e: KPUEntry,
+    cools: Dict[str, CoolingSolutionEntry],
+) -> List[Tuple[str, str, str, str, str, str, str]]:
+    """One row per thermal profile, ready for any renderer:
+    (profile, tdp_w, w_per_mm2, cooling_id, cool_max_w, cool_max_w_per_mm2, status)."""
+    rows = []
+    die_mm2 = e.die.die_size_mm2
+    for tp in e.power.thermal_profiles:
+        cool = cools.get(tp.cooling_solution_id)
+        density = tp.tdp_watts / die_mm2 if die_mm2 > 0 else 0.0
+        if cool is None:
+            rows.append((
+                tp.name, f"{tp.tdp_watts:.0f}", f"{density:.3f}",
+                tp.cooling_solution_id, "?", "?", "MISSING_COOLING_REF",
+            ))
+            continue
+        flags = []
+        if tp.tdp_watts > cool.max_total_w:
+            flags.append("TDP>cool.max_total_w")
+        if density > cool.max_power_density_w_per_mm2:
+            flags.append("density>cool.max_W/mm^2")
+        status = "OK" if not flags else "; ".join(flags)
+        rows.append((
+            tp.name, f"{tp.tdp_watts:.0f}", f"{density:.3f}",
+            cool.id, f"{cool.max_total_w:.0f}",
+            f"{cool.max_power_density_w_per_mm2:.2f}", status,
+        ))
+    return rows
+
+
+def _render_crosscheck_text(
+    e: KPUEntry, cools: Dict[str, CoolingSolutionEntry]
+) -> str:
+    out = ["=== ComputeProduct cross-checks ===", ""]
+    out.append("--- Thermal headroom (per profile) ---")
+    out.append(
+        f"  {'profile':10s} {'TDP':>5s} {'W/mm^2':>8s}  "
+        f"{'cooling_id':28s} {'max W':>6s} {'max W/mm^2':>10s}  status"
+    )
+    for r in _thermal_check_rows(e, cools):
+        out.append(
+            f"  {r[0]:10s} {r[1]:>5s} {r[2]:>8s}  "
+            f"{r[3]:28s} {r[4]:>6s} {r[5]:>10s}  {r[6]}"
+        )
+    out.append("")
+    return "\n".join(out)
+
+
+def _render_crosscheck_md(
+    e: KPUEntry, cools: Dict[str, CoolingSolutionEntry]
+) -> str:
+    lines = [
+        "## ComputeProduct cross-checks", "",
+        "### Thermal headroom (per profile)", "",
+        "| profile | TDP (W) | W/mm^2 | cooling_id | max W | max W/mm^2 | status |",
+        "|---|---:|---:|---|---:|---:|---|",
+    ]
+    for r in _thermal_check_rows(e, cools):
+        lines.append(
+            f"| {r[0]} | {r[1]} | {r[2]} | `{r[3]}` | {r[4]} | {r[5]} | {r[6]} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+# --- Composition --------------------------------------------------------
+
+def _banner(sku: KPUEntry, node_resolved: bool, cool_unresolved: List[str]) -> List[str]:
+    cooling_ids = sorted({tp.cooling_solution_id for tp in sku.power.thermal_profiles})
+    bar = "#" * 60
+    lines = [
+        bar,
+        f"# ComputeProduct: {sku.id}",
+        f"#   process_node:   {sku.process_node_id} "
+        f"({'resolved' if node_resolved else 'UNRESOLVED'})",
+        f"#   cooling refs:   {', '.join(cooling_ids)}",
+    ]
+    if cool_unresolved:
+        lines.append(f"#   UNRESOLVED:     {', '.join(cool_unresolved)}")
+    lines.append(bar)
+    lines.append("")
+    return lines
+
+
+def _compose_text(
+    sku: KPUEntry, node: Optional[ProcessNodeEntry],
+    cools: Dict[str, CoolingSolutionEntry],
+    cool_unresolved: List[str],
+) -> str:
+    parts = _banner(sku, node is not None, cool_unresolved)
+    parts.append(_render_kpu_text(sku))
+    parts.append("")
+    if node is not None:
+        parts.append(_render_node_text(node))
+        parts.append("")
+    else:
+        parts.append(f"!! ProcessNode {sku.process_node_id!r} not found in catalog")
+        parts.append("")
+    for cid in sorted({tp.cooling_solution_id for tp in sku.power.thermal_profiles}):
+        cool = cools.get(cid)
+        if cool is None:
+            parts.append(f"!! CoolingSolution {cid!r} not found in catalog")
+            parts.append("")
+        else:
+            parts.append(_render_cool_text(cool))
+            parts.append("")
+    parts.append(_render_crosscheck_text(sku, cools))
+    return "\n".join(parts)
+
+
+def _compose_md(
+    sku: KPUEntry, node: Optional[ProcessNodeEntry],
+    cools: Dict[str, CoolingSolutionEntry],
+    cool_unresolved: List[str],
+) -> str:
+    cooling_ids = sorted({tp.cooling_solution_id for tp in sku.power.thermal_profiles})
+    parts = [f"# ComputeProduct: `{sku.id}`", ""]
+    parts.append(
+        f"- process_node: `{sku.process_node_id}`"
+        f"{'' if node is not None else ' (UNRESOLVED)'}"
+    )
+    parts.append(f"- cooling refs: {', '.join(f'`{c}`' for c in cooling_ids)}")
+    if cool_unresolved:
+        parts.append(f"- **UNRESOLVED**: {', '.join(cool_unresolved)}")
+    parts.append("")
+    # show_kpu has no MD renderer; embed text in a fenced block.
+    parts.append("## KPU SKU")
+    parts.append("")
+    parts.append("```")
+    parts.append(_render_kpu_text(sku))
+    parts.append("```")
+    parts.append("")
+    if node is not None:
+        parts.append(_render_node_md(node))
+        parts.append("")
+    else:
+        parts.append(f"> ProcessNode `{sku.process_node_id}` not found in catalog")
+        parts.append("")
+    for cid in cooling_ids:
+        cool = cools.get(cid)
+        if cool is None:
+            parts.append(f"> CoolingSolution `{cid}` not found in catalog")
+            parts.append("")
+        else:
+            parts.append(_render_cool_md(cool))
+            parts.append("")
+    parts.append(_render_crosscheck_md(sku, cools))
+    return "\n".join(parts)
+
+
+def _compose_json(
+    sku: KPUEntry, node: Optional[ProcessNodeEntry],
+    cools: Dict[str, CoolingSolutionEntry],
+    cool_unresolved: List[str],
+) -> Dict[str, Any]:
+    return {
+        "compute_product_id": sku.id,
+        "sku": sku.model_dump(mode="json"),
+        "process_node": node.model_dump(mode="json") if node is not None else None,
+        "cooling_solutions": {
+            cid: cool.model_dump(mode="json") for cid, cool in cools.items()
+        },
+        "unresolved_cooling_refs": cool_unresolved,
+        "cross_checks": {
+            "thermal_headroom": [
+                {
+                    "profile": r[0],
+                    "tdp_w": None if r[1] == "?" else float(r[1]),
+                    "power_density_w_per_mm2": None if r[2] == "?" else float(r[2]),
+                    "cooling_id": r[3],
+                    "cool_max_total_w": None if r[4] == "?" else float(r[4]),
+                    "cool_max_w_per_mm2": None if r[5] == "?" else float(r[5]),
+                    "status": r[6],
+                }
+                for r in _thermal_check_rows(sku, cools)
+            ],
+        },
+    }
+
+
+def _detect_format(output: Optional[str]) -> str:
+    if not output:
+        return "text"
+    ext = os.path.splitext(output)[1].lower().lstrip(".")
+    return {"json": "json", "md": "md", "markdown": "md", "txt": "text"}.get(ext, "text")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Show the full assembled ComputeProduct hierarchy "
+                    "(SKU + ProcessNode + CoolingSolutions) for one KPU SKU."
+    )
+    parser.add_argument("kpu_id", help="KPU SKU id, e.g., stillwater_kpu_t256")
+    parser.add_argument(
+        "--output",
+        help="Output file. Format auto-detected from extension (.json/.md/.txt).",
+    )
+    args = parser.parse_args()
+
+    try:
+        kpus = load_kpus()
+        nodes = load_process_nodes()
+        sols = load_cooling_solutions()
+    except Exception as exc:
+        print(f"error: failed to load catalog: {exc}", file=sys.stderr)
+        return 1
+
+    sku = kpus.get(args.kpu_id)
+    if sku is None:
+        print(
+            f"error: no KPU SKU with id={args.kpu_id!r}. "
+            f"Available: {', '.join(sorted(kpus))}",
+            file=sys.stderr,
+        )
+        return 1
+
+    node = nodes.get(sku.process_node_id)
+    cooling_ids = sorted({tp.cooling_solution_id for tp in sku.power.thermal_profiles})
+    cools = {cid: sols[cid] for cid in cooling_ids if cid in sols}
+    cool_unresolved = [cid for cid in cooling_ids if cid not in sols]
+
+    fmt = _detect_format(args.output)
+    if fmt == "json":
+        rendered = json.dumps(
+            _compose_json(sku, node, cools, cool_unresolved), indent=2
+        ) + "\n"
+    elif fmt == "md":
+        rendered = _compose_md(sku, node, cools, cool_unresolved) + "\n"
+    else:
+        rendered = _compose_text(sku, node, cools, cool_unresolved) + "\n"
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(rendered)
+    else:
+        sys.stdout.write(rendered)
+
+    if node is None or cool_unresolved:
+        print(
+            "warning: ComputeProduct has unresolved refs "
+            f"(node_resolved={node is not None}, "
+            f"cooling_unresolved={cool_unresolved})",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/graphs/hardware/kpu_power_model.py
+++ b/src/graphs/hardware/kpu_power_model.py
@@ -1,0 +1,315 @@
+"""KPU thermal-design-power (TDP) derivation.
+
+Given a SKU spec, a thermal profile (clock + cooling), a process node, and
+a workload assumption, derive the sustained worst-case power dissipation.
+The architect chooses clocks and cooling; TDP is the consequence.
+
+The power model is a roll-up of five terms:
+
+  1. PE compute power      = peak_compute_w x utilization x duty_cycle
+  2. L2 SRAM access        = (1 - L1_hit) x byte_rate x sram_pj_per_byte
+  3. L3 SRAM access        = (1 - L2_hit) x L2_byte_rate x sram_pj_per_byte
+  4. NoC traversal         = noc_flit_rate x avg_hops x noc_pj_per_flit
+  5. DRAM PHY              = (1 - L3_hit) x L3_byte_rate x dram_pj_per_byte
+  + chip leakage           (already on the SKU)
+
+PE compute power uses ``ProcessNode.energy_per_op_pj`` (already in the
+schema) and assumes L1 access energy is rolled into it. Memory and NoC
+terms use the new ProcessNode fields ``sram_access_pj_per_byte``,
+``dram_io_pj_per_byte``, ``noc_pj_per_flit_per_hop``.
+
+Workload assumption: the architect sizes the chip for a target workload,
+not for sustained worst-case GEMM. The default ``WorkloadAssumption``
+captures DNN inference (well-tiled, ~15% compute duty cycle, modest
+cache miss rates). Architects can override per spec or per profile.
+
+The TDP picks the worst-case precision the chip supports -- if the chip
+runs FP32 at higher power than INT8, FP32 sets TDP. Activity factor is
+applied uniformly across precisions (the workload duty cycle is a chip
+property, not a precision-specific one).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from embodied_schemas.kpu import KPUEntry, KPUThermalProfile
+from embodied_schemas.process_node import CircuitClass, ProcessNodeEntry
+
+from .kpu_sku_input import KPUSKUInputSpec
+from .sku_validators.silicon_math import total_chip_leakage_w
+
+
+@dataclass(frozen=True)
+class WorkloadAssumption:
+    """Workload knobs that turn peak compute throughput into sustained power.
+
+    Defaults model well-tiled DNN inference: high cache hit rates,
+    moderate duty cycle (the chip is rate-limited by something, usually
+    DRAM bandwidth or DMA, not compute). Architects override this when
+    sizing for a different workload class (training, sparse, attention,
+    etc.).
+    """
+
+    # Fraction of cycles in which a PE actually fires its datapath. The
+    # rest are clock-gated stalls (DMA waits, pipeline bubbles, control).
+    # Inference: ~0.15. Training: closer to 0.4. Memory-bound LLM: ~0.05.
+    compute_duty_cycle: float = 0.15
+
+    # Bytes touched per op (operand load + result store). 1.5 captures
+    # weight reuse: weights stay resident, only activations stream.
+    bytes_per_op: float = 1.5
+
+    # Cache hit rates. Per-level miss rate = 1 - hit. L1 misses go to L2,
+    # L2 to L3, L3 to DRAM.
+    l1_hit_rate: float = 0.95
+    l2_hit_rate: float = 0.85
+    l3_hit_rate: float = 0.70
+
+    # NoC: fraction of L1 accesses that traverse the on-chip mesh, times
+    # the average number of hops. Tile-local data movement (within-tile
+    # PE-to-PE) is rolled into PE compute energy.
+    noc_traversal_rate_per_op: float = 0.05
+    avg_noc_hops: float = 4.0
+
+
+DEFAULT_WORKLOAD = WorkloadAssumption()
+
+
+@dataclass
+class TDPBreakdown:
+    """Per-term decomposition for one thermal profile."""
+
+    profile_name: str
+    clock_mhz: float
+    worst_precision: str
+    pe_compute_w: float
+    l2_sram_w: float
+    l3_sram_w: float
+    noc_w: float
+    dram_phy_w: float
+    leakage_w: float
+
+    @property
+    def dynamic_w(self) -> float:
+        return self.pe_compute_w + self.l2_sram_w + self.l3_sram_w + self.noc_w + self.dram_phy_w
+
+    @property
+    def total_tdp_w(self) -> float:
+        return self.dynamic_w + self.leakage_w
+
+
+def _peak_compute_w_for_precision(
+    spec: KPUSKUInputSpec,
+    node: ProcessNodeEntry,
+    precision: str,
+    clock_mhz: float,
+) -> float:
+    """Peak compute power assuming every PE that supports `precision` is
+    firing every clock. Sums per-tile-class contributions using the
+    tile's ``pe_circuit_class`` to look up energy_per_op_pj."""
+    clock_hz = clock_mhz * 1e6
+    total_pj_per_clock = 0.0
+    for tile in spec.kpu_architecture.tiles:
+        ops_per_clock = tile.ops_per_tile_per_clock.get(precision, 0.0) * tile.num_tiles
+        if ops_per_clock <= 0:
+            continue
+        key = f"{tile.pe_circuit_class.value}:{precision}"
+        e_pj = node.energy_per_op_pj.get(key)
+        if e_pj is None:
+            continue  # unsupported precision on this library; skip silently
+        total_pj_per_clock += ops_per_clock * e_pj
+    return total_pj_per_clock * clock_hz * 1e-12  # W
+
+
+def _peak_ops_per_s_for_precision(
+    spec: KPUSKUInputSpec,
+    precision: str,
+    clock_mhz: float,
+) -> float:
+    """Total ops/sec across the chip if every supporting tile fires every clock."""
+    clock_hz = clock_mhz * 1e6
+    return clock_hz * sum(
+        tile.num_tiles * tile.ops_per_tile_per_clock.get(precision, 0.0)
+        for tile in spec.kpu_architecture.tiles
+    )
+
+
+def _sram_pj_per_byte(node: ProcessNodeEntry, lib: CircuitClass, default: float) -> float:
+    """Look up the node's sram_access_pj_per_byte for `lib`, falling back
+    to ``default`` if unset (older ProcessNode YAMLs)."""
+    return node.sram_access_pj_per_byte.get(lib, default)
+
+
+def _noc_pj_per_flit(node: ProcessNodeEntry, lib: CircuitClass, default: float) -> float:
+    return node.noc_pj_per_flit_per_hop.get(lib, default)
+
+
+def compute_thermal_profile_tdp_breakdown(
+    spec: KPUSKUInputSpec,
+    profile: KPUThermalProfile,
+    node: ProcessNodeEntry,
+    workload: WorkloadAssumption | None = None,
+) -> TDPBreakdown:
+    """Derive a per-term TDP breakdown for one thermal profile.
+
+    Picks the precision that produces the highest sustained dynamic
+    power and reports it as ``worst_precision``. TDP is the sum of all
+    five terms plus chip leakage.
+    """
+    workload = workload or DEFAULT_WORKLOAD
+    arch = spec.kpu_architecture
+
+    # Build a placeholder KPUEntry so total_chip_leakage_w can walk the
+    # silicon_bin (it expects a sized chip). The transistor / die fields
+    # don't affect leakage math -- only the per-block area does.
+    placeholder = _placeholder_entry(spec, profile, node)
+    leakage_w = max(0.0, total_chip_leakage_w(placeholder, node))
+
+    # Voltage scaling: dynamic power scales by (V/Vnom)^2. Defaults to
+    # nominal_vdd if the profile doesn't pick a Vdd. This is what spreads
+    # TDP across DVFS operating points (Orin-style: lower-power modes
+    # drop both clock AND Vdd).
+    vdd = profile.vdd_v if profile.vdd_v is not None else node.nominal_vdd_v
+    voltage_scale = (vdd / node.nominal_vdd_v) ** 2
+
+    # Per-tile L2 + L3 use sram_hd by convention (matches catalog silicon_bin).
+    sram_pj = _sram_pj_per_byte(node, CircuitClass.SRAM_HD, default=0.5)
+    dram_pj = node.dram_io_pj_per_byte if node.dram_io_pj_per_byte is not None else 7.0
+    noc_pj = _noc_pj_per_flit(node, arch.noc.router_circuit_class, default=1.0)
+    flit_bytes = arch.noc.flit_bytes
+    duty = workload.compute_duty_cycle
+    bpo = workload.bytes_per_op
+
+    best: TDPBreakdown | None = None
+    precisions = set()
+    for tile in arch.tiles:
+        precisions.update(tile.ops_per_tile_per_clock.keys())
+
+    for precision in precisions:
+        peak_compute_w = _peak_compute_w_for_precision(
+            spec, node, precision, profile.clock_mhz
+        )
+        if peak_compute_w <= 0:
+            continue
+        # Tile utilization for this precision (default 0.95 if unset).
+        tile_util = (
+            profile.tile_utilization_by_precision.get(precision, 0.95)
+            if profile.tile_utilization_by_precision
+            else 0.95
+        )
+        # Optional per-profile activity_factor multiplies the chip-wide
+        # workload duty cycle. Lets architects tune low-power profiles
+        # without changing the workload model.
+        profile_activity = (
+            profile.activity_factor if profile.activity_factor is not None else 1.0
+        )
+        effective_duty = duty * profile_activity
+        sustained_compute_w = peak_compute_w * tile_util * effective_duty
+
+        # Memory traffic at this precision.
+        peak_ops_per_s = _peak_ops_per_s_for_precision(
+            spec, precision, profile.clock_mhz
+        )
+        sustained_ops_per_s = peak_ops_per_s * tile_util * effective_duty
+        l1_byte_rate = sustained_ops_per_s * bpo
+        l2_byte_rate = l1_byte_rate * (1.0 - workload.l1_hit_rate)
+        l3_byte_rate = l2_byte_rate * (1.0 - workload.l2_hit_rate)
+        dram_byte_rate = l3_byte_rate * (1.0 - workload.l3_hit_rate)
+
+        # All dynamic terms scale with V^2 (charging/discharging C*V^2*f).
+        # Leakage doesn't scale here (model limitation: should also drop
+        # with Vdd, but our leakage_w_per_mm2 is single-Vdd in the schema).
+        sustained_compute_w *= voltage_scale
+        l2_w = l2_byte_rate * sram_pj * 1e-12 * voltage_scale
+        l3_w = l3_byte_rate * sram_pj * 1e-12 * voltage_scale
+        dram_w = dram_byte_rate * dram_pj * 1e-12 * voltage_scale
+
+        # NoC: a fraction of L1 byte traffic crosses the mesh, packed
+        # into flits, traversing avg_hops on average.
+        noc_byte_rate = l1_byte_rate * workload.noc_traversal_rate_per_op
+        noc_flit_rate = noc_byte_rate / flit_bytes
+        noc_w = noc_flit_rate * workload.avg_noc_hops * noc_pj * 1e-12 * voltage_scale
+
+        bd = TDPBreakdown(
+            profile_name=profile.name,
+            clock_mhz=profile.clock_mhz,
+            worst_precision=precision,
+            pe_compute_w=sustained_compute_w,
+            l2_sram_w=l2_w,
+            l3_sram_w=l3_w,
+            noc_w=noc_w,
+            dram_phy_w=dram_w,
+            leakage_w=leakage_w,
+        )
+        if best is None or bd.total_tdp_w > best.total_tdp_w:
+            best = bd
+
+    if best is None:
+        # Spec has no precisions / no usable tiles; report leakage-only.
+        return TDPBreakdown(
+            profile_name=profile.name,
+            clock_mhz=profile.clock_mhz,
+            worst_precision="(none)",
+            pe_compute_w=0.0, l2_sram_w=0.0, l3_sram_w=0.0,
+            noc_w=0.0, dram_phy_w=0.0, leakage_w=leakage_w,
+        )
+    return best
+
+
+def compute_thermal_profile_tdp_w(
+    spec: KPUSKUInputSpec,
+    profile: KPUThermalProfile,
+    node: ProcessNodeEntry,
+    workload: WorkloadAssumption | None = None,
+) -> float:
+    """Convenience wrapper: just the rounded TDP in watts."""
+    return round(
+        compute_thermal_profile_tdp_breakdown(spec, profile, node, workload).total_tdp_w,
+        1,
+    )
+
+
+def _placeholder_entry(
+    spec: KPUSKUInputSpec,
+    profile: KPUThermalProfile,
+    node: ProcessNodeEntry,
+) -> KPUEntry:
+    """Build a minimum-viable KPUEntry so silicon_math helpers (which
+    walk a SKU rather than a spec) can run during TDP derivation. The
+    die / performance / power roll-ups are placeholders -- only the
+    architecture and silicon_bin matter for the math we use here."""
+    from embodied_schemas import KPUDieSpec, KPUPowerSpec, KPUTheoreticalPerformance
+
+    die = KPUDieSpec(
+        architecture="KPU Tile",
+        foundry=node.foundry,
+        process_nm=node.node_nm,
+        process_name=node.node_name,
+        transistors_billion=1.0,  # placeholder
+        die_size_mm2=1.0,         # placeholder
+    )
+    perf = KPUTheoreticalPerformance(int8_tops=0.0, bf16_tflops=0.0, fp32_tflops=0.0)
+    power = KPUPowerSpec(
+        tdp_watts=profile.tdp_watts if profile.tdp_watts > 0 else 1.0,
+        max_power_watts=profile.tdp_watts if profile.tdp_watts > 0 else 1.0,
+        min_power_watts=profile.tdp_watts if profile.tdp_watts > 0 else 1.0,
+        default_thermal_profile=profile.name,
+        thermal_profiles=[profile],
+    )
+    return KPUEntry(
+        id=spec.id,
+        name=spec.name,
+        vendor=spec.vendor,
+        process_node_id=spec.process_node_id,
+        die=die,
+        kpu_architecture=spec.kpu_architecture,
+        silicon_bin=spec.silicon_bin,
+        clocks=spec.clocks,
+        performance=perf,
+        power=power,
+        market=spec.market,
+        notes=spec.notes,
+        datasheet_url=spec.datasheet_url,
+        last_updated=spec.last_updated,
+    )

--- a/src/graphs/hardware/kpu_sku_generator.py
+++ b/src/graphs/hardware/kpu_sku_generator.py
@@ -10,8 +10,11 @@ inputs and the referenced ``ProcessNodeEntry``:
 * ``performance.{int8_tops, bf16_tflops, fp32_tflops, int4_tops}`` --
   Σ(tile.num_tiles × ops_per_tile_per_clock) × default-profile clock
 * ``power.{tdp_watts, max_power_watts, min_power_watts,
-  default_thermal_profile, thermal_profiles}`` -- from the input
-  thermal profiles (architect-declared)
+  thermal_profiles[].tdp_watts}`` -- DERIVED via the kpu_power_model
+  from clock + architecture + ProcessNode energies under a
+  ``WorkloadAssumption``. The architect's hand-authored tdp_watts in
+  the input spec is ignored. The architect chooses clocks and cooling;
+  TDP is the consequence.
 * ``power.idle_power_watts`` -- chip-wide leakage from ProcessNode
   ``leakage_w_per_mm2`` × per-block area
 
@@ -38,8 +41,14 @@ from embodied_schemas import (
     KPUTheoreticalPerformance,
     load_process_nodes,
 )
+from embodied_schemas.kpu import KPUThermalProfile
 from embodied_schemas.process_node import ProcessNodeEntry
 
+from .kpu_power_model import (
+    DEFAULT_WORKLOAD,
+    WorkloadAssumption,
+    compute_thermal_profile_tdp_w,
+)
 from .kpu_sku_input import KPUSKUInputSpec
 from .sku_validators.silicon_math import (
     SiliconMathError,
@@ -60,6 +69,7 @@ def generate_kpu_sku(
     spec: KPUSKUInputSpec,
     *,
     process_nodes: Optional[dict[str, ProcessNodeEntry]] = None,
+    workload: Optional[WorkloadAssumption] = None,
 ) -> KPUEntry:
     """Produce a fully-populated KPUEntry from an input spec.
 
@@ -201,20 +211,31 @@ def generate_kpu_sku(
     )
 
     # ---- Power roll-up ----
-    # tdp_watts comes from the default profile (architect-declared).
-    # max/min from the highest/lowest profile TDP.
-    max_w = max(p.tdp_watts for p in spec.thermal_profiles)
-    min_w = min(p.tdp_watts for p in spec.thermal_profiles)
+    # TDP per profile is DERIVED from the chip configuration (clock,
+    # architecture, ProcessNode energies) under the workload assumption
+    # in graphs.hardware.kpu_power_model.WorkloadAssumption. The
+    # architect's hand-authored tdp_watts in the input spec is ignored
+    # -- it's the consequence of the design, not an input.
+    workload = workload or DEFAULT_WORKLOAD
+    derived_profiles: list[KPUThermalProfile] = []
+    for p in spec.thermal_profiles:
+        derived_tdp = compute_thermal_profile_tdp_w(spec, p, node, workload)
+        derived_profiles.append(p.model_copy(update={"tdp_watts": derived_tdp}))
+    derived_default = next(
+        dp for dp in derived_profiles if dp.name == spec.default_thermal_profile
+    )
+    max_w = max(p.tdp_watts for p in derived_profiles)
+    min_w = min(p.tdp_watts for p in derived_profiles)
     leakage_w = total_chip_leakage_w(placeholder_sku, node)
     idle_w = round(leakage_w, 2) if leakage_w > 0 else None
 
     power = KPUPowerSpec(
-        tdp_watts=default_profile.tdp_watts,
+        tdp_watts=derived_default.tdp_watts,
         max_power_watts=max_w,
         min_power_watts=min_w,
         idle_power_watts=idle_w,
         default_thermal_profile=spec.default_thermal_profile,
-        thermal_profiles=spec.thermal_profiles,
+        thermal_profiles=derived_profiles,
     )
 
     # ---- Construct the final KPUEntry ----
@@ -234,6 +255,61 @@ def generate_kpu_sku(
         datasheet_url=spec.datasheet_url,
         last_updated=spec.last_updated,
     )
+
+
+def apply_pe_array_override(
+    spec: KPUSKUInputSpec,
+    pe_array_rows: int,
+    pe_array_cols: int,
+) -> KPUSKUInputSpec:
+    """Resize the PE array on every tile class in a spec.
+
+    Returns a new ``KPUSKUInputSpec`` with ``pe_array_rows`` /
+    ``pe_array_cols`` set to the given dimensions on every tile class,
+    and ``ops_per_tile_per_clock`` rescaled by ``new_pes / old_pes`` so
+    the per-PE op throughput (e.g., int8=2 ops/PE/clock) is preserved.
+    Pipeline fill / drain cycles are also rescaled to track the longer
+    PE-array dimension, matching the family convention (T64/T128 use 32
+    fill/drain at 32x32; T768 uses 16 at 16x8).
+
+    Designed for roadmap sweeps -- run the generator across PE-array
+    sizes without hand-editing each tile class. Caller is responsible
+    for choosing dimensions that make architectural sense (e.g., a
+    32x32 array is dense in NoC routers per PE; a 16x16 leaves more
+    NoC headroom).
+
+    Note: silicon_bin coefficients are *not* touched -- per-PE blocks
+    use ``kind=per_pe`` so total area auto-scales with the new PE
+    count. Per-tile and fixed blocks are insensitive to PE size.
+    """
+    if pe_array_rows <= 0 or pe_array_cols <= 0:
+        raise ValueError(
+            f"pe_array dimensions must be positive; got "
+            f"rows={pe_array_rows}, cols={pe_array_cols}"
+        )
+    new_pes = pe_array_rows * pe_array_cols
+    new_pipeline_depth = max(pe_array_rows, pe_array_cols)
+    new_tiles = []
+    for t in spec.kpu_architecture.tiles:
+        old_pes = t.pe_array_rows * t.pe_array_cols
+        scale = new_pes / old_pes
+        new_ops = {
+            precision: ops * scale
+            for precision, ops in t.ops_per_tile_per_clock.items()
+        }
+        new_tiles.append(
+            t.model_copy(
+                update={
+                    "pe_array_rows": pe_array_rows,
+                    "pe_array_cols": pe_array_cols,
+                    "ops_per_tile_per_clock": new_ops,
+                    "pipeline_fill_cycles": new_pipeline_depth,
+                    "pipeline_drain_cycles": new_pipeline_depth,
+                }
+            )
+        )
+    new_arch = spec.kpu_architecture.model_copy(update={"tiles": new_tiles})
+    return spec.model_copy(update={"kpu_architecture": new_arch})
 
 
 def input_spec_from_kpu_entry(entry: KPUEntry) -> KPUSKUInputSpec:

--- a/tests/cli/test_check_tdp_feasibility.py
+++ b/tests/cli/test_check_tdp_feasibility.py
@@ -66,14 +66,11 @@ class TestKPUFeasibility:
             f"(over by {row.overshoot:.2f}x)"
         )
 
-    @pytest.mark.xfail(
-        reason="T64/T128 moved to canonical 32x32 tile; their 6 W / "
-               "12 W TDP targets need re-derivation. Run "
-               "cli/check_tdp_feasibility.py and pick envelopes that "
-               "accommodate 1024 PE/tile at the listed clocks.",
-        strict=True,
-    )
     def test_t64_t128_feasible_at_32x32(self):
+        """T64/T128 moved to canonical 32x32 tile; PR #153 then dropped
+        catalog clocks and added per-profile Vdd so derived TDPs land on
+        the 6 W / 12 W targets cleanly. Both SKUs are now feasible at
+        their default operating points (xfail removed)."""
         tool = _load_tool()
         for sku in ("Stillwater-KPU-T64", "Stillwater-KPU-T128"):
             row = tool.check_sku(sku)
@@ -104,19 +101,21 @@ class TestKPUFeasibility:
 class TestCLI:
     def test_cli_runs_default(self):
         tool = _load_tool()
-        # T128 at 32x32 exceeds its 12 W TDP; exit 0 still expected when
-        # --fail-on-infeasible is not set (tool reports and returns 0).
+        # Tool returns 0 by default whether or not the SKU is feasible;
+        # only --fail-on-infeasible elevates the exit code (T128 is in
+        # fact feasible at its post-PR#153 12W operating point).
         rc = tool.main(["--hardware", "kpu_t128"])
         assert rc == 0
 
     def test_cli_fail_on_infeasible_flag(self):
         tool = _load_tool()
-        # T64 and T128 moved to canonical 32x32 tile and now exceed
-        # their original 6 W / 12 W envelopes; the --fail-on-infeasible
-        # run is expected to return 1 until new TDP targets are chosen.
+        # PR #153 dropped catalog clocks and added per-profile Vdd; T64,
+        # T128, and T256 now derive cleanly to their 6 W / 12 W / 30 W
+        # targets and are all feasible. --fail-on-infeasible should
+        # return 0 since no infeasible SKUs are passed.
         rc = tool.main(["--hardware", "kpu_t64", "kpu_t128", "kpu_t256",
                         "--fail-on-infeasible"])
-        assert rc == 1
+        assert rc == 0
 
     def test_cli_t256_alone_still_feasible(self):
         tool = _load_tool()

--- a/tests/hardware/test_kpu_domainflow_tile.py
+++ b/tests/hardware/test_kpu_domainflow_tile.py
@@ -43,16 +43,19 @@ class TestPE_ArraySizes:
         for spec in cr.tile_specializations:
             assert spec.array_dimensions == (32, 32)
 
-    def test_t256_uses_20x20_pe_arrays(self):
-        """T256 uses 20x20 (revised from 16x16 after commercial review).
-        At 16x16 x 256 tiles, T256 had fewer total PEs (65,536) than T128
-        (73,728) - making it commercially unjustifiable at 2.5x TDP.
-        20x20 x 256 = 102,400 PEs gives T256 a ~1.56x peak advantage."""
+    def test_t256_uses_32x32_pe_arrays(self):
+        """T256 uses 32x32 (uniform with T64/T128 since the post-PR#152
+        family-consistency rebuild). The earlier 20x20 design was a
+        hand-tuned compromise to keep T256 in a 30W envelope at 1.4 GHz;
+        once TDP became derived from (clock, Vdd) per PR #153, the
+        20x20 inverse-scaling design produced a discontinuity in the
+        cost/perf curve and was retired in favor of the uniform 32x32.
+        T256 now has 256 tiles x 1024 PEs = 262,144 PEs total."""
         model = kpu_t256_resource_model()
         tp = model.thermal_operating_points[model.default_thermal_profile]
         cr = tp.performance_specs[Precision.INT8].compute_resource
         for spec in cr.tile_specializations:
-            assert spec.array_dimensions == (20, 20)
+            assert spec.array_dimensions == (32, 32)
 
 
 class TestScheduleClass:
@@ -238,15 +241,16 @@ class TestEnergyAdvantage:
         )
 
     def test_kpu_array_size_sanity(self):
-        """M0.5 canonical KPU tile is 32x32; T64 and T128 both use it.
-        T256 uses a smaller 20x20 per-tile array to trade per-tile
-        array size for tile count as the engine grows:
-        T64  = 32x32 (1024 PEs/tile) - canonical tile
-        T128 = 32x32 (1024 PEs/tile) - canonical tile, 2x count
-        T256 = 20x20 (400 PEs/tile)  - smaller tiles for the big engine
-        The 32x32 tile for T64 and T128 exceeds the original 6 W / 12 W
-        ALU envelopes at listed clocks; rerun cli/check_tdp_feasibility.py
-        to pick new TDP targets."""
+        """All edge KPUs use the canonical 32x32 PE tile. T256 was
+        retrofitted from 20x20 to 32x32 in the post-PR#152 family-
+        consistency rebuild so PE count scales linearly with tile count
+        across the family, making roadmap sweeps clean:
+        T64  = 32x32 (1024 PEs/tile) -> 65,536 PEs total
+        T128 = 32x32 (1024 PEs/tile) -> 131,072 PEs total
+        T256 = 32x32 (1024 PEs/tile) -> 262,144 PEs total
+        TDP scaling is handled per-profile via (clock, Vdd) operating
+        points (PR #153); the 32x32 design no longer creates an
+        envelope problem because the architect tunes Vdd per profile."""
         t64 = kpu_t64_resource_model()
         t128 = kpu_t128_resource_model()
         t256 = kpu_t256_resource_model()
@@ -256,7 +260,7 @@ class TestEnergyAdvantage:
             return cr.tile_specializations[0].pe_count
         assert pe_count(t64) == 1024
         assert pe_count(t128) == 1024
-        assert pe_count(t256) == 400
+        assert pe_count(t256) == 1024
 
     def test_t256_peak_throughput_exceeds_t128(self):
         """Commercial sanity: T256 at the bigger TDP must deliver more

--- a/tests/hardware/test_kpu_sku_generator.py
+++ b/tests/hardware/test_kpu_sku_generator.py
@@ -298,10 +298,7 @@ def test_pe_array_override_rejects_non_positive_dims(catalogs):
 # Power model -- V^2*f scaling, sweep monotonicity, activity_factor knob
 # ---------------------------------------------------------------------------
 
-from graphs.hardware.kpu_power_model import (
-    WorkloadAssumption,
-    compute_thermal_profile_tdp_breakdown,
-)
+from graphs.hardware.kpu_power_model import compute_thermal_profile_tdp_breakdown
 
 
 def test_tdp_scales_quadratically_with_vdd(catalogs):

--- a/tests/hardware/test_kpu_sku_generator.py
+++ b/tests/hardware/test_kpu_sku_generator.py
@@ -23,6 +23,7 @@ from embodied_schemas import (
 
 from graphs.hardware.kpu_sku_generator import (
     GeneratorError,
+    apply_pe_array_override,
     generate_kpu_sku,
     input_spec_from_kpu_entry,
 )
@@ -115,18 +116,31 @@ def test_roundtrip_performance_within_rounding(sku_id, catalogs):
     "stillwater_kpu_t256",
     "stillwater_kpu_t768",
 ])
-def test_roundtrip_power_default_tdp_passes_through(sku_id, catalogs):
-    """power.tdp_watts comes from the default thermal profile -- the
-    generator must not change it."""
+def test_roundtrip_power_default_tdp_is_derived(sku_id, catalogs):
+    """power.tdp_watts is DERIVED by the kpu_power_model from
+    (clock, Vdd, ProcessNode energies, WorkloadAssumption). The catalog
+    YAML's tdp_watts must match the generator's derived value to within
+    0.5W -- the architect tunes (clock, Vdd) per profile so derivation
+    lands at the target TDP."""
     original = catalogs["kpus"][sku_id]
     spec = input_spec_from_kpu_entry(original)
     regen = generate_kpu_sku(
         spec,
         process_nodes=catalogs["process_nodes"],
     )
-    assert regen.power.tdp_watts == original.power.tdp_watts
     assert regen.power.default_thermal_profile == original.power.default_thermal_profile
     assert len(regen.power.thermal_profiles) == len(original.power.thermal_profiles)
+    # Default-profile TDP within rounding of catalog target
+    assert abs(regen.power.tdp_watts - original.power.tdp_watts) < 0.5, (
+        f"{sku_id}: catalog default TDP={original.power.tdp_watts} W, "
+        f"derived={regen.power.tdp_watts} W"
+    )
+    # Per-profile derived TDPs match catalog targets
+    for o, r in zip(original.power.thermal_profiles, regen.power.thermal_profiles):
+        assert abs(r.tdp_watts - o.tdp_watts) < 0.5, (
+            f"{sku_id} profile {o.name}: catalog={o.tdp_watts} W, "
+            f"derived={r.tdp_watts} W"
+        )
 
 
 @pytest.mark.parametrize("sku_id", [
@@ -225,3 +239,130 @@ def test_input_spec_does_not_carry_die_or_perf_rollups(catalogs):
     assert "die" not in spec_fields
     assert "performance" not in spec_fields
     assert "power" not in spec_fields  # Power.tdp roll-up is generator-derived; profiles are separate
+
+
+# ---------------------------------------------------------------------------
+# apply_pe_array_override -- PE-array sweep helper
+# ---------------------------------------------------------------------------
+
+def test_pe_array_override_is_no_op_when_dims_unchanged(catalogs):
+    """Override to the spec's existing PE-array dims must round-trip."""
+    original = catalogs["kpus"]["stillwater_kpu_t256"]
+    spec = input_spec_from_kpu_entry(original)
+    rows = spec.kpu_architecture.tiles[0].pe_array_rows
+    cols = spec.kpu_architecture.tiles[0].pe_array_cols
+    overridden = apply_pe_array_override(spec, rows, cols)
+    g_orig = generate_kpu_sku(spec, process_nodes=catalogs["process_nodes"])
+    g_over = generate_kpu_sku(overridden, process_nodes=catalogs["process_nodes"])
+    assert g_orig.die.die_size_mm2 == g_over.die.die_size_mm2
+    assert g_orig.die.transistors_billion == g_over.die.transistors_billion
+    assert g_orig.performance == g_over.performance
+
+
+def test_pe_array_override_preserves_ops_per_pe_ratio(catalogs):
+    """Scaling PE-array size must keep ops/PE/clock constant."""
+    original = catalogs["kpus"]["stillwater_kpu_t256"]
+    spec = input_spec_from_kpu_entry(original)
+    overridden = apply_pe_array_override(spec, 16, 16)
+    for orig_t, new_t in zip(spec.kpu_architecture.tiles, overridden.kpu_architecture.tiles):
+        old_pes = orig_t.pe_array_rows * orig_t.pe_array_cols
+        new_pes = new_t.pe_array_rows * new_t.pe_array_cols
+        for precision, old_ops in orig_t.ops_per_tile_per_clock.items():
+            new_ops = new_t.ops_per_tile_per_clock[precision]
+            assert (new_ops / new_pes) == pytest.approx(old_ops / old_pes)
+
+
+def test_pe_array_override_scales_die_area(catalogs):
+    """Halving PE-array dims should reduce die area but not below the
+    fixed (IO/control/memory_phys) floor."""
+    original = catalogs["kpus"]["stillwater_kpu_t256"]
+    spec = input_spec_from_kpu_entry(original)
+    g_full = generate_kpu_sku(spec, process_nodes=catalogs["process_nodes"])
+    g_half = generate_kpu_sku(
+        apply_pe_array_override(spec, 16, 16),
+        process_nodes=catalogs["process_nodes"],
+    )
+    assert g_half.die.die_size_mm2 < g_full.die.die_size_mm2
+    assert g_half.performance.int8_tops < g_full.performance.int8_tops
+
+
+def test_pe_array_override_rejects_non_positive_dims(catalogs):
+    spec = input_spec_from_kpu_entry(catalogs["kpus"]["stillwater_kpu_t256"])
+    with pytest.raises(ValueError):
+        apply_pe_array_override(spec, 0, 32)
+    with pytest.raises(ValueError):
+        apply_pe_array_override(spec, 32, -1)
+
+
+# ---------------------------------------------------------------------------
+# Power model -- V^2*f scaling, sweep monotonicity, activity_factor knob
+# ---------------------------------------------------------------------------
+
+from graphs.hardware.kpu_power_model import (
+    WorkloadAssumption,
+    compute_thermal_profile_tdp_breakdown,
+)
+
+
+def test_tdp_scales_quadratically_with_vdd(catalogs):
+    """Dropping Vdd by sqrt(2) should halve the dynamic power; total
+    TDP drops by half the dynamic share."""
+    sku = catalogs["kpus"]["stillwater_kpu_t256"]
+    spec = input_spec_from_kpu_entry(sku)
+    node = catalogs["process_nodes"][sku.process_node_id]
+    # Take the default profile and run with two Vdds: nominal and nominal/sqrt(2).
+    base = sku.power.thermal_profiles[1]  # 30W profile
+    high_v = base.model_copy(update={"vdd_v": 0.80})  # ~ Vnom
+    low_v = base.model_copy(update={"vdd_v": 0.80 / (2 ** 0.5)})  # halved V^2
+    bd_high = compute_thermal_profile_tdp_breakdown(spec, high_v, node)
+    bd_low = compute_thermal_profile_tdp_breakdown(spec, low_v, node)
+    # Dynamic should halve; leakage unchanged.
+    assert bd_low.dynamic_w == pytest.approx(bd_high.dynamic_w / 2.0, rel=0.01)
+    assert bd_low.leakage_w == pytest.approx(bd_high.leakage_w)
+
+
+def test_tdp_scales_linearly_with_clock(catalogs):
+    """At fixed Vdd, doubling clock doubles dynamic power."""
+    sku = catalogs["kpus"]["stillwater_kpu_t256"]
+    spec = input_spec_from_kpu_entry(sku)
+    node = catalogs["process_nodes"][sku.process_node_id]
+    base = sku.power.thermal_profiles[1]
+    p_low = base.model_copy(update={"clock_mhz": 500.0, "vdd_v": 0.80})
+    p_high = base.model_copy(update={"clock_mhz": 1000.0, "vdd_v": 0.80})
+    bd_low = compute_thermal_profile_tdp_breakdown(spec, p_low, node)
+    bd_high = compute_thermal_profile_tdp_breakdown(spec, p_high, node)
+    assert bd_high.dynamic_w == pytest.approx(2.0 * bd_low.dynamic_w, rel=0.01)
+
+
+def test_activity_factor_scales_dynamic(catalogs):
+    """Per-profile activity_factor=0.5 should halve dynamic power
+    (it's a multiplier on the workload duty cycle)."""
+    sku = catalogs["kpus"]["stillwater_kpu_t256"]
+    spec = input_spec_from_kpu_entry(sku)
+    node = catalogs["process_nodes"][sku.process_node_id]
+    base = sku.power.thermal_profiles[1]
+    full = base.model_copy(update={"activity_factor": 1.0})
+    half = base.model_copy(update={"activity_factor": 0.5})
+    bd_full = compute_thermal_profile_tdp_breakdown(spec, full, node)
+    bd_half = compute_thermal_profile_tdp_breakdown(spec, half, node)
+    assert bd_half.dynamic_w == pytest.approx(bd_full.dynamic_w / 2.0, rel=0.01)
+    assert bd_half.leakage_w == pytest.approx(bd_full.leakage_w)
+
+
+def test_pe_array_sweep_tdp_monotonic(catalogs):
+    """Across a PE-array sweep at fixed clock + Vdd, derived TDP must
+    strictly increase with PE count -- the whole point of programmable
+    PE arrays for roadmap generation."""
+    sku = catalogs["kpus"]["stillwater_kpu_t256"]
+    spec = input_spec_from_kpu_entry(sku)
+    node = catalogs["process_nodes"][sku.process_node_id]
+    base = sku.power.thermal_profiles[1]
+    sweep = [(16, 16), (24, 24), (32, 32), (40, 40)]
+    tdps = []
+    for rows, cols in sweep:
+        s = apply_pe_array_override(spec, rows, cols)
+        bd = compute_thermal_profile_tdp_breakdown(s, base, node)
+        tdps.append(bd.total_tdp_w)
+    assert tdps == sorted(tdps), (
+        f"TDP not monotonic across PE-array sweep: {list(zip(sweep, tdps))}"
+    )

--- a/tests/hardware/test_kpu_t64_precision_profiles.py
+++ b/tests/hardware/test_kpu_t64_precision_profiles.py
@@ -32,22 +32,21 @@ def test_kpu_t64_lists_precision(kpu_t64, precision):
 @pytest.mark.parametrize(
     "precision,expected_tops",
     [
-        # Phase 4b PR 4 reconciled to M0.5 / loader values. Previous
-        # numbers came from a pre-M0.5 16x16 PE-array model that
-        # contradicted the 32x32 ops_per_tile_per_clock already declared
-        # in this file's TileSpecialization block. See
-        # docs/designs/kpu-test-contract-snapshot.md sections 1, 5.
-        (Precision.INT4, 162.2),  # 44 INT8-tiles x 4096 INT4 x 900 MHz
-        (Precision.INT8, 118.0),  # 64 tiles x 2048 INT8 x 900 MHz
-        (Precision.BF16, 59.0),   # 64 tiles x 1024 BF16 x 900 MHz
-        (Precision.FP16, 59.0),   # = BF16 throughput (same datapath)
-        (Precision.FP32, 6.0),    # 13 BF16-primary tiles x 512 FP32 x 900 MHz
+        # PR #153 dropped the catalog default profile clock from 900 MHz
+        # to 475 MHz when Vdd was added per profile (Orin-style DVFS).
+        # Peak TOPS scales linearly with clock so values are 475/900 of
+        # the prior numbers. Architecture (32x32 PE, 64 tiles) unchanged.
+        (Precision.INT4,  85.6),  # 44 INT8-tiles x 4096 INT4 x 475 MHz
+        (Precision.INT8,  62.3),  # 64 tiles x 2048 INT8 x 475 MHz
+        (Precision.BF16,  31.1),  # 64 tiles x 1024 BF16 x 475 MHz
+        (Precision.FP16,  31.1),  # = BF16 throughput (same datapath)
+        (Precision.FP32,   3.2),  # 13 BF16-primary tiles x 512 FP32 x 475 MHz
     ],
 )
 def test_kpu_t64_peak_ops(kpu_t64, precision, expected_tops):
     """get_peak_ops must return the per-precision value, not the INT8 fallback."""
     actual_tops = kpu_t64.get_peak_ops(precision) / 1e12
-    assert actual_tops == pytest.approx(expected_tops, rel=1e-6)
+    assert actual_tops == pytest.approx(expected_tops, abs=0.05)
 
 
 @pytest.mark.parametrize(

--- a/tests/hardware/test_sku_validators_phase2b.py
+++ b/tests/hardware/test_sku_validators_phase2b.py
@@ -170,18 +170,22 @@ def test_cross_ref_catches_unsupported_circuit_class(ctx):
 # ---------------------------------------------------------------------------
 
 def test_power_monotonicity_catches_inverted_clocks(ctx):
-    """A higher-TDP profile that runs slower than a lower-TDP one."""
+    """A higher-TDP profile that runs slower than a lower-TDP one. Pick
+    the inverted clock relative to the catalog's middle-profile clock so
+    the test stays robust as catalog clocks evolve (PR #153 dropped the
+    catalog clocks substantially when Vdd was added per profile)."""
     profiles = list(ctx.sku.power.thermal_profiles)
-    # Sorted by TDP ascending: 15W -> 1100, 30W -> 1400, 50W -> 1650
-    # Force 50W to run at 1000 MHz (slower than 30W's 1400).
+    by_tdp = sorted(profiles, key=lambda p: p.tdp_watts)
+    middle, top = by_tdp[1], by_tdp[2]
+    inverted_clock = middle.clock_mhz - 50.0  # below middle profile's clock
     for i, p in enumerate(profiles):
-        if p.name == "50W":
-            profiles[i] = p.model_copy(update={"clock_mhz": 1000.0})
+        if p.name == top.name:
+            profiles[i] = p.model_copy(update={"clock_mhz": inverted_clock})
     bad_power = ctx.sku.power.model_copy(update={"thermal_profiles": profiles})
     bad_ctx = _ctx_with_sku(ctx, power=bad_power)
     findings = _findings_for("power_profile_monotonicity", bad_ctx)
     assert any(
-        f.severity == Severity.WARNING and f.profile == "50W"
+        f.severity == Severity.WARNING and f.profile == top.name
         for f in findings
     )
 


### PR DESCRIPTION
## Summary

- **Derived TDP**: KPU SKU generator now computes TDP per thermal profile from `(clock, Vdd, ProcessNode energies, WorkloadAssumption)` via the new `graphs.hardware.kpu_power_model` module. Architects pick clocks and cooling; TDP is the consequence. Replaces the old "trust architect-declared `tdp_watts`" path. Catalog round-trips: derived TDP equals catalog target within 0.5W on every profile across all 4 SKUs.
- **PE-array programmability**: `apply_pe_array_override(spec, rows, cols)` rescales every tile class's PE array and `ops_per_tile_per_clock` (preserving per-PE op throughput) so cost/perf roadmaps can sweep PE size with one command. Surfaced via `--pe-array ROWSxCOLS` on `cli/generate_kpu_sku.py`.
- **`cli/show_compute_product.py`**: prints the assembled ComputeProduct hierarchy (SKU + ProcessNode + every referenced CoolingSolution) plus a thermal-headroom cross-check panel.

## Power model details

- V²·f scaling: dynamic terms (PE compute, L2/L3 SRAM, NoC, DRAM PHY) scale by `(vdd_v / nominal_vdd_v)²`; leakage held flat (single-Vdd schema limitation — flagged for follow-up with `leakage(Vdd)` curves).
- WorkloadAssumption defaults to well-tiled DNN inference (compute_duty_cycle=0.15, bytes_per_op=1.5, L1/L2/L3 hit rates 0.95/0.85/0.70). Architects override per-spec for different workload mixes.
- Worst-case-precision selection: bf16 dominates for the current SKU set (1.4 vs 0.3 pJ/op outweighs lower ops/clock).
- Optional per-profile `activity_factor` knob multiplies the workload duty cycle for fine-tuning a single operating point without changing the chip-wide model.

## Roadmap sweep example (T256, 256 tiles, 1.4 GHz @ 0.75V)

| PE array | PEs/tile | int8 TOPS | die mm² | trans (B) | idle W |
|---|---:|---:|---:|---:|---:|
| 16×16 | 256 | 183.5 | 124.4 | 4.72 | 0.79 |
| 20×20 | 400 | 286.7 | 136.3 | 5.04 | 0.98 |
| 32×32 | 1024 | 734.0 | 188.0 | 6.42 | 1.79 |
| 40×40 | 1600 | 1146.9 | 235.6 | 7.69 | 2.54 |

## Dependencies

Requires the matching embodied-schemas commit (now merged) that adds `vdd_v` + `activity_factor` to `KPUThermalProfile` and `sram_access_pj_per_byte` / `dram_io_pj_per_byte` / `noc_pj_per_flit_per_hop` to `ProcessNodeEntry`.

## Test plan

- [x] `pytest tests/hardware/test_kpu_sku_generator.py` — 29/29 passing
  - 4 round-trip tests (one per SKU): catalog TDP == derived TDP within 0.5W on every profile
  - V²·f scaling: TDP halves when V drops by √2; doubles when clock doubles
  - `activity_factor` knob: 0.5× activity halves dynamic, leaves leakage unchanged
  - PE-array sweep produces strictly monotonic TDP — the roadmap-generation invariant
  - `apply_pe_array_override` no-op, ops/PE preservation, area scaling, dim validation
- [x] `cli/show_compute_product.py stillwater_kpu_t{64,128,256,768}` — all four render cleanly with OK cross-check status
- [x] `cli/generate_kpu_sku.py --from-sku stillwater_kpu_t256 --pe-array {16x16,24x24,32x32,40x40}` — sweep produces consistent (PE area, transistors, perf, V/f, TDP, idle) at each step

## Notes for reviewers

- **Catalog clocks dropped substantially** on t64/t128/t256 (e.g., t256 default went 1400 → 600 MHz). The prior catalog values were aspirational marketing numbers — chips couldn't physically sustain them at the advertised TDPs under the workload model. New clocks line up with real-world Orin AGX (420/624/828 MHz at 15/30/50W). Marketing positioning may need a refresh.
- **t256 PE arrays bumped from 20×20 → 32×32** (uniform with t64/t128) so cost/perf curve stays continuous across the entry/mid/high tier. t256 die area 136 → 188 mm², transistors 5.04 → 6.42 B, total PEs 102K → 262K.
- **t768 untouched** at the microarch level — it uses different N7-tuned ops/PE ratios; left as the datacenter outlier per prior decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)