### PR TITLE
refactor(cli): migrate show_kpu + show_compute_product to ComputeProduct

### DIFF
--- a/cli/show_compute_product.py
+++ b/cli/show_compute_product.py
@@ -28,10 +28,15 @@ import os
 import sys
 from typing import Any, Dict, List, Optional, Tuple
 
-from embodied_schemas import load_cooling_solutions, load_kpus, load_process_nodes
+from embodied_schemas import (
+    ComputeProduct,
+    load_cooling_solutions,
+    load_process_nodes,
+)
 from embodied_schemas.cooling_solution import CoolingSolutionEntry
-from embodied_schemas.kpu import KPUEntry
 from embodied_schemas.process_node import ProcessNodeEntry
+
+from graphs.hardware.compute_product_loader import load_compute_products_unified
 
 # Reuse the layer renderers from sibling inspectors so the composed view
 # stays formatting-identical to the per-layer tools.
@@ -46,14 +51,14 @@ from show_process_node import _render_text as _render_node_text  # noqa: E402
 # --- Cross-checks -------------------------------------------------------
 
 def _thermal_check_rows(
-    e: KPUEntry,
+    cp: ComputeProduct,
     cools: Dict[str, CoolingSolutionEntry],
 ) -> List[Tuple[str, str, str, str, str, str, str]]:
     """One row per thermal profile, ready for any renderer:
     (profile, tdp_w, w_per_mm2, cooling_id, cool_max_w, cool_max_w_per_mm2, status)."""
     rows = []
-    die_mm2 = e.die.die_size_mm2
-    for tp in e.power.thermal_profiles:
+    die_mm2 = cp.dies[0].die_size_mm2
+    for tp in cp.power.thermal_profiles:
         cool = cools.get(tp.cooling_solution_id)
         density = tp.tdp_watts / die_mm2 if die_mm2 > 0 else 0.0
         if cool is None:
@@ -77,7 +82,7 @@ def _thermal_check_rows(
 
 
 def _render_crosscheck_text(
-    e: KPUEntry, cools: Dict[str, CoolingSolutionEntry]
+    cp: ComputeProduct, cools: Dict[str, CoolingSolutionEntry]
 ) -> str:
     out = ["=== ComputeProduct cross-checks ===", ""]
     out.append("--- Thermal headroom (per profile) ---")
@@ -85,7 +90,7 @@ def _render_crosscheck_text(
         f"  {'profile':10s} {'TDP':>5s} {'W/mm^2':>8s}  "
         f"{'cooling_id':28s} {'max W':>6s} {'max W/mm^2':>10s}  status"
     )
-    for r in _thermal_check_rows(e, cools):
+    for r in _thermal_check_rows(cp, cools):
         out.append(
             f"  {r[0]:10s} {r[1]:>5s} {r[2]:>8s}  "
             f"{r[3]:28s} {r[4]:>6s} {r[5]:>10s}  {r[6]}"
@@ -95,7 +100,7 @@ def _render_crosscheck_text(
 
 
 def _render_crosscheck_md(
-    e: KPUEntry, cools: Dict[str, CoolingSolutionEntry]
+    cp: ComputeProduct, cools: Dict[str, CoolingSolutionEntry]
 ) -> str:
     lines = [
         "## ComputeProduct cross-checks", "",
@@ -103,7 +108,7 @@ def _render_crosscheck_md(
         "| profile | TDP (W) | W/mm^2 | cooling_id | max W | max W/mm^2 | status |",
         "|---|---:|---:|---|---:|---:|---|",
     ]
-    for r in _thermal_check_rows(e, cools):
+    for r in _thermal_check_rows(cp, cools):
         lines.append(
             f"| {r[0]} | {r[1]} | {r[2]} | `{r[3]}` | {r[4]} | {r[5]} | {r[6]} |"
         )
@@ -113,13 +118,13 @@ def _render_crosscheck_md(
 
 # --- Composition --------------------------------------------------------
 
-def _banner(sku: KPUEntry, node_resolved: bool, cool_unresolved: List[str]) -> List[str]:
-    cooling_ids = sorted({tp.cooling_solution_id for tp in sku.power.thermal_profiles})
+def _banner(cp: ComputeProduct, node_resolved: bool, cool_unresolved: List[str]) -> List[str]:
+    cooling_ids = sorted({tp.cooling_solution_id for tp in cp.power.thermal_profiles})
     bar = "#" * 60
     lines = [
         bar,
-        f"# ComputeProduct: {sku.id}",
-        f"#   process_node:   {sku.process_node_id} "
+        f"# ComputeProduct: {cp.id}",
+        f"#   process_node:   {cp.dies[0].process_node_id} "
         f"({'resolved' if node_resolved else 'UNRESOLVED'})",
         f"#   cooling refs:   {', '.join(cooling_ids)}",
     ]
@@ -131,20 +136,22 @@ def _banner(sku: KPUEntry, node_resolved: bool, cool_unresolved: List[str]) -> L
 
 
 def _compose_text(
-    sku: KPUEntry, node: Optional[ProcessNodeEntry],
+    cp: ComputeProduct, node: Optional[ProcessNodeEntry],
     cools: Dict[str, CoolingSolutionEntry],
     cool_unresolved: List[str],
 ) -> str:
-    parts = _banner(sku, node is not None, cool_unresolved)
-    parts.append(_render_kpu_text(sku))
+    parts = _banner(cp, node is not None, cool_unresolved)
+    parts.append(_render_kpu_text(cp, node))
     parts.append("")
     if node is not None:
         parts.append(_render_node_text(node))
         parts.append("")
     else:
-        parts.append(f"!! ProcessNode {sku.process_node_id!r} not found in catalog")
+        parts.append(
+            f"!! ProcessNode {cp.dies[0].process_node_id!r} not found in catalog"
+        )
         parts.append("")
-    for cid in sorted({tp.cooling_solution_id for tp in sku.power.thermal_profiles}):
+    for cid in sorted({tp.cooling_solution_id for tp in cp.power.thermal_profiles}):
         cool = cools.get(cid)
         if cool is None:
             parts.append(f"!! CoolingSolution {cid!r} not found in catalog")
@@ -152,19 +159,19 @@ def _compose_text(
         else:
             parts.append(_render_cool_text(cool))
             parts.append("")
-    parts.append(_render_crosscheck_text(sku, cools))
+    parts.append(_render_crosscheck_text(cp, cools))
     return "\n".join(parts)
 
 
 def _compose_md(
-    sku: KPUEntry, node: Optional[ProcessNodeEntry],
+    cp: ComputeProduct, node: Optional[ProcessNodeEntry],
     cools: Dict[str, CoolingSolutionEntry],
     cool_unresolved: List[str],
 ) -> str:
-    cooling_ids = sorted({tp.cooling_solution_id for tp in sku.power.thermal_profiles})
-    parts = [f"# ComputeProduct: `{sku.id}`", ""]
+    cooling_ids = sorted({tp.cooling_solution_id for tp in cp.power.thermal_profiles})
+    parts = [f"# ComputeProduct: `{cp.id}`", ""]
     parts.append(
-        f"- process_node: `{sku.process_node_id}`"
+        f"- process_node: `{cp.dies[0].process_node_id}`"
         f"{'' if node is not None else ' (UNRESOLVED)'}"
     )
     parts.append(f"- cooling refs: {', '.join(f'`{c}`' for c in cooling_ids)}")
@@ -175,14 +182,14 @@ def _compose_md(
     parts.append("## KPU SKU")
     parts.append("")
     parts.append("```")
-    parts.append(_render_kpu_text(sku))
+    parts.append(_render_kpu_text(cp, node))
     parts.append("```")
     parts.append("")
     if node is not None:
         parts.append(_render_node_md(node))
         parts.append("")
     else:
-        parts.append(f"> ProcessNode `{sku.process_node_id}` not found in catalog")
+        parts.append(f"> ProcessNode `{cp.dies[0].process_node_id}` not found in catalog")
         parts.append("")
     for cid in cooling_ids:
         cool = cools.get(cid)
@@ -192,18 +199,18 @@ def _compose_md(
         else:
             parts.append(_render_cool_md(cool))
             parts.append("")
-    parts.append(_render_crosscheck_md(sku, cools))
+    parts.append(_render_crosscheck_md(cp, cools))
     return "\n".join(parts)
 
 
 def _compose_json(
-    sku: KPUEntry, node: Optional[ProcessNodeEntry],
+    cp: ComputeProduct, node: Optional[ProcessNodeEntry],
     cools: Dict[str, CoolingSolutionEntry],
     cool_unresolved: List[str],
 ) -> Dict[str, Any]:
     return {
-        "compute_product_id": sku.id,
-        "sku": sku.model_dump(mode="json"),
+        "compute_product_id": cp.id,
+        "sku": cp.model_dump(mode="json"),
         "process_node": node.model_dump(mode="json") if node is not None else None,
         "cooling_solutions": {
             cid: cool.model_dump(mode="json") for cid, cool in cools.items()
@@ -220,14 +227,14 @@ def _compose_json(
                     "cool_max_w_per_mm2": None if r[5] == "?" else float(r[5]),
                     "status": r[6],
                 }
-                for r in _thermal_check_rows(sku, cools)
+                for r in _thermal_check_rows(cp, cools)
             ],
         },
     }
 
 
 def _compose_csv(
-    sku: KPUEntry,
+    cp: ComputeProduct,
     node: Optional[ProcessNodeEntry],
     cools: Dict[str, CoolingSolutionEntry],
 ) -> str:
@@ -253,10 +260,10 @@ def _compose_csv(
         ],
     )
     writer.writeheader()
-    for r in _thermal_check_rows(sku, cools):
+    for r in _thermal_check_rows(cp, cools):
         writer.writerow({
-            "compute_product_id": sku.id,
-            "process_node_id": sku.process_node_id,
+            "compute_product_id": cp.id,
+            "process_node_id": cp.dies[0].process_node_id,
             "process_node_resolved": node is not None,
             "profile": r[0],
             "tdp_w": None if r[1] == "?" else float(r[1]),
@@ -296,38 +303,38 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        kpus = load_kpus()
+        cps = load_compute_products_unified()
         nodes = load_process_nodes()
         sols = load_cooling_solutions()
     except Exception as exc:
         print(f"error: failed to load catalog: {exc}", file=sys.stderr)
         return 1
 
-    sku = kpus.get(args.kpu_id)
-    if sku is None:
+    cp = cps.get(args.kpu_id)
+    if cp is None:
         print(
             f"error: no KPU SKU with id={args.kpu_id!r}. "
-            f"Available: {', '.join(sorted(kpus))}",
+            f"Available: {', '.join(sorted(cps))}",
             file=sys.stderr,
         )
         return 1
 
-    node = nodes.get(sku.process_node_id)
-    cooling_ids = sorted({tp.cooling_solution_id for tp in sku.power.thermal_profiles})
+    node = nodes.get(cp.dies[0].process_node_id)
+    cooling_ids = sorted({tp.cooling_solution_id for tp in cp.power.thermal_profiles})
     cools = {cid: sols[cid] for cid in cooling_ids if cid in sols}
     cool_unresolved = [cid for cid in cooling_ids if cid not in sols]
 
     fmt = _detect_format(args.output)
     if fmt == "json":
         rendered = json.dumps(
-            _compose_json(sku, node, cools, cool_unresolved), indent=2
+            _compose_json(cp, node, cools, cool_unresolved), indent=2
         ) + "\n"
     elif fmt == "csv":
-        rendered = _compose_csv(sku, node, cools)
+        rendered = _compose_csv(cp, node, cools)
     elif fmt == "md":
-        rendered = _compose_md(sku, node, cools, cool_unresolved) + "\n"
+        rendered = _compose_md(cp, node, cools, cool_unresolved) + "\n"
     else:
-        rendered = _compose_text(sku, node, cools, cool_unresolved) + "\n"
+        rendered = _compose_text(cp, node, cools, cool_unresolved) + "\n"
 
     if args.output:
         with open(args.output, "w", encoding="utf-8") as fh:

--- a/cli/show_kpu.py
+++ b/cli/show_kpu.py
@@ -2,11 +2,18 @@
 """
 KPU SKU Detail Inspector
 
-Prints the full breakdown of one KPUEntry: identity, process-node ref,
-die rolls, kpu_architecture (tiles + NoC + memory), silicon_bin
-decomposition, performance, power profiles with cooling refs, market.
+Prints the full breakdown of one KPU ComputeProduct: identity, packaging,
+per-die structure (process node, die size, transistors, silicon_bin,
+clocks), the KPU block (tiles + NoC + memory), performance roll-up,
+power profiles with cooling refs, market.
 
 Pair with ``list_kpus.py`` for the catalog-level view.
+
+Migrated from the legacy ``KPUEntry`` view to the unified
+``ComputeProduct`` view. Output for KPU monolithic SKUs is content-
+identical to the legacy view (same numbers, same structure); the
+underlying types and field paths differ. JSON output is now the
+``ComputeProduct`` schema rather than the legacy ``KPUEntry`` schema.
 
 Usage:
     python cli/show_kpu.py kpu_t256_32x32_lp5x16_16nm_tsmc_ffp
@@ -22,18 +29,31 @@ import os
 import sys
 from typing import Optional
 
-from embodied_schemas import load_kpus
-from embodied_schemas.kpu import KPUEntry
+from embodied_schemas import ComputeProduct, PackagingKind, load_process_nodes
+from embodied_schemas.process_node import ProcessNodeEntry
+
+from graphs.hardware.compute_product_loader import load_compute_products_unified
 
 
-def _render_csv(e: KPUEntry) -> str:
+def _kpu_block(cp: ComputeProduct):
+    """Return the KPUBlock from a monolithic-KPU ComputeProduct.
+
+    v1 KPU products always have one Die with one KPUBlock; this helper
+    pulls it out so callers don't have to walk ``cp.dies[0].blocks[0]``
+    each time. Future chiplet KPU products will need an iteration."""
+    return cp.dies[0].blocks[0]
+
+
+def _render_csv(cp: ComputeProduct) -> str:
     """Single-row CSV with the headline-numbers a SKU author tracks.
 
-    Detail-view CSV is awkward (KPUEntry has nested structures), so this
-    renders a flat row of the most-comparable scalars. JSON is the right
-    format for the full nested view; CSV is here for spreadsheet
+    Detail-view CSV is awkward (ComputeProduct has nested structures), so
+    this renders a flat row of the most-comparable scalars. JSON is the
+    right format for the full nested view; CSV is here for spreadsheet
     interop on the headline metrics."""
-    total_pes = sum(t.total_pes for t in e.kpu_architecture.tiles)
+    block = _kpu_block(cp)
+    die = cp.dies[0]
+    total_pes = sum(t.total_pes for t in block.tiles)
     buf = io.StringIO()
     writer = csv.writer(buf)
     writer.writerow([
@@ -45,48 +65,55 @@ def _render_csv(e: KPUEntry) -> str:
         "memory_type", "memory_size_gb", "memory_bandwidth_gbps",
     ])
     default_clock = next(
-        (p.clock_mhz for p in e.power.thermal_profiles
-         if p.name == e.power.default_thermal_profile),
+        (p.clock_mhz for p in cp.power.thermal_profiles
+         if p.name == cp.power.default_thermal_profile),
         0.0,
     )
     writer.writerow([
-        e.id, e.name, e.vendor, e.process_node_id,
-        e.kpu_architecture.total_tiles, total_pes,
-        e.die.die_size_mm2, e.die.transistors_billion,
-        e.power.tdp_watts, default_clock,
-        e.performance.int8_tops, e.performance.bf16_tflops,
-        e.performance.fp32_tflops, e.performance.int4_tops or "",
-        e.kpu_architecture.memory.memory_type.value,
-        e.kpu_architecture.memory.memory_size_gb,
-        e.kpu_architecture.memory.memory_bandwidth_gbps,
+        cp.id, cp.name, cp.vendor, die.process_node_id,
+        block.total_tiles, total_pes,
+        die.die_size_mm2, die.transistors_billion,
+        cp.power.tdp_watts, default_clock,
+        cp.performance.int8_tops, cp.performance.bf16_tflops,
+        cp.performance.fp32_tflops, cp.performance.int4_tops or "",
+        block.memory.memory_type.value,
+        block.memory.memory_size_gb,
+        block.memory.memory_bandwidth_gbps,
     ])
     return buf.getvalue()
 
 
-def _render_text(e: KPUEntry) -> str:
+def _render_text(cp: ComputeProduct, node: Optional[ProcessNodeEntry]) -> str:
     out = []
-    out.append(f"=== KPU SKU: {e.id} ===")
-    out.append(f"  Name:            {e.name}")
-    out.append(f"  Vendor:          {e.vendor}")
-    out.append(f"  Process node:    {e.process_node_id}")
-    out.append(f"  Last updated:    {e.last_updated}")
+    out.append(f"=== KPU SKU: {cp.id} ===")
+    out.append(f"  Name:            {cp.name}")
+    out.append(f"  Vendor:          {cp.vendor}")
+    die = cp.dies[0]
+    out.append(f"  Process node:    {die.process_node_id}")
+    out.append(f"  Last updated:    {cp.last_updated}")
     out.append("")
 
-    # Die
+    # Die roll-up
+    block = _kpu_block(cp)
     out.append("--- Die (roll-up) ---")
-    out.append(f"  Architecture:    {e.die.architecture}")
-    out.append(f"  Foundry / node:  {e.die.foundry.value} {e.die.process_name} ({e.die.process_nm} nm)")
-    out.append(f"  Transistors:     {e.die.transistors_billion:.2f} B")
-    out.append(f"  Die size:        {e.die.die_size_mm2:.1f} mm^2")
-    if e.die.is_chiplet:
-        out.append(f"  Chiplet:         yes ({e.die.num_dies} dies)")
+    out.append(f"  Architecture:    {block.kind.value.upper()}")
+    if node is not None:
+        out.append(
+            f"  Foundry / node:  {node.foundry.value} {node.node_name} "
+            f"({node.node_nm} nm)"
+        )
+    else:
+        out.append(f"  Foundry / node:  {die.process_node_id} (process node not in catalog)")
+    out.append(f"  Transistors:     {die.transistors_billion:.2f} B")
+    out.append(f"  Die size:        {die.die_size_mm2:.1f} mm^2")
+    if cp.packaging.kind != PackagingKind.MONOLITHIC:
+        out.append(f"  Chiplet:         yes ({cp.packaging.num_dies} dies)")
     out.append("")
 
-    # Architecture
-    arch = e.kpu_architecture
+    # Architecture (KPU block)
     out.append("--- Architecture ---")
-    out.append(f"  Total tiles:     {arch.total_tiles}")
-    out.append(f"  Multi-precision: {', '.join(arch.multi_precision_alu)}")
+    out.append(f"  Total tiles:     {block.total_tiles}")
+    out.append(f"  Multi-precision: {', '.join(block.multi_precision_alu)}")
     out.append("")
     out.append("  Tile classes:")
     out.append(
@@ -94,7 +121,7 @@ def _render_text(e: KPUEntry) -> str:
         f"{'lib':>16s}  ops/tile/clock"
     )
     total_pes = 0
-    for t in arch.tiles:
+    for t in block.tiles:
         ops_str = ", ".join(f"{p}={int(v)}" for p, v in t.ops_per_tile_per_clock.items())
         total_pes += t.total_pes
         out.append(
@@ -105,29 +132,29 @@ def _render_text(e: KPUEntry) -> str:
     out.append(f"  Total PEs:       {total_pes}")
     out.append("")
     out.append(
-        f"  NoC: {arch.noc.topology} {arch.noc.mesh_rows}x{arch.noc.mesh_cols}, "
-        f"{arch.noc.flit_bytes}-byte flits, "
-        f"router_lib={arch.noc.router_circuit_class.value}"
+        f"  NoC: {block.noc.topology} {block.noc.mesh_rows}x{block.noc.mesh_cols}, "
+        f"{block.noc.flit_bytes}-byte flits, "
+        f"router_lib={block.noc.router_circuit_class.value}"
     )
     out.append(
-        f"  Memory: {arch.memory.memory_type.value} "
-        f"{arch.memory.memory_size_gb:.0f} GB, "
-        f"{arch.memory.memory_bandwidth_gbps:.0f} GB/s, "
-        f"{arch.memory.memory_bus_bits}-bit, "
-        f"{arch.memory.memory_controllers} controllers"
+        f"  Memory: {block.memory.memory_type.value} "
+        f"{block.memory.memory_size_gb:.0f} GB, "
+        f"{block.memory.memory_bandwidth_gbps:.0f} GB/s, "
+        f"{block.memory.memory_bus_bits}-bit, "
+        f"{block.memory.memory_controllers} controllers"
     )
     out.append(
-        f"  L1: {arch.memory.l1_kib_per_pe} KiB/PE  "
-        f"L2: {arch.memory.l2_kib_per_tile} KiB/tile  "
-        f"L3: {arch.memory.l3_kib_per_tile} KiB/tile  "
-        f"(L3 total: {arch.memory.l3_kib_per_tile * arch.total_tiles / 1024:.1f} MiB)"
+        f"  L1: {block.memory.l1_kib_per_pe} KiB/PE  "
+        f"L2: {block.memory.l2_kib_per_tile} KiB/tile  "
+        f"L3: {block.memory.l3_kib_per_tile} KiB/tile  "
+        f"(L3 total: {block.memory.l3_kib_per_tile * block.total_tiles / 1024:.1f} MiB)"
     )
     out.append("")
 
-    # Silicon bin
+    # Silicon bin (under die now)
     out.append("--- Silicon bin (per-block transistor decomposition) ---")
     out.append(f"  {'block':20s} {'circuit_class':18s} {'kind':>16s}  source")
-    for b in e.silicon_bin.blocks:
+    for b in die.silicon_bin.blocks:
         ts = b.transistor_source
         if ts.kind.value == "fixed":
             src = f"{ts.mtx} Mtx fixed"
@@ -138,33 +165,33 @@ def _render_text(e: KPUEntry) -> str:
         )
     out.append("")
 
-    # Performance
+    # Performance (top-level roll-up)
     out.append("--- Performance (roll-up) ---")
-    out.append(f"  INT8:  {e.performance.int8_tops:>8.1f} TOPS")
-    out.append(f"  BF16:  {e.performance.bf16_tflops:>8.1f} TFLOPS")
-    out.append(f"  FP32:  {e.performance.fp32_tflops:>8.1f} TFLOPS")
-    if e.performance.int4_tops is not None:
-        out.append(f"  INT4:  {e.performance.int4_tops:>8.1f} TOPS")
+    out.append(f"  INT8:  {cp.performance.int8_tops:>8.1f} TOPS")
+    out.append(f"  BF16:  {cp.performance.bf16_tflops:>8.1f} TFLOPS")
+    out.append(f"  FP32:  {cp.performance.fp32_tflops:>8.1f} TFLOPS")
+    if cp.performance.int4_tops is not None:
+        out.append(f"  INT4:  {cp.performance.int4_tops:>8.1f} TOPS")
     out.append("")
 
-    # Clocks
+    # Clocks (under die now)
     out.append("--- Clocks ---")
-    out.append(f"  Base:  {e.clocks.base_clock_mhz} MHz")
-    out.append(f"  Boost: {e.clocks.boost_clock_mhz} MHz")
+    out.append(f"  Base:  {die.clocks.base_clock_mhz} MHz")
+    out.append(f"  Boost: {die.clocks.boost_clock_mhz} MHz")
     out.append("")
 
     # Power + thermal profiles
     out.append("--- Power ---")
-    out.append(f"  Default profile: {e.power.default_thermal_profile}")
-    out.append(f"  TDP (default):   {e.power.tdp_watts} W")
-    out.append(f"  Max:             {e.power.max_power_watts} W")
-    out.append(f"  Min:             {e.power.min_power_watts} W")
-    if e.power.idle_power_watts is not None:
-        out.append(f"  Idle:            {e.power.idle_power_watts} W")
+    out.append(f"  Default profile: {cp.power.default_thermal_profile}")
+    out.append(f"  TDP (default):   {cp.power.tdp_watts} W")
+    out.append(f"  Max:             {cp.power.max_power_watts} W")
+    out.append(f"  Min:             {cp.power.min_power_watts} W")
+    if cp.power.idle_power_watts is not None:
+        out.append(f"  Idle:            {cp.power.idle_power_watts} W")
     out.append("")
     out.append("  Thermal profiles:")
     out.append(f"    {'profile':10s} {'TDP':>5s} {'clock':>9s}  cooling solution")
-    for tp in e.power.thermal_profiles:
+    for tp in cp.power.thermal_profiles:
         out.append(
             f"    {tp.name:10s} {tp.tdp_watts:>5.0f} {tp.clock_mhz:>7.0f} MHz  "
             f"-> {tp.cooling_solution_id}"
@@ -173,19 +200,19 @@ def _render_text(e: KPUEntry) -> str:
 
     # Market
     out.append("--- Market ---")
-    out.append(f"  Target:          {e.market.target_market}")
-    out.append(f"  Tier:            {e.market.model_tier}")
-    out.append(f"  Family:          {e.market.product_family}")
-    if e.market.launch_date:
-        out.append(f"  Launch:          {e.market.launch_date}")
-    if e.market.launch_msrp_usd is not None:
-        out.append(f"  MSRP:            ${e.market.launch_msrp_usd:,.0f}")
-    out.append(f"  Available:       {'yes' if e.market.is_available else 'no'}")
+    out.append(f"  Target:          {cp.market.target_market}")
+    out.append(f"  Tier:            {cp.market.model_tier}")
+    out.append(f"  Family:          {cp.market.product_family}")
+    if cp.market.launch_date:
+        out.append(f"  Launch:          {cp.market.launch_date}")
+    if cp.market.launch_msrp_usd is not None:
+        out.append(f"  MSRP:            ${cp.market.launch_msrp_usd:,.0f}")
+    out.append(f"  Available:       {'yes' if cp.market.is_available else 'no'}")
     out.append("")
 
-    if e.notes:
+    if cp.notes:
         out.append("--- Notes ---")
-        out.append(e.notes.rstrip())
+        out.append(cp.notes.rstrip())
         out.append("")
     return "\n".join(out)
 
@@ -201,7 +228,9 @@ def _detect_format(output: Optional[str]) -> str:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Show full spec of one KPUEntry.")
+    parser = argparse.ArgumentParser(
+        description="Show full spec of one KPU ComputeProduct."
+    )
     parser.add_argument("kpu_id", help="KPU SKU id, e.g., kpu_t256_32x32_lp5x16_16nm_tsmc_ffp")
     parser.add_argument(
         "--output",
@@ -210,30 +239,33 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        kpus = load_kpus()
+        cps = load_compute_products_unified()
+        nodes = load_process_nodes()
     except Exception as exc:
-        print(f"error: failed to load KPUs: {exc}", file=sys.stderr)
+        print(f"error: failed to load catalog: {exc}", file=sys.stderr)
         return 1
 
-    e = kpus.get(args.kpu_id)
-    if e is None:
+    cp = cps.get(args.kpu_id)
+    if cp is None:
         print(
             f"error: no KPU SKU with id={args.kpu_id!r}. "
-            f"Available: {', '.join(sorted(kpus))}",
+            f"Available: {', '.join(sorted(cps))}",
             file=sys.stderr,
         )
         return 1
 
+    node = nodes.get(cp.dies[0].process_node_id)
+
     fmt = _detect_format(args.output)
     if fmt == "json":
-        rendered = json.dumps(e.model_dump(mode="json"), indent=2) + "\n"
+        rendered = json.dumps(cp.model_dump(mode="json"), indent=2) + "\n"
     elif fmt == "csv":
-        rendered = _render_csv(e)
+        rendered = _render_csv(cp)
     elif fmt == "md":
         # Reuse text but wrap in code block; keeps the inspector simple
-        rendered = "```\n" + _render_text(e) + "```\n"
+        rendered = "```\n" + _render_text(cp, node) + "```\n"
     else:
-        rendered = _render_text(e) + "\n"
+        rendered = _render_text(cp, node) + "\n"
 
     if args.output:
         with open(args.output, "w", encoding="utf-8") as fh:


### PR DESCRIPTION
## Why

First step of the consumer migration off the legacy \`KPUEntry\` API onto the unified \`ComputeProduct\` interface introduced in PRs #156 + embodied-schemas #15-17.

Both files are tightly coupled (\`show_compute_product\` composes \`show_kpu\`'s renderer), so they migrate as one PR. The pattern established here is the template for the remaining ~6 consumer migrations.

## What changed

### \`cli/show_kpu.py\`

- \`load_kpus()\` → \`load_compute_products_unified()\` from \`graphs.hardware.compute_product_loader\`
- Renderer signature: \`_render_text(e: KPUEntry)\` → \`_render_text(cp: ComputeProduct, node: Optional[ProcessNodeEntry])\`
- The legacy \`KPUDieSpec\` held \`foundry\` / \`process_name\` / \`process_nm\` that aren't on the new \`ComputeProduct.Die\`. Look these up via \`load_process_nodes()\` instead — the canonical home.
- Field-access updates throughout:

| Legacy | Unified |
|---|---|
| \`e.kpu_architecture.*\` | \`cp.dies[0].blocks[0].*\` (helper \`_kpu_block\`) |
| \`e.die.die_size_mm2\` | \`cp.dies[0].die_size_mm2\` |
| \`e.die.transistors_billion\` | \`cp.dies[0].transistors_billion\` |
| \`e.silicon_bin\` | \`cp.dies[0].silicon_bin\` |
| \`e.clocks\` | \`cp.dies[0].clocks\` |
| \`e.performance\` | \`cp.performance\` (unchanged location) |
| \`e.power\` | \`cp.power\` (unchanged location) |
| \`e.market\` | \`cp.market\` (unchanged location) |
| \`e.die.is_chiplet\` | \`cp.packaging.kind != PackagingKind.MONOLITHIC\` |
| \`e.die.num_dies\` | \`cp.packaging.num_dies\` |

- JSON output now uses \`ComputeProduct\` schema (\`cp.model_dump\`) rather than the legacy \`KPUEntry\` schema. **Deliberate**: the inspector should reflect the new shape. No tests or downstream consumers parse this JSON.

### \`cli/show_compute_product.py\`

- \`load_kpus()\` → \`load_compute_products_unified()\`
- All helpers (\`_thermal_check_rows\`, \`_render_crosscheck_*\`, \`_banner\`, \`_compose_*\`) now take \`ComputeProduct\` instead of \`KPUEntry\`.
- Calls \`_render_kpu_text(cp, node)\` with the migrated signature.

## Output verification

Diffed text/csv/md/json outputs for \`kpu_t64\`, \`kpu_t256\`, \`kpu_t768\` before vs after. Only diff is one cosmetic line per text/md output:

\`\`\`diff
- Architecture:    KPU Tile
+ Architecture:    KPU
\`\`\`

The legacy \`KPUDieSpec.architecture\` was a free-form display string; the new schema doesn't have an equivalent. The block kind (\`BlockKind.KPU.value.upper()\`) is the canonical replacement.

| Format | Diff vs main |
|---|---|
| text | One line ("KPU Tile" → "KPU") per SKU |
| csv | Byte-identical |
| md | Same one-line diff (text wrapped in code block) |
| json | Now \`ComputeProduct\` shape (intentional) |

## Tests

- All 2,696 unit tests pass under \`pytest -n 4\` (1:27 wall clock locally)
- Hardware test suite (692 tests) green in 32s
- No tests cover these CLI tools (verified by grep), no downstream consumers parse their JSON output

## Migration sequence (this PR is step 1 of ~7)

- [x] **\`show_kpu.py\` + \`show_compute_product.py\`** — this PR
- [x] \`cli/list_kpus.py\`
- [x] \`cli/show_floorplan.py\`
- [x] \`cli/validate_sku.py\` + \`cli/generate_kpu_sku.py\`
- [ ] \`sku_validators/{context,framework,silicon_math}.py\`
- [ ] \`silicon_floorplan.py\` + \`kpu_power_model.py\`
- [ ] \`models/accelerators/kpu_yaml_loader.py\` (mapper backbone)
- [ ] cleanup PR — delete \`data/kpus/\`, reduce \`load_kpus()\` to a shim

## Test plan

- [x] Text/CSV/MD/JSON outputs produce expected results
- [x] Pre/post diff is exactly the one cosmetic line
- [x] Full unit test suite passes
- [x] Hardware test suite passes
- [ ] PR CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CLI tools for displaying product information now use a unified data schema, ensuring consistent and reliable output across all supported formats (JSON, CSV, text, Markdown)
  * Enhanced resolution and tracking of process node and cooling solution references
  * Improved thermal profile cross-validation logic for more comprehensive system information analysis

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/160)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->