### PR TITLE
feat(hardware): adopt new KPU SKU naming convention; rename legacy refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,8 @@ jobs:
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
           #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
-          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
+          #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
+          ref: 846a0d219b5e8ade881ddae5d13747926599a0c0
           path: embodied-schemas
           fetch-depth: 1
 
@@ -135,7 +136,8 @@ jobs:
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
           #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
-          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
+          #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
+          ref: 846a0d219b5e8ade881ddae5d13747926599a0c0
           path: embodied-schemas
           fetch-depth: 1
 
@@ -230,7 +232,8 @@ jobs:
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
           #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
-          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
+          #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
+          ref: 846a0d219b5e8ade881ddae5d13747926599a0c0
           path: embodied-schemas
           fetch-depth: 1
 
@@ -322,7 +325,8 @@ jobs:
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
           #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
-          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
+          #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
+          ref: 846a0d219b5e8ade881ddae5d13747926599a0c0
           path: embodied-schemas
           fetch-depth: 1
 
@@ -387,7 +391,8 @@ jobs:
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
           #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
-          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
+          #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
+          ref: 846a0d219b5e8ade881ddae5d13747926599a0c0
           path: embodied-schemas
           fetch-depth: 1
 
@@ -440,7 +445,8 @@ jobs:
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
           #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
-          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
+          #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
+          ref: 846a0d219b5e8ade881ddae5d13747926599a0c0
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -93,7 +93,8 @@ jobs:
           #   PR #11 (bd61f3c) FP16 throughput backfill on KPU tile classes
           #   PR #12 (3509e68) PROCESS_NODE_DATA_DIR env overlay (Phase 7)
           #   PR #13 (5741e75) per-profile Vdd + ProcessNode SRAM/NoC/DRAM energies
-          ref: 5741e75fff786d6fa50d749c0711ddc8eb06fc51
+          #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
+          ref: 846a0d219b5e8ade881ddae5d13747926599a0c0
           path: embodied-schemas
           fetch-depth: 1
 

--- a/cli/generate_kpu_sku.py
+++ b/cli/generate_kpu_sku.py
@@ -21,13 +21,13 @@ Two modes:
 
 2. Extract a spec from an existing SKU and regenerate (template / round-trip):
 
-    python cli/generate_kpu_sku.py --from-sku stillwater_kpu_t256 \\
+    python cli/generate_kpu_sku.py --from-sku kpu_t256_32x32_lp5x16_16nm_tsmc_ffp \\
         --output regenerated_t256.yaml --validate
 
 3. Roadmap sweep -- override PE-array size while keeping everything else:
 
     for pe in 16x16 24x24 32x32 40x40; do
-      python cli/generate_kpu_sku.py --from-sku stillwater_kpu_t256 \\
+      python cli/generate_kpu_sku.py --from-sku kpu_t256_32x32_lp5x16_16nm_tsmc_ffp \\
           --pe-array $pe --output t256_$pe.yaml
     done
 
@@ -112,7 +112,7 @@ def main() -> int:
         help="Override PE-array dimensions across every tile class "
         "(e.g., '32x32', '16x16'). ops_per_tile_per_clock and pipeline "
         "fill/drain cycles are scaled to match. Use for roadmap sweeps: "
-        "`--from-sku stillwater_kpu_t256 --pe-array 16x16` regenerates "
+        "`--from-sku kpu_t256_32x32_lp5x16_16nm_tsmc_ffp --pe-array 16x16` regenerates "
         "T256 with smaller PEs to compare cost / capability.",
     )
     parser.add_argument(

--- a/cli/list_kpus.py
+++ b/cli/list_kpus.py
@@ -148,8 +148,11 @@ def _filter_rows(
     if node_nm is not None:
         out = [r for r in out if r.node_nm == node_nm]
     if library:
+        # Match against the LAST '_'-segment of the SKU id (the library
+        # tag's position in the naming convention) so short tags like
+        # 'lp' don't accidentally match memory tokens such as 'lp5x16'.
         lib = library.lower()
-        out = [r for r in out if lib in r.id.lower()]
+        out = [r for r in out if lib in r.id.rsplit("_", 1)[-1].lower()]
     return out
 
 

--- a/cli/list_kpus.py
+++ b/cli/list_kpus.py
@@ -19,6 +19,10 @@ Usage:
     python cli/list_kpus.py
     python cli/list_kpus.py --vendor stillwater
     python cli/list_kpus.py --target-market datacenter
+    python cli/list_kpus.py --foundry gf                # all GF-fabbed SKUs
+    python cli/list_kpus.py --node-nm 12                # all 12nm SKUs
+    python cli/list_kpus.py --library fdx               # all FD-SOI SKUs
+    python cli/list_kpus.py --foundry tsmc --node-nm 7  # AND-combined
     python cli/list_kpus.py --sort tops
     python cli/list_kpus.py --output kpus.csv
     python cli/list_kpus.py --output kpus.md
@@ -44,6 +48,8 @@ class KPURow:
     vendor: str
     process_node_id: str
     process_node_resolved: bool
+    foundry: str  # from ProcessNodeEntry.foundry; "" if unresolved
+    node_nm: int  # from ProcessNodeEntry.node_nm; 0 if unresolved
     total_tiles: int
     total_pes: int
     default_tdp_w: float
@@ -69,12 +75,15 @@ def _build_row(
         for tp in e.power.thermal_profiles
         if tp.cooling_solution_id not in sols
     ]
+    node = nodes.get(e.process_node_id)
     return KPURow(
         id=e.id,
         name=e.name,
         vendor=e.vendor,
         process_node_id=e.process_node_id,
-        process_node_resolved=e.process_node_id in nodes,
+        process_node_resolved=node is not None,
+        foundry=node.foundry.value if node is not None else "",
+        node_nm=node.node_nm if node is not None else 0,
         total_tiles=e.kpu_architecture.total_tiles,
         total_pes=total_pes,
         default_tdp_w=e.power.tdp_watts,
@@ -101,37 +110,79 @@ _SORT_KEYS = {
 }
 
 
+# Short-form aliases for the Foundry enum so users can type 'gf' instead
+# of 'globalfoundries'. The canonical values are also accepted as-is.
+_FOUNDRY_ALIASES = {
+    "gf": "globalfoundries",
+    "global": "globalfoundries",
+    "globalfoundries": "globalfoundries",
+    "tsmc": "tsmc",
+    "samsung": "samsung",
+    "sec": "samsung",
+    "intel": "intel",
+    "smic": "smic",
+    "umc": "umc",
+}
+
+
 def _filter_rows(
     rows: List[KPURow],
     vendor: Optional[str],
     target_market: Optional[str],
+    foundry: Optional[str],
+    node_nm: Optional[int],
+    library: Optional[str],
 ) -> List[KPURow]:
+    """Apply filters in AND-conjunction. Foundry and node_nm match the
+    resolved ProcessNode fields (data-driven, doesn't depend on SKU
+    naming). Library substring-matches the SKU id (since the library
+    tag lives in the name, not as a top-level ProcessNode field)."""
     out = rows
     if vendor:
         out = [r for r in out if r.vendor == vendor.lower()]
     if target_market:
         out = [r for r in out if r.target_market == target_market.lower()]
+    if foundry:
+        canonical = _FOUNDRY_ALIASES.get(foundry.lower(), foundry.lower())
+        out = [r for r in out if r.foundry == canonical]
+    if node_nm is not None:
+        out = [r for r in out if r.node_nm == node_nm]
+    if library:
+        lib = library.lower()
+        out = [r for r in out if lib in r.id.lower()]
     return out
 
 
 def _render_text(rows: List[KPURow]) -> str:
     if not rows:
         return "(no entries match)\n"
+    # Dynamic widths so long-form SKU ids and foundry-prefixed node ids
+    # don't break alignment. Fall back to header-label length as the floor.
+    id_w = max((len(r.id) for r in rows), default=2)
+    id_w = max(id_w, len("id"))
+    node_w = max(
+        (len(r.process_node_id) + (3 if not r.process_node_resolved else 0))
+        for r in rows
+    )
+    node_w = max(node_w, len("node"))
+    tier_w = max((len(r.model_tier) for r in rows), default=4)
+    tier_w = max(tier_w, len("tier"))
     header = (
-        f"{'id':30s} {'tiles':>5s} {'PEs':>7s} {'TDP':>5s} "
+        f"{'id':<{id_w}s} {'tiles':>5s} {'PEs':>7s} {'TDP':>5s} "
         f"{'INT8 TOPS':>10s} {'BF16 TFLOPS':>11s} "
         f"{'die mm^2':>9s} {'B trans':>8s} {'mem GB':>7s} {'GB/s':>7s} "
-        f"{'node':>16s} {'tier':>11s}"
+        f"{'node':>{node_w}s} {'tier':>{tier_w}s}"
     )
     lines = [header, "-" * len(header)]
     for r in rows:
         node_str = r.process_node_id if r.process_node_resolved else f"{r.process_node_id}(!)"
         lines.append(
-            f"{r.id:30s} {r.total_tiles:>5d} {r.total_pes:>7d} "
+            f"{r.id:<{id_w}s} {r.total_tiles:>5d} {r.total_pes:>7d} "
             f"{r.default_tdp_w:>5.0f} {r.int8_tops:>10.0f} "
             f"{r.bf16_tflops:>11.0f} {r.die_size_mm2:>9.0f} "
             f"{r.transistors_billion:>8.1f} {r.memory_gb:>7.0f} "
-            f"{r.memory_bandwidth_gbps:>7.0f} {node_str:>16s} {r.model_tier:>11s}"
+            f"{r.memory_bandwidth_gbps:>7.0f} {node_str:>{node_w}s} "
+            f"{r.model_tier:>{tier_w}s}"
         )
         if r.cooling_unresolved:
             lines.append(
@@ -206,6 +257,24 @@ def main() -> int:
         "--target-market", help="Filter by target market (edge/embodied/datacenter)"
     )
     parser.add_argument(
+        "--foundry",
+        help="Filter by silicon foundry (e.g., gf, tsmc, samsung, intel, "
+        "smic, umc). Short aliases like 'gf' are mapped to the canonical "
+        "Foundry value ('globalfoundries').",
+    )
+    parser.add_argument(
+        "--node-nm",
+        type=int,
+        help="Filter by process node generation in nm (e.g., 7, 12, 16). "
+        "Matches the resolved ProcessNodeEntry.node_nm field exactly.",
+    )
+    parser.add_argument(
+        "--library",
+        help="Filter by library tag (e.g., fdx, hpc, lpp). Substring match "
+        "against the SKU id, since library is encoded in the SKU name "
+        "convention rather than as a top-level ProcessNode field.",
+    )
+    parser.add_argument(
         "--sort",
         choices=sorted(_SORT_KEYS),
         default="tiles",
@@ -226,7 +295,10 @@ def main() -> int:
         return 1
 
     rows = [_build_row(k, nodes, sols) for k in kpus.values()]
-    rows = _filter_rows(rows, args.vendor, args.target_market)
+    rows = _filter_rows(
+        rows, args.vendor, args.target_market,
+        args.foundry, args.node_nm, args.library,
+    )
     rows.sort(key=_SORT_KEYS[args.sort])
 
     fmt = _detect_format(args.output)

--- a/cli/show_compute_product.py
+++ b/cli/show_compute_product.py
@@ -21,6 +21,8 @@ Usage:
 """
 
 import argparse
+import csv
+import io
 import json
 import os
 import sys
@@ -224,11 +226,60 @@ def _compose_json(
     }
 
 
+def _compose_csv(
+    sku: KPUEntry,
+    node: Optional[ProcessNodeEntry],
+    cools: Dict[str, CoolingSolutionEntry],
+) -> str:
+    """One CSV row per thermal profile; the assembled hierarchy doesn't
+    flatten cleanly into a single table, so this emits the cross-check
+    panel (the most spreadsheet-friendly slice) with the SKU id and node
+    resolution status as context columns. Use --output FILE.json for the
+    full nested view."""
+    buf = io.StringIO()
+    writer = csv.DictWriter(
+        buf,
+        fieldnames=[
+            "compute_product_id",
+            "process_node_id",
+            "process_node_resolved",
+            "profile",
+            "tdp_w",
+            "power_density_w_per_mm2",
+            "cooling_id",
+            "cool_max_total_w",
+            "cool_max_w_per_mm2",
+            "status",
+        ],
+    )
+    writer.writeheader()
+    for r in _thermal_check_rows(sku, cools):
+        writer.writerow({
+            "compute_product_id": sku.id,
+            "process_node_id": sku.process_node_id,
+            "process_node_resolved": node is not None,
+            "profile": r[0],
+            "tdp_w": None if r[1] == "?" else float(r[1]),
+            "power_density_w_per_mm2": None if r[2] == "?" else float(r[2]),
+            "cooling_id": r[3],
+            "cool_max_total_w": None if r[4] == "?" else float(r[4]),
+            "cool_max_w_per_mm2": None if r[5] == "?" else float(r[5]),
+            "status": r[6],
+        })
+    return buf.getvalue()
+
+
 def _detect_format(output: Optional[str]) -> str:
     if not output:
         return "text"
     ext = os.path.splitext(output)[1].lower().lstrip(".")
-    return {"json": "json", "md": "md", "markdown": "md", "txt": "text"}.get(ext, "text")
+    return {
+        "json": "json",
+        "csv": "csv",
+        "md": "md",
+        "markdown": "md",
+        "txt": "text",
+    }.get(ext, "text")
 
 
 def main() -> int:
@@ -239,7 +290,8 @@ def main() -> int:
     parser.add_argument("kpu_id", help="KPU SKU id, e.g., kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
     parser.add_argument(
         "--output",
-        help="Output file. Format auto-detected from extension (.json/.md/.txt).",
+        help="Output file. Format auto-detected from extension "
+        "(.json/.csv/.md/.txt).",
     )
     args = parser.parse_args()
 
@@ -270,6 +322,8 @@ def main() -> int:
         rendered = json.dumps(
             _compose_json(sku, node, cools, cool_unresolved), indent=2
         ) + "\n"
+    elif fmt == "csv":
+        rendered = _compose_csv(sku, node, cools)
     elif fmt == "md":
         rendered = _compose_md(sku, node, cools, cool_unresolved) + "\n"
     else:

--- a/cli/show_compute_product.py
+++ b/cli/show_compute_product.py
@@ -15,9 +15,9 @@ Today only KPU SKUs are supported -- extend when other product types
 need the same composed view.
 
 Usage:
-    python cli/show_compute_product.py stillwater_kpu_t256
-    python cli/show_compute_product.py stillwater_kpu_t768 --output t768.json
-    python cli/show_compute_product.py stillwater_kpu_t64  --output t64.md
+    python cli/show_compute_product.py kpu_t256_32x32_lp5x16_16nm_tsmc_ffp
+    python cli/show_compute_product.py kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc --output t768.json
+    python cli/show_compute_product.py kpu_t64_32x32_lp5x4_16nm_tsmc_ffp  --output t64.md
 """
 
 import argparse
@@ -236,7 +236,7 @@ def main() -> int:
         description="Show the full assembled ComputeProduct hierarchy "
                     "(SKU + ProcessNode + CoolingSolutions) for one KPU SKU."
     )
-    parser.add_argument("kpu_id", help="KPU SKU id, e.g., stillwater_kpu_t256")
+    parser.add_argument("kpu_id", help="KPU SKU id, e.g., kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
     parser.add_argument(
         "--output",
         help="Output file. Format auto-detected from extension (.json/.md/.txt).",

--- a/cli/show_floorplan.py
+++ b/cli/show_floorplan.py
@@ -24,11 +24,11 @@ Future work: SVG / HTML renderer that overlays the NoC topology
 (2D mesh / ring / CLOS) on top of the placed blocks.
 
 Usage:
-    python cli/show_floorplan.py stillwater_kpu_t256
-    python cli/show_floorplan.py stillwater_kpu_t768 --width 100
-    python cli/show_floorplan.py stillwater_kpu_t256 --view circuit
-    python cli/show_floorplan.py stillwater_kpu_t64 --output fp.txt
-    python cli/show_floorplan.py stillwater_kpu_t128 --json --output fp.json
+    python cli/show_floorplan.py kpu_t256_32x32_lp5x16_16nm_tsmc_ffp
+    python cli/show_floorplan.py kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc --width 100
+    python cli/show_floorplan.py kpu_t256_32x32_lp5x16_16nm_tsmc_ffp --view circuit
+    python cli/show_floorplan.py kpu_t64_32x32_lp5x4_16nm_tsmc_ffp --output fp.txt
+    python cli/show_floorplan.py kpu_t128_32x32_lp5x8_16nm_tsmc_ffp --json --output fp.json
 
 Exit codes:
     0 = rendered successfully
@@ -642,7 +642,7 @@ def main() -> int:
         "sku_id",
         nargs="?",
         help=(
-            "KPU SKU id (e.g., stillwater_kpu_t256). Omit with --list to "
+            "KPU SKU id (e.g., kpu_t256_32x32_lp5x16_16nm_tsmc_ffp). Omit with --list to "
             "list available ids."
         ),
     )

--- a/cli/show_kpu.py
+++ b/cli/show_kpu.py
@@ -9,9 +9,9 @@ decomposition, performance, power profiles with cooling refs, market.
 Pair with ``list_kpus.py`` for the catalog-level view.
 
 Usage:
-    python cli/show_kpu.py stillwater_kpu_t256
-    python cli/show_kpu.py stillwater_kpu_t768 --output t768.json
-    python cli/show_kpu.py stillwater_kpu_t64 --output t64.md
+    python cli/show_kpu.py kpu_t256_32x32_lp5x16_16nm_tsmc_ffp
+    python cli/show_kpu.py kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc --output t768.json
+    python cli/show_kpu.py kpu_t64_32x32_lp5x4_16nm_tsmc_ffp --output t64.md
 """
 
 import argparse
@@ -202,7 +202,7 @@ def _detect_format(output: Optional[str]) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Show full spec of one KPUEntry.")
-    parser.add_argument("kpu_id", help="KPU SKU id, e.g., stillwater_kpu_t256")
+    parser.add_argument("kpu_id", help="KPU SKU id, e.g., kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
     parser.add_argument(
         "--output",
         help="Output file. Format auto-detected from extension (.json/.md/.txt).",

--- a/cli/show_tops_per_watt.py
+++ b/cli/show_tops_per_watt.py
@@ -298,7 +298,7 @@ KNOWN_TDP_WATTS = {
 
     # ==== DATA CENTER ACCELERATORS ====
     'qualcomm_cloud_ai_100': 75,  # 75W PCIe card
-    'stillwater_kpu_t768': {
+    'kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc': {
         '30W': 30,
         '60W': 60,
         '100W': 100,
@@ -363,14 +363,14 @@ KNOWN_TDP_WATTS = {
     },
 
     # ==== EMBODIED AI - Stillwater KPU ====
-    'stillwater_kpu_t256': {
+    'kpu_t256_32x32_lp5x16_16nm_tsmc_ffp': {
         '15W': 15,
         '30W': 30,
         '50W': 50,
     },
 
     # ==== EDGE AI - Stillwater KPU ====
-    'stillwater_kpu_t64': {
+    'kpu_t64_32x32_lp5x4_16nm_tsmc_ffp': {
         '3W': 3,
         '6W': 6,
         '10W': 10,
@@ -717,9 +717,9 @@ def get_power_profiles_str(profile) -> str:
         'jetson_orin_agx_gpu': '15W/30W/50W/MAXN',
         'nvidia_jetson_thor_128gb': '30W/60W/100W',
         'qualcomm_snapdragon_ride': '65W/100W/130W',
-        'stillwater_kpu_t64': '3W/6W/10W',
-        'stillwater_kpu_t256': '15W/30W/50W',
-        'stillwater_kpu_t768': '30W/60W/100W',
+        'kpu_t64_32x32_lp5x4_16nm_tsmc_ffp': '3W/6W/10W',
+        'kpu_t256_32x32_lp5x16_16nm_tsmc_ffp': '15W/30W/50W',
+        'kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc': '30W/60W/100W',
     }
 
     return power_profiles.get(hw_id, '-')

--- a/cli/validate_sku.py
+++ b/cli/validate_sku.py
@@ -16,12 +16,12 @@ ERROR. Identical contract to ``tests/hardware/test_sku_catalog_validation.py``;
 useful for human-driven sweeps.
 
 Usage:
-    python cli/validate_sku.py stillwater_kpu_t256
-    python cli/validate_sku.py stillwater_kpu_t768 --category thermal
-    python cli/validate_sku.py stillwater_kpu_t64 --severity warning
-    python cli/validate_sku.py stillwater_kpu_t256 --output findings.json
-    python cli/validate_sku.py stillwater_kpu_t256 --output findings.csv
-    python cli/validate_sku.py stillwater_kpu_t256 --output findings.md
+    python cli/validate_sku.py kpu_t256_32x32_lp5x16_16nm_tsmc_ffp
+    python cli/validate_sku.py kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc --category thermal
+    python cli/validate_sku.py kpu_t64_32x32_lp5x4_16nm_tsmc_ffp --severity warning
+    python cli/validate_sku.py kpu_t256_32x32_lp5x16_16nm_tsmc_ffp --output findings.json
+    python cli/validate_sku.py kpu_t256_32x32_lp5x16_16nm_tsmc_ffp --output findings.csv
+    python cli/validate_sku.py kpu_t256_32x32_lp5x16_16nm_tsmc_ffp --output findings.md
     python cli/validate_sku.py --all                  # gate every catalog SKU
     python cli/validate_sku.py --all --strict         # also fail on warnings
 
@@ -251,7 +251,7 @@ def main() -> int:
     )
     sku_group = parser.add_mutually_exclusive_group(required=True)
     sku_group.add_argument(
-        "sku_id", nargs="?", help="SKU id, e.g., stillwater_kpu_t256"
+        "sku_id", nargs="?", help="SKU id, e.g., kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"
     )
     sku_group.add_argument(
         "--all",

--- a/docs/designs/kpu-sku-and-process-node-plan.md
+++ b/docs/designs/kpu-sku-and-process-node-plan.md
@@ -315,7 +315,7 @@ All cross-repo work landed via `embodied-schemas` PRs #9, #10, #11 and
 - `src/embodied_schemas/loaders.py` — register new types
 - `src/embodied_schemas/data/process-nodes/{tsmc,samsung,globalfoundries}/*.yaml`
 - `src/embodied_schemas/data/cooling-solutions/*.yaml`
-- `src/embodied_schemas/data/kpus/stillwater/stillwater_kpu_t{64,128,256,768}.yaml`
+- `src/embodied_schemas/data/kpus/stillwater/kpu_t{64,128,256,768}_*_*nm_*_*.yaml` (catalog uses the new naming convention: `kpu_t<count>_<rows>x<cols>_<mem><ch>_<value>nm_<foundry>_<library>`)
 
 ### graphs (this repo)
 

--- a/docs/guides/kpu_sku_input_spec_methodology.md
+++ b/docs/guides/kpu_sku_input_spec_methodology.md
@@ -8,7 +8,7 @@ Let create one and read through the nested types.
    usage: generate_kpu_sku.py [-h] (--input INPUT | --from-sku FROM_SKU)
                                 [--output OUTPUT] [--validate] [--strict]
 
-python /home/stillwater/dev/branes/clones/graphs/cli/generate_kpu_sku.py --from-sku kpu_t256_32x32_lp5x16_16nm_tsmc_ffp --output /tmp/t256_input_spec.yaml
+python cli/generate_kpu_sku.py --from-sku kpu_t256_32x32_lp5x16_16nm_tsmc_ffp --output /tmp/t256_input_spec.yaml
 ```
 
 There are no example input-spec YAMLs checked in — start from a round-trip template and edit it. Here's the workflow plus the field-by-field rules.

--- a/docs/guides/kpu_sku_input_spec_methodology.md
+++ b/docs/guides/kpu_sku_input_spec_methodology.md
@@ -8,7 +8,7 @@ Let create one and read through the nested types.
    usage: generate_kpu_sku.py [-h] (--input INPUT | --from-sku FROM_SKU)
                                 [--output OUTPUT] [--validate] [--strict]
 
-python /home/stillwater/dev/branes/clones/graphs/cli/generate_kpu_sku.py --from-sku stillwater_kpu_t256 --output /tmp/t256_input_spec.yaml
+python /home/stillwater/dev/branes/clones/graphs/cli/generate_kpu_sku.py --from-sku kpu_t256_32x32_lp5x16_16nm_tsmc_ffp --output /tmp/t256_input_spec.yaml
 ```
 
 There are no example input-spec YAMLs checked in — start from a round-trip template and edit it. Here's the workflow plus the field-by-field rules.
@@ -20,7 +20,7 @@ There are no example input-spec YAMLs checked in — start from a round-trip tem
   python -c "
   import yaml; from embodied_schemas import load_kpus
   from graphs.hardware.kpu_sku_generator import input_spec_from_kpu_entry
-  spec = input_spec_from_kpu_entry(load_kpus()['stillwater_kpu_t256'])
+  spec = input_spec_from_kpu_entry(load_kpus()['kpu_t256_32x32_lp5x16_16nm_tsmc_ffp'])
   print(yaml.safe_dump(spec.model_dump(mode='json', exclude_none=True),
                        sort_keys=False, default_flow_style=False, indent=2))
   " > my_kpu_spec.yaml
@@ -40,7 +40,7 @@ The generator owns the derived fields (die.transistors_billion, die.die_size_mm2
 ## Identity (top-level)
 
 ```yaml
-  id: stillwater_kpu_t512        # globally unique; convention: <vendor>_kpu_t<tile_count>
+  id: kpu_t512_32x32_lp5x32_12nm_gf_fdx        # globally unique; convention: kpu_t<count>_<rows>x<cols>_<mem><ch>_<value>nm_<foundry>_<library>
   name: Stillwater KPU-T512
   vendor: stillwater
   process_node_id: tsmc_n16      # MUST resolve in data/process-nodes/<foundry>/<node>.yaml
@@ -188,4 +188,4 @@ on the same node.
 3. Run cli/show_compute_product.py <new_id> after generation — the thermal cross-check panel catches TDP-vs-cooling violations that the generator may flag as warnings.
 4. The four shipped SKUs (t64/t128/t256/t768) are your reference points — they cover the entry/mid/high/datacenter tiers and span tsmc_n16 → tsmc_n7, so most new SKUs are an interpolation.
 
-A worked round-trip dump for stillwater_kpu_t256 is in /tmp/t256_input_spec.yaml if you want to inspect a complete file.
+A worked round-trip dump for kpu_t256_32x32_lp5x16_16nm_tsmc_ffp is in /tmp/t256_input_spec.yaml if you want to inspect a complete file.

--- a/hardware_registry/accelerator/kpu_t256_32x32_lp5x16_16nm_tsmc_ffp/spec.json
+++ b/hardware_registry/accelerator/kpu_t256_32x32_lp5x16_16nm_tsmc_ffp/spec.json
@@ -1,5 +1,5 @@
 {
-  "id": "stillwater_kpu_t256",
+  "id": "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp",
   "vendor": "Stillwater",
   "model": "Stillwater KPU-T256",
   "device_type": "kpu",

--- a/hardware_registry/accelerator/kpu_t64_32x32_lp5x4_16nm_tsmc_ffp/spec.json
+++ b/hardware_registry/accelerator/kpu_t64_32x32_lp5x4_16nm_tsmc_ffp/spec.json
@@ -1,5 +1,5 @@
 {
-  "id": "stillwater_kpu_t64",
+  "id": "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp",
   "vendor": "Stillwater",
   "model": "Stillwater KPU-T64",
   "device_type": "kpu",

--- a/hardware_registry/accelerator/kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc/spec.json
+++ b/hardware_registry/accelerator/kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc/spec.json
@@ -1,5 +1,5 @@
 {
-  "id": "stillwater_kpu_t768",
+  "id": "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc",
   "vendor": "Stillwater",
   "model": "Stillwater KPU-T768",
   "device_type": "kpu",

--- a/src/graphs/hardware/kpu_sku_input.py
+++ b/src/graphs/hardware/kpu_sku_input.py
@@ -44,7 +44,7 @@ class KPUSKUInputSpec(BaseModel):
     """
 
     # Identity
-    id: str = Field(..., description="Unique id, e.g., 'stillwater_kpu_t1024'")
+    id: str = Field(..., description="Unique id, e.g., 'kpu_t1024_32x32_lp5x4_5nm_tsmc_hpc'")
     name: str = Field(..., description="Human-readable name")
     vendor: str = Field(..., description="Vendor, e.g., 'stillwater'")
 

--- a/src/graphs/hardware/mappers/accelerators/kpu.py
+++ b/src/graphs/hardware/mappers/accelerators/kpu.py
@@ -539,7 +539,7 @@ def create_kpu_t64_mapper(thermal_profile: str = None) -> KPUMapper:
 
     mapper = KPUMapper(model, thermal_profile=thermal_profile)
     mapper.physical_spec = load_physical_spec_or_none(
-        vendor="stillwater", base_id="stillwater_kpu_t64"
+        vendor="stillwater", base_id="kpu_t64_32x32_lp5x4_16nm_tsmc_ffp"
     )
     return mapper
 
@@ -567,7 +567,7 @@ def create_kpu_t128_mapper(thermal_profile: str = None) -> KPUMapper:
 
     mapper = KPUMapper(model, thermal_profile=thermal_profile)
     mapper.physical_spec = load_physical_spec_or_none(
-        vendor="stillwater", base_id="stillwater_kpu_t128"
+        vendor="stillwater", base_id="kpu_t128_32x32_lp5x8_16nm_tsmc_ffp"
     )
     return mapper
 
@@ -594,7 +594,7 @@ def create_kpu_t256_mapper(thermal_profile: str = None) -> KPUMapper:
 
     mapper = KPUMapper(model, thermal_profile=thermal_profile)
     mapper.physical_spec = load_physical_spec_or_none(
-        vendor="stillwater", base_id="stillwater_kpu_t256"
+        vendor="stillwater", base_id="kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"
     )
     return mapper
 
@@ -621,6 +621,6 @@ def create_kpu_t768_mapper(thermal_profile: str = None) -> KPUMapper:
 
     mapper = KPUMapper(model, thermal_profile=thermal_profile)
     mapper.physical_spec = load_physical_spec_or_none(
-        vendor="stillwater", base_id="stillwater_kpu_t768"
+        vendor="stillwater", base_id="kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"
     )
     return mapper

--- a/src/graphs/hardware/models/accelerators/kpu_t128.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t128.py
@@ -17,7 +17,7 @@ def kpu_t128_resource_model() -> HardwareResourceModel:
     (102K). Targets autonomous robots, advanced edge AI. Power
     profiles: 6W, 12W (default), 18W.
     """
-    model = load_kpu_resource_model_from_yaml("stillwater_kpu_t128")
+    model = load_kpu_resource_model_from_yaml("kpu_t128_32x32_lp5x8_16nm_tsmc_ffp")
     # M0.5 domain-flow MAC energies (see kpu_t64.py for rationale).
     model.tile_energy_model.mac_energy_int8 = 0.10e-12
     model.tile_energy_model.mac_energy_bf16 = 0.16e-12

--- a/src/graphs/hardware/models/accelerators/kpu_t256.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t256.py
@@ -17,7 +17,7 @@ def kpu_t256_resource_model() -> HardwareResourceModel:
     Targets edge servers, autonomous vehicles, advanced drones.
     Power profiles: 15W, 30W (default), 50W.
     """
-    model = load_kpu_resource_model_from_yaml("stillwater_kpu_t256")
+    model = load_kpu_resource_model_from_yaml("kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
     # M0.5 domain-flow MAC energies (see kpu_t64.py for rationale).
     model.tile_energy_model.mac_energy_int8 = 0.10e-12
     model.tile_energy_model.mac_energy_bf16 = 0.16e-12

--- a/src/graphs/hardware/models/accelerators/kpu_t64.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t64.py
@@ -3,7 +3,7 @@
 Thin wrapper around ``load_kpu_resource_model_from_yaml`` (Phase 4b PR 5).
 Architecture, performance, thermal profiles, energy, fabric, and M3-M7
 layer attributes all come from
-``embodied-schemas:kpus/stillwater/stillwater_kpu_t64.yaml`` via the
+``embodied-schemas:kpus/stillwater/kpu_t64_32x32_lp5x4_16nm_tsmc_ffp.yaml`` via the
 loader. This factory only adds the BOM cost profile, which is
 economic / market data not tracked in the silicon-architecture YAML.
 
@@ -25,7 +25,7 @@ def kpu_t64_resource_model() -> HardwareResourceModel:
     arrays, TSMC N16. Targets battery-powered drones, robots, edge AI.
     Power profiles: 3W (battery), 6W (standard, default), 10W (peak).
     """
-    model = load_kpu_resource_model_from_yaml("stillwater_kpu_t64")
+    model = load_kpu_resource_model_from_yaml("kpu_t64_32x32_lp5x4_16nm_tsmc_ffp")
     # M0.5 domain-flow MAC energies are more aggressive than the
     # generic N16 BALANCED_LOGIC numbers in process-nodes/tsmc/n16.yaml.
     # Preserved here so the per-MAC energy ranges asserted by

--- a/src/graphs/hardware/models/accelerators/kpu_t768.py
+++ b/src/graphs/hardware/models/accelerators/kpu_t768.py
@@ -18,7 +18,7 @@ def kpu_t768_resource_model() -> HardwareResourceModel:
     datacenter LLM inference, batch-processing AI workloads.
     Power profiles: 30W, 60W (default), 100W (liquid-cooled).
     """
-    model = load_kpu_resource_model_from_yaml("stillwater_kpu_t768")
+    model = load_kpu_resource_model_from_yaml("kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc")
     # M0.5 domain-flow MAC energies, datacenter-tuned. See kpu_t64.py
     # for the override rationale; T768 uses lower per-MAC numbers
     # than the T64-T256 family (more aggressive datacenter binning).

--- a/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
+++ b/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
@@ -412,7 +412,7 @@ def load_kpu_resource_model_from_yaml(
     """Build a ``HardwareResourceModel`` for ``base_id`` from the YAML catalog.
 
     Args:
-        base_id: KPU SKU id, e.g., ``"stillwater_kpu_t256"``.
+        base_id: KPU SKU id, e.g., ``"kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"``.
         kpus / process_nodes: Optional pre-loaded catalogs (tests pass
             in-memory dicts to avoid disk I/O). Defaults load from the
             installed ``embodied-schemas`` package.
@@ -649,10 +649,10 @@ def load_kpu_resource_model_from_yaml(
     # these values are legacy-architectural placeholders. Eventual
     # cleanup tracked in docs/designs/kpu-test-contract-snapshot.md.
     _LEGACY_L2_CACHE_TOTAL_MB = {
-        "stillwater_kpu_t64":  4,
-        "stillwater_kpu_t128": 8,
-        "stillwater_kpu_t256": 16,
-        "stillwater_kpu_t768": 32,
+        "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp":  4,
+        "kpu_t128_32x32_lp5x8_16nm_tsmc_ffp": 8,
+        "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp": 16,
+        "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc": 32,
     }
     l2_cache_total_bytes = (
         _LEGACY_L2_CACHE_TOTAL_MB.get(base_id, 0) * 1024 * 1024

--- a/src/graphs/hardware/sku_validators/__init__.py
+++ b/src/graphs/hardware/sku_validators/__init__.py
@@ -12,7 +12,7 @@ Typical use:
         build_context_for_kpu,
     )
 
-    ctx = build_context_for_kpu("stillwater_kpu_t256")
+    ctx = build_context_for_kpu("kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
     findings = default_registry.run_all(ctx)
     for f in findings:
         print(f.render_one_line())

--- a/src/graphs/hardware/sku_validators/context.py
+++ b/src/graphs/hardware/sku_validators/context.py
@@ -40,7 +40,7 @@ def build_context_for_kpu(
     """Build a ValidatorContext for KPU SKU ``sku_id``.
 
     Args:
-        sku_id: The KPU SKU id, e.g., ``"stillwater_kpu_t256"``.
+        sku_id: The KPU SKU id, e.g., ``"kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"``.
         kpus / process_nodes / cooling_solutions: Optional pre-loaded
             catalogs. Tests pass small in-memory dicts here to avoid
             disk IO; the CLI lets them default to disk loaders.

--- a/tests/hardware/test_kpu_sku_generator.py
+++ b/tests/hardware/test_kpu_sku_generator.py
@@ -52,10 +52,10 @@ def catalogs():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("sku_id", [
-    "stillwater_kpu_t64",
-    "stillwater_kpu_t128",
-    "stillwater_kpu_t256",
-    "stillwater_kpu_t768",
+    "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp",
+    "kpu_t128_32x32_lp5x8_16nm_tsmc_ffp",
+    "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp",
+    "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc",
 ])
 def test_roundtrip_die_within_rounding(sku_id, catalogs):
     """Generator-derived die.transistors_billion and die.die_size_mm2
@@ -87,10 +87,10 @@ def test_roundtrip_die_within_rounding(sku_id, catalogs):
 
 
 @pytest.mark.parametrize("sku_id", [
-    "stillwater_kpu_t64",
-    "stillwater_kpu_t128",
-    "stillwater_kpu_t256",
-    "stillwater_kpu_t768",
+    "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp",
+    "kpu_t128_32x32_lp5x8_16nm_tsmc_ffp",
+    "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp",
+    "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc",
 ])
 def test_roundtrip_performance_within_rounding(sku_id, catalogs):
     """int8_tops, bf16_tflops, fp32_tflops should round-trip within 1%."""
@@ -111,10 +111,10 @@ def test_roundtrip_performance_within_rounding(sku_id, catalogs):
 
 
 @pytest.mark.parametrize("sku_id", [
-    "stillwater_kpu_t64",
-    "stillwater_kpu_t128",
-    "stillwater_kpu_t256",
-    "stillwater_kpu_t768",
+    "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp",
+    "kpu_t128_32x32_lp5x8_16nm_tsmc_ffp",
+    "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp",
+    "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc",
 ])
 def test_roundtrip_power_default_tdp_is_derived(sku_id, catalogs):
     """power.tdp_watts is DERIVED by the kpu_power_model from
@@ -144,10 +144,10 @@ def test_roundtrip_power_default_tdp_is_derived(sku_id, catalogs):
 
 
 @pytest.mark.parametrize("sku_id", [
-    "stillwater_kpu_t64",
-    "stillwater_kpu_t128",
-    "stillwater_kpu_t256",
-    "stillwater_kpu_t768",
+    "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp",
+    "kpu_t128_32x32_lp5x8_16nm_tsmc_ffp",
+    "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp",
+    "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc",
 ])
 def test_generated_sku_validates_clean(sku_id, catalogs):
     """Output of the generator should have zero ERROR findings when run
@@ -178,7 +178,7 @@ def test_generated_sku_validates_clean(sku_id, catalogs):
 
 def test_unknown_process_node_raises(catalogs):
     """A spec referencing a non-existent process_node_id raises GeneratorError."""
-    original = catalogs["kpus"]["stillwater_kpu_t256"]
+    original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(original).model_copy(
         update={"process_node_id": "no_such_node"}
     )
@@ -191,7 +191,7 @@ def test_unknown_process_node_raises(catalogs):
 
 def test_bad_default_profile_name_raises(catalogs):
     """default_thermal_profile must name an existing profile."""
-    original = catalogs["kpus"]["stillwater_kpu_t256"]
+    original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(original).model_copy(
         update={"default_thermal_profile": "9000W"}
     )
@@ -204,7 +204,7 @@ def test_bad_default_profile_name_raises(catalogs):
 
 def test_empty_silicon_bin_raises(catalogs):
     """A spec with an empty silicon_bin (no resolvable blocks) raises."""
-    original = catalogs["kpus"]["stillwater_kpu_t256"]
+    original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(original).model_copy(
         update={"silicon_bin": KPUSiliconBin(blocks=[])}
     )
@@ -220,7 +220,7 @@ def test_empty_silicon_bin_raises(catalogs):
 # ---------------------------------------------------------------------------
 
 def test_input_spec_preserves_architecture(catalogs):
-    original = catalogs["kpus"]["stillwater_kpu_t256"]
+    original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(original)
     assert spec.kpu_architecture == original.kpu_architecture
     assert spec.silicon_bin == original.silicon_bin
@@ -233,7 +233,7 @@ def test_input_spec_does_not_carry_die_or_perf_rollups(catalogs):
     """The spec's shape excludes the generator-derived roll-ups -- if a
     field is in KPUEntry but not in KPUSKUInputSpec, the spec is
     correctly minimal."""
-    original = catalogs["kpus"]["stillwater_kpu_t256"]
+    original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(original)
     spec_fields = set(type(spec).model_fields)
     assert "die" not in spec_fields
@@ -247,7 +247,7 @@ def test_input_spec_does_not_carry_die_or_perf_rollups(catalogs):
 
 def test_pe_array_override_is_no_op_when_dims_unchanged(catalogs):
     """Override to the spec's existing PE-array dims must round-trip."""
-    original = catalogs["kpus"]["stillwater_kpu_t256"]
+    original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(original)
     rows = spec.kpu_architecture.tiles[0].pe_array_rows
     cols = spec.kpu_architecture.tiles[0].pe_array_cols
@@ -261,7 +261,7 @@ def test_pe_array_override_is_no_op_when_dims_unchanged(catalogs):
 
 def test_pe_array_override_preserves_ops_per_pe_ratio(catalogs):
     """Scaling PE-array size must keep ops/PE/clock constant."""
-    original = catalogs["kpus"]["stillwater_kpu_t256"]
+    original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(original)
     overridden = apply_pe_array_override(spec, 16, 16)
     for orig_t, new_t in zip(spec.kpu_architecture.tiles, overridden.kpu_architecture.tiles):
@@ -275,7 +275,7 @@ def test_pe_array_override_preserves_ops_per_pe_ratio(catalogs):
 def test_pe_array_override_scales_die_area(catalogs):
     """Halving PE-array dims should reduce die area but not below the
     fixed (IO/control/memory_phys) floor."""
-    original = catalogs["kpus"]["stillwater_kpu_t256"]
+    original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(original)
     g_full = generate_kpu_sku(spec, process_nodes=catalogs["process_nodes"])
     g_half = generate_kpu_sku(
@@ -287,7 +287,7 @@ def test_pe_array_override_scales_die_area(catalogs):
 
 
 def test_pe_array_override_rejects_non_positive_dims(catalogs):
-    spec = input_spec_from_kpu_entry(catalogs["kpus"]["stillwater_kpu_t256"])
+    spec = input_spec_from_kpu_entry(catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"])
     with pytest.raises(ValueError):
         apply_pe_array_override(spec, 0, 32)
     with pytest.raises(ValueError):
@@ -304,7 +304,7 @@ from graphs.hardware.kpu_power_model import compute_thermal_profile_tdp_breakdow
 def test_tdp_scales_quadratically_with_vdd(catalogs):
     """Dropping Vdd by sqrt(2) should halve the dynamic power; total
     TDP drops by half the dynamic share."""
-    sku = catalogs["kpus"]["stillwater_kpu_t256"]
+    sku = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(sku)
     node = catalogs["process_nodes"][sku.process_node_id]
     # Take the default profile and run with two Vdds: nominal and nominal/sqrt(2).
@@ -320,7 +320,7 @@ def test_tdp_scales_quadratically_with_vdd(catalogs):
 
 def test_tdp_scales_linearly_with_clock(catalogs):
     """At fixed Vdd, doubling clock doubles dynamic power."""
-    sku = catalogs["kpus"]["stillwater_kpu_t256"]
+    sku = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(sku)
     node = catalogs["process_nodes"][sku.process_node_id]
     base = sku.power.thermal_profiles[1]
@@ -334,7 +334,7 @@ def test_tdp_scales_linearly_with_clock(catalogs):
 def test_activity_factor_scales_dynamic(catalogs):
     """Per-profile activity_factor=0.5 should halve dynamic power
     (it's a multiplier on the workload duty cycle)."""
-    sku = catalogs["kpus"]["stillwater_kpu_t256"]
+    sku = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(sku)
     node = catalogs["process_nodes"][sku.process_node_id]
     base = sku.power.thermal_profiles[1]
@@ -350,7 +350,7 @@ def test_pe_array_sweep_tdp_monotonic(catalogs):
     """Across a PE-array sweep at fixed clock + Vdd, derived TDP must
     strictly increase with PE count -- the whole point of programmable
     PE arrays for roadmap generation."""
-    sku = catalogs["kpus"]["stillwater_kpu_t256"]
+    sku = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     spec = input_spec_from_kpu_entry(sku)
     node = catalogs["process_nodes"][sku.process_node_id]
     base = sku.power.thermal_profiles[1]

--- a/tests/hardware/test_kpu_yaml_loader.py
+++ b/tests/hardware/test_kpu_yaml_loader.py
@@ -39,10 +39,10 @@ def catalogs():
 
 
 SKU_IDS = [
-    "stillwater_kpu_t64",
-    "stillwater_kpu_t128",
-    "stillwater_kpu_t256",
-    "stillwater_kpu_t768",
+    "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp",
+    "kpu_t128_32x32_lp5x8_16nm_tsmc_ffp",
+    "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp",
+    "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc",
 ]
 
 
@@ -175,7 +175,7 @@ def test_loader_unknown_base_id_raises(catalogs):
 
 def test_loader_unresolved_process_node_raises(catalogs):
     """Hand-craft a SKU pointing at a non-existent process node."""
-    real = catalogs["kpus"]["stillwater_kpu_t256"]
+    real = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     bad_sku = real.model_copy(update={"process_node_id": "nonexistent"})
     with pytest.raises(KPUYamlLoaderError, match="does not resolve"):
         load_kpu_resource_model_from_yaml(
@@ -308,7 +308,7 @@ def test_soc_fabric_unknown_topology_marks_low_confidence(catalogs):
     new YAML topology values land cleanly even before the enum map
     is updated."""
     from graphs.hardware.fabric_model import Topology
-    real = catalogs["kpus"]["stillwater_kpu_t256"]
+    real = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     bad_arch = real.kpu_architecture.model_copy(
         update={"noc": real.kpu_architecture.noc.model_copy(
             update={"topology": "future_topology_3d_torus"}
@@ -330,7 +330,7 @@ def test_soc_fabric_lossy_torus_mapping_marks_low_confidence(catalogs):
     ``low_confidence=True`` so consumers (hop-count, bisection-bandwidth
     formulas) see the approximation."""
     from graphs.hardware.fabric_model import Topology
-    real = catalogs["kpus"]["stillwater_kpu_t256"]
+    real = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     arch = real.kpu_architecture.model_copy(
         update={"noc": real.kpu_architecture.noc.model_copy(
             update={"topology": "torus_2d"}
@@ -404,7 +404,7 @@ def test_loader_falls_back_to_placeholder_when_yaml_omits_efficiency(catalogs):
     ``efficiency_factor_by_precision`` should produce the historical
     flat placeholder (0.70 / 0.95). This is the backward-compat path
     for external user YAMLs that haven't backfilled."""
-    real = catalogs["kpus"]["stillwater_kpu_t256"]
+    real = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     profiles = [
         p.model_copy(
             update={
@@ -458,7 +458,7 @@ def test_tile_energy_model_mac_fallback_is_node_scaled(catalogs):
     ``get_base_alu_energy``, not collapse to a fixed constant. Lower
     nm -> lower fallback MAC energy."""
     from embodied_schemas.process_node import CircuitClass
-    real = catalogs["kpus"]["stillwater_kpu_t256"]
+    real = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
     n16_node = catalogs["process_nodes"]["tsmc_n16"]
     # Strip every balanced_logic energy entry to force the fallback path.
     sparse_n16 = n16_node.model_copy(update={

--- a/tests/hardware/test_silicon_floorplan.py
+++ b/tests/hardware/test_silicon_floorplan.py
@@ -258,7 +258,7 @@ def test_pitch_match_warns_on_t768(kpus, nodes, cooling):
     accidentally hides the T768 pitch mismatch (e.g., by inflating
     INT8 per-PE area), this test fails so we notice.
     """
-    sku = kpus["stillwater_kpu_t768"]
+    sku = kpus["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
     ctx = ValidatorContext(
         sku=sku,
         process_node=nodes[sku.process_node_id],
@@ -290,7 +290,7 @@ def test_show_floorplan_cli_renders_t256():
     ``test_show_floorplan_cli_default_is_architectural``.
     """
     result = subprocess.run(
-        [sys.executable, str(SHOW_FLOORPLAN_CLI), "stillwater_kpu_t256"],
+        [sys.executable, str(SHOW_FLOORPLAN_CLI), "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"],
         cwd=REPO_ROOT, capture_output=True, text=True,
     )
     assert result.returncode == 0, result.stderr
@@ -308,19 +308,19 @@ def test_show_floorplan_cli_json_output(tmp_path: Path):
     out = tmp_path / "fp.json"
     result = subprocess.run(
         [sys.executable, str(SHOW_FLOORPLAN_CLI),
-         "stillwater_kpu_t64", "--output", str(out)],
+         "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp", "--output", str(out)],
         cwd=REPO_ROOT, capture_output=True, text=True,
     )
     assert result.returncode == 0, result.stderr
     payload = json.loads(out.read_text())
-    assert payload["sku_id"] == "stillwater_kpu_t64"
+    assert payload["sku_id"] == "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp"
     assert payload["die_area_mm2"] > 0
     assert len(payload["blocks"]) > 0
 
 
 def test_show_floorplan_cli_unknown_sku():
     result = subprocess.run(
-        [sys.executable, str(SHOW_FLOORPLAN_CLI), "stillwater_kpu_t999"],
+        [sys.executable, str(SHOW_FLOORPLAN_CLI), "kpu_t999_32x32_lp5x4_5nm_tsmc_hpc"],
         cwd=REPO_ROOT, capture_output=True, text=True,
     )
     assert result.returncode == 2
@@ -335,8 +335,8 @@ def test_show_floorplan_cli_list_mode():
     )
     assert result.returncode == 0
     ids = result.stdout.strip().split("\n")
-    assert "stillwater_kpu_t256" in ids
-    assert "stillwater_kpu_t768" in ids
+    assert "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp" in ids
+    assert "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc" in ids
 
 
 # ---------------------------------------------------------------------------
@@ -411,7 +411,7 @@ def test_arch_what_if_all_int8_smaller_than_all_matrix(kpus, nodes):
     silicon_bin coefficients have drifted in a way the architect
     should know about.
     """
-    sku = kpus["stillwater_kpu_t768"]
+    sku = kpus["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
     fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
     by_class = {wi.tile_class: wi for wi in fp.what_if}
     assert "INT8-primary" in by_class
@@ -428,7 +428,7 @@ def test_compute_memory_pitch_match_warns_on_t768(kpus, nodes, cooling):
     """T768's compute tiles range from 0.175 mm (INT8) to 0.508 mm
     (Matrix); memory pitch is ~0.142 mm. The C/M pitch validator
     must fire on at least one tile class for T768."""
-    sku = kpus["stillwater_kpu_t768"]
+    sku = kpus["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
     ctx = ValidatorContext(
         sku=sku, process_node=nodes[sku.process_node_id],
         cooling_solutions=cooling,
@@ -446,7 +446,7 @@ def test_compute_memory_pitch_match_warns_on_t768(kpus, nodes, cooling):
 def test_whitespace_validator_warns_on_t768(kpus, nodes, cooling):
     """T768 has 76% architectural whitespace (Matrix tiles dominate
     the unified pitch). Whitespace validator must fire."""
-    sku = kpus["stillwater_kpu_t768"]
+    sku = kpus["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
     ctx = ValidatorContext(
         sku=sku, process_node=nodes[sku.process_node_id],
         cooling_solutions=cooling,
@@ -472,7 +472,7 @@ def test_show_floorplan_cli_default_is_architectural():
     'architectural', the per-class compute summary, and the what-if
     table."""
     result = subprocess.run(
-        [sys.executable, str(SHOW_FLOORPLAN_CLI), "stillwater_kpu_t256"],
+        [sys.executable, str(SHOW_FLOORPLAN_CLI), "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"],
         cwd=REPO_ROOT, capture_output=True, text=True,
     )
     assert result.returncode == 0, result.stderr
@@ -490,7 +490,7 @@ def test_show_floorplan_cli_view_circuit_falls_back_to_old():
     """--view circuit reproduces the Stage 8a renderer output."""
     result = subprocess.run(
         [sys.executable, str(SHOW_FLOORPLAN_CLI),
-         "stillwater_kpu_t256", "--view", "circuit"],
+         "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp", "--view", "circuit"],
         cwd=REPO_ROOT, capture_output=True, text=True,
     )
     assert result.returncode == 0, result.stderr
@@ -577,7 +577,7 @@ def test_mc_count_equals_memory_controllers_field(sku_id, kpus, nodes):
 
 def test_lpddr_mc_is_long_narrow_stripe(kpus, nodes):
     """LPDDR PHY blocks are narrow stripes (~5:1 aspect)."""
-    sku = kpus["stillwater_kpu_t256"]  # LPDDR5
+    sku = kpus["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]  # LPDDR5
     fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
     for mc in fp.memory_controllers():
         long = max(mc.width_mm, mc.height_mm)
@@ -591,8 +591,8 @@ def test_lpddr_mc_is_long_narrow_stripe(kpus, nodes):
 
 def test_hbm_mc_is_squarer_than_lpddr(kpus, nodes):
     """HBM PHY blocks are squarer (~1.5:1 aspect) than LPDDR (~5:1)."""
-    lpddr_sku = kpus["stillwater_kpu_t256"]
-    hbm_sku = kpus["stillwater_kpu_t768"]
+    lpddr_sku = kpus["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
+    hbm_sku = kpus["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
     fp_lpddr = derive_kpu_architectural_floorplan(
         lpddr_sku, nodes[lpddr_sku.process_node_id]
     )
@@ -663,13 +663,13 @@ def test_show_floorplan_cli_arch_json_output(tmp_path: Path):
     out = tmp_path / "fp.json"
     result = subprocess.run(
         [sys.executable, str(SHOW_FLOORPLAN_CLI),
-         "stillwater_kpu_t768", "--output", str(out)],
+         "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc", "--output", str(out)],
         cwd=REPO_ROOT, capture_output=True, text=True,
     )
     assert result.returncode == 0, result.stderr
     payload = json.loads(out.read_text())
     assert payload["view"] == "architectural"
-    assert payload["sku_id"] == "stillwater_kpu_t768"
+    assert payload["sku_id"] == "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"
     assert "compute_summaries" in payload
     assert "memory_summary" in payload
     assert "what_if" in payload

--- a/tests/hardware/test_sku_catalog_validation.py
+++ b/tests/hardware/test_sku_catalog_validation.py
@@ -1,7 +1,7 @@
 """Phase 6 CI gate: every SKU YAML in the catalog must validate cleanly.
 
 The Phase 2 validator framework + Phase 4b factories tested specific
-SKUs by id (T64/T128/T256/T768) -- a future ``stillwater_kpu_t1024``
+SKUs by id (T64/T128/T256/T768) -- a future ``kpu_t1024_..._tsmc_n5_hpc``
 or third-party KPU SKU added to the catalog wouldn't trip those tests.
 
 This module parametrizes over ``load_kpus().keys()`` so every SKU in
@@ -95,8 +95,8 @@ def test_kpu_catalog_is_non_empty():
     assert sku_ids, "embodied-schemas catalog has zero KPU SKUs"
     # Sanity: the four Stillwater SKUs Phase 4b authored should be present.
     for required in (
-        "stillwater_kpu_t64", "stillwater_kpu_t128",
-        "stillwater_kpu_t256", "stillwater_kpu_t768",
+        "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp", "kpu_t128_32x32_lp5x8_16nm_tsmc_ffp",
+        "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp", "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc",
     ):
         assert required in sku_ids, (
             f"{required!r} missing from catalog -- Phase 4b SKUs must "

--- a/tests/hardware/test_sku_validator_framework.py
+++ b/tests/hardware/test_sku_validator_framework.py
@@ -154,7 +154,7 @@ def real_ctx():
     """Build a context against the real catalog. Skipped if catalog not
     reachable (e.g., embodied-schemas not installed in this environment)."""
     try:
-        return build_context_for_kpu("stillwater_kpu_t256")
+        return build_context_for_kpu("kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
     except Exception as exc:
         pytest.skip(f"catalog unreachable: {exc}")
         # pytest.skip raises Skipped; the explicit raise below makes the
@@ -289,8 +289,8 @@ def test_has_errors_detects_errors():
 # ---------------------------------------------------------------------------
 
 def test_build_context_for_existing_kpu():
-    ctx = build_context_for_kpu("stillwater_kpu_t256")
-    assert ctx.sku.id == "stillwater_kpu_t256"
+    ctx = build_context_for_kpu("kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
+    assert ctx.sku.id == "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"
     assert ctx.process_node.id == "tsmc_n16"
     assert "active_fan" in ctx.cooling_solutions
 
@@ -302,9 +302,9 @@ def test_build_context_unknown_sku_raises():
 
 def test_build_context_passes_in_memory_catalogs():
     """Tests can short-circuit disk IO by passing pre-built dicts."""
-    real = build_context_for_kpu("stillwater_kpu_t256")
+    real = build_context_for_kpu("kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
     ctx = build_context_for_kpu(
-        "stillwater_kpu_t256",
+        "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp",
         kpus={real.sku.id: real.sku},
         process_nodes={real.process_node.id: real.process_node},
         cooling_solutions=real.cooling_solutions,
@@ -314,13 +314,13 @@ def test_build_context_passes_in_memory_catalogs():
 
 
 def test_context_cooling_for_resolves_existing_profile():
-    ctx = build_context_for_kpu("stillwater_kpu_t256")
+    ctx = build_context_for_kpu("kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
     cs = ctx.cooling_for("15W")
     assert cs is not None and cs.id == "passive_heatsink_large"
 
 
 def test_context_cooling_for_returns_none_for_unknown_profile():
-    ctx = build_context_for_kpu("stillwater_kpu_t256")
+    ctx = build_context_for_kpu("kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
     assert ctx.cooling_for("not_a_profile") is None
 
 
@@ -328,7 +328,7 @@ def test_context_unresolved_process_node_raises():
     """Hand-build a SKU that points at a non-existent process node and
     confirm build_context surfaces it as ContextError. Uses an
     in-memory catalog override so we don't need to author a broken YAML."""
-    real = build_context_for_kpu("stillwater_kpu_t256")
+    real = build_context_for_kpu("kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
     broken_sku = real.sku.model_copy(update={"process_node_id": "nonexistent_node"})
     with pytest.raises(ContextError, match="does not resolve"):
         build_context_for_kpu(

--- a/tests/hardware/test_sku_validators_phase2b.py
+++ b/tests/hardware/test_sku_validators_phase2b.py
@@ -6,7 +6,7 @@ produce) the expected Findings. Uses ``model_copy(update=)`` to mutate
 Pydantic models without touching disk.
 
 Test fixtures:
-- ``ctx``: real ValidatorContext for stillwater_kpu_t256 (a known-good
+- ``ctx``: real ValidatorContext for kpu_t256_32x32_lp5x16_16nm_tsmc_ffp (a known-good
   SKU). Tests perturb it to verify catches.
 """
 
@@ -40,7 +40,7 @@ load_validators()
 def ctx() -> ValidatorContext:
     """Real context for a known-good SKU. Tests mutate sku/process_node
     via model_copy and feed the result into a perturbed context."""
-    return build_context_for_kpu("stillwater_kpu_t256")
+    return build_context_for_kpu("kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
 
 
 def _ctx_with_sku(ctx: ValidatorContext, **sku_updates) -> ValidatorContext:
@@ -62,10 +62,10 @@ def _findings_for(name: str, ctx: ValidatorContext):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("sku_id", [
-    "stillwater_kpu_t64",
-    "stillwater_kpu_t128",
-    "stillwater_kpu_t256",
-    "stillwater_kpu_t768",
+    "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp",
+    "kpu_t128_32x32_lp5x8_16nm_tsmc_ffp",
+    "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp",
+    "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc",
 ])
 def test_real_skus_have_no_errors(sku_id):
     """Hand-authored SKUs should pass every validator. If a future YAML

--- a/tests/hardware/test_sku_validators_phase2cd.py
+++ b/tests/hardware/test_sku_validators_phase2cd.py
@@ -23,7 +23,7 @@ load_validators()
 
 @pytest.fixture
 def ctx() -> ValidatorContext:
-    return build_context_for_kpu("stillwater_kpu_t256")
+    return build_context_for_kpu("kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
 
 
 def _ctx_with(ctx, **sku_updates) -> ValidatorContext:
@@ -177,10 +177,10 @@ def test_em_catches_outrageous_design(ctx):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("sku_id", [
-    "stillwater_kpu_t64",
-    "stillwater_kpu_t128",
-    "stillwater_kpu_t256",
-    "stillwater_kpu_t768",
+    "kpu_t64_32x32_lp5x4_16nm_tsmc_ffp",
+    "kpu_t128_32x32_lp5x8_16nm_tsmc_ffp",
+    "kpu_t256_32x32_lp5x16_16nm_tsmc_ffp",
+    "kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc",
 ])
 def test_real_skus_have_no_errors_after_phase2cd(sku_id):
     """All four hand-authored SKUs should have zero ERROR findings


### PR DESCRIPTION
## Summary

Update all source code, tests, mappers, factories, CLI tools, hardware registry, and docs to use the new self-describing KPU SKU naming convention introduced by the matching merged embodied-schemas PR ([branes-ai/embodied-schemas#14](https://github.com/branes-ai/embodied-schemas/pull/14)).

```
kpu_t<count>_<rows>x<cols>_<mem><ch>_<value>nm_<foundry>_<library>
```

Library tag conveys product positioning: `fdx` / `ull` (energy-efficient FD-SOI), `hpc` (datacenter compute), `lpp` / `pp` / `ffp` (FinFET performance), `lp` / `hd` (mainstream / high-density).

## Mechanical id renames

Everywhere `stillwater_kpu_t*` was referenced:

| Old id | New id |
|---|---|
| `stillwater_kpu_t64` | `kpu_t64_32x32_lp5x4_16nm_tsmc_ffp` |
| `stillwater_kpu_t128` | `kpu_t128_32x32_lp5x8_16nm_tsmc_ffp` |
| `stillwater_kpu_t256` | `kpu_t256_32x32_lp5x16_16nm_tsmc_ffp` |
| `stillwater_kpu_t768` | `kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc` |

- **Factory function names** (`kpu_t64_resource_model()` etc) keep their short ergonomic form — only the catalog id binding changes
- **Mapper display names** (`Stillwater-KPU-T64`) are user-facing labels and stay
- **Hardware registry** parallel-store JSON specs (`hardware_registry/accelerator/`) renamed to match the new ids (directory + `spec.json` id field)

## list_kpus.py enhancements

- **Dynamic column widths** so long-form SKU ids and foundry-prefixed node ids no longer break alignment
- **`KPURow` gains `foundry` and `node_nm` fields** populated from the resolved ProcessNode (also exported in JSON/CSV/MD)
- **Three new filter flags**, AND-combinable with existing `--vendor` / `--target-market`:
  - `--foundry` — exact match on `ProcessNodeEntry.foundry`, with short aliases (`gf` → `globalfoundries`, `sec` → `samsung`)
  - `--node-nm` — exact match on `ProcessNodeEntry.node_nm` (int)
  - `--library` — substring match on the SKU id (since library is encoded in the name, not as a top-level node field)

## Pre-existing test failures fixed during the migration

These broke at PR #153's catalog regen but never surfaced because the relevant tests weren't run together:

- `test_power_monotonicity_catches_inverted_clocks` — was hardcoded to pre-PR#153 t256 clocks (1100/1400/1650 MHz); now derives the inverted clock from the loaded profile so it stays robust as catalog clocks evolve
- `test_kpu_t64_peak_ops` (5 parametrized cases) — was pegged to t64 at 900 MHz; updated to the post-PR#153 475 MHz default-profile values (62/31/3 TOPS instead of 118/59/6)
- `test_t256_uses_20x20_pe_arrays` → renamed to `*_uses_32x32_pe_arrays`; new t256 architecture is uniform with t64/t128 per the family-consistency rebuild
- `test_kpu_array_size_sanity` — PE count expectation 400 → 1024 for t256

## Dependencies

- ✅ **embodied-schemas#14 (merged)** — provides the renamed catalog YAMLs and 12FDX node energy fields
- ⏳ **graphs#153 (open)** — derived TDP / V/f / PE-array sweep CLI. This branch stacks on top of #153's commit (`2504f15`). Recommended merge order: #153 first, then this PR. After #153 squash-merges, this branch will need a rebase to drop the stacked commit; happy to do that as a follow-up.

## Test plan

- [x] `pytest tests/hardware/` — 680/680 pass
- [x] `cli/list_kpus.py --foundry gf` lists 4 12FDX SKUs; `--node-nm 7` lists 5 N7 SKUs; `--library fdx` lists 4 FD-SOI SKUs
- [x] `cli/show_compute_product.py kpu_t256_32x32_lp5x16_16nm_tsmc_ffp` renders cleanly with OK cross-check status
- [x] Zero `stillwater_kpu_t*` references remain in production source / tests / CLI / docs (verified by grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PE-array dimension override capability for KPU generation.
  * Enhanced KPU listing with additional filtering by foundry, process node, and library.
  * New compute product view showing KPU specifications with thermal headroom cross-checks.
  * Improved power modeling with workload-driven TDP computation.

* **Documentation**
  * Updated KPU SKU naming convention to descriptive format (e.g., `kpu_t256_32x32_lp5x16_16nm_tsmc_ffp`).
  * Refreshed CLI examples and guides with new identifiers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/155)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->