### PR TITLE
ci: bump embodied-schemas pin to PR #17 (full 12-SKU ComputeProduct catalog)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
           #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
-          ref: 7babd4cc66b3457e5e6ea4446b6a21a30f4a4434
+          #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
+          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
           path: embodied-schemas
           fetch-depth: 1
 
@@ -141,7 +142,8 @@ jobs:
           #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
-          ref: 7babd4cc66b3457e5e6ea4446b6a21a30f4a4434
+          #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
+          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
           path: embodied-schemas
           fetch-depth: 1
 
@@ -239,7 +241,8 @@ jobs:
           #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
-          ref: 7babd4cc66b3457e5e6ea4446b6a21a30f4a4434
+          #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
+          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
           path: embodied-schemas
           fetch-depth: 1
 
@@ -334,7 +337,8 @@ jobs:
           #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
-          ref: 7babd4cc66b3457e5e6ea4446b6a21a30f4a4434
+          #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
+          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
           path: embodied-schemas
           fetch-depth: 1
 
@@ -402,7 +406,8 @@ jobs:
           #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
-          ref: 7babd4cc66b3457e5e6ea4446b6a21a30f4a4434
+          #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
+          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
           path: embodied-schemas
           fetch-depth: 1
 
@@ -458,7 +463,8 @@ jobs:
           #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
-          ref: 7babd4cc66b3457e5e6ea4446b6a21a30f4a4434
+          #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
+          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -96,7 +96,8 @@ jobs:
           #   PR #14 (846a0d2) KPU SKU naming convention (kpu_t<N>_..._<foundry>_<library>)
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
-          ref: 7babd4cc66b3457e5e6ea4446b6a21a30f4a4434
+          #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
+          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
           path: embodied-schemas
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

Bumps the embodied-schemas CI pin from \`7babd4c\` (PR #16, single t256 ComputeProduct YAML) to \`845a9f2\` (PR #17, full 12-SKU catalog).

PR #17 in embodied-schemas converted the remaining 11 KPU SKUs to ComputeProduct YAMLs. After merging it on the embodied-schemas side, this repo's CI needs to point at the new pin so:

- \`tests/hardware/test_compute_product_loader.py\` (added in #156) sees the full 12-SKU \`compute_products\` catalog instead of just t256
- The \`prefer_native\` precedence path is exercised across all SKUs that exist in both catalogs (now: all 12)
- Future tests against \`load_compute_products()\` see real-world data, not the t256-only sentinel

## Diff

7 places updated (6 in \`ci.yml\`, 1 in \`v4-validation.yml\`), each:
- Append \`#   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs\` to the history comment block
- Bump \`ref:\` from \`7babd4cc66b3457e5e6ea4446b6a21a30f4a4434\` to \`845a9f2939fa8a49df16c203f1be72a54f838578\`

This is a follow-up to merged PRs:
- [embodied-schemas#15](https://github.com/branes-ai/embodied-schemas/pull/15) — schema
- [embodied-schemas#16](https://github.com/branes-ai/embodied-schemas/pull/16) — first YAML + loader
- [graphs#156](https://github.com/branes-ai/graphs/pull/156) — graphs-side adapter
- [embodied-schemas#17](https://github.com/branes-ai/embodied-schemas/pull/17) — remaining 11 YAMLs (this PR's trigger)

## Test plan

- [x] CI runs against the new embodied-schemas SHA
- [x] All hardware tests pass (the loader tests added in #156 now have 12 native ComputeProducts to load instead of 1)
- [ ] Watch CI here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configurations to reference updated schema resources for improved validation and consistency across pipeline jobs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/157)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->