### PR TITLE
refactor(sku_validators): migrate to ComputeProduct (10 modules + 3 tests)

### DIFF
--- a/src/graphs/hardware/compute_product_loader.py
+++ b/src/graphs/hardware/compute_product_loader.py
@@ -168,6 +168,14 @@ def compute_product_to_kpu_entry(
             f"compute_product_to_kpu_entry: only KPUBlock is supported, "
             f"got {type(block).__name__} for {cp.id!r}"
         )
+    if process_node.id != die.process_node_id:
+        raise ValueError(
+            f"compute_product_to_kpu_entry: process_node.id "
+            f"{process_node.id!r} does not match die.process_node_id "
+            f"{die.process_node_id!r} for {cp.id!r}; the resulting "
+            f"KPUEntry would be self-inconsistent (foundry / process_name "
+            f"/ process_nm copied from the wrong node)"
+        )
 
     return KPUEntry(
         id=cp.id,

--- a/src/graphs/hardware/compute_product_loader.py
+++ b/src/graphs/hardware/compute_product_loader.py
@@ -45,6 +45,13 @@ from embodied_schemas import (
     load_compute_products,
     load_kpus,
 )
+from embodied_schemas.kpu import (
+    KPUArchitecture,
+    KPUDieSpec,
+    KPUMarket,
+    KPUPowerSpec,
+)
+from embodied_schemas.process_node import ProcessNodeEntry
 
 
 def kpu_entry_to_compute_product(entry: KPUEntry) -> ComputeProduct:
@@ -120,6 +127,93 @@ def kpu_entry_to_compute_product(entry: KPUEntry) -> ComputeProduct:
         notes=entry.notes,
         datasheet_url=entry.datasheet_url,
         last_updated=entry.last_updated,
+    )
+
+
+def compute_product_to_kpu_entry(
+    cp: ComputeProduct,
+    process_node: ProcessNodeEntry,
+) -> KPUEntry:
+    """Reverse adapter: convert a v1-monolithic-KPU ``ComputeProduct``
+    back to a legacy ``KPUEntry``.
+
+    Bridge for consumers that haven't been migrated to ComputeProduct
+    yet (silicon_floorplan, kpu_power_model, kpu_yaml_loader). Each of
+    those owns a follow-up PR; once they accept ComputeProduct directly
+    this adapter is unused and can be deleted.
+
+    Requires the ``ProcessNodeEntry`` because the legacy ``KPUDieSpec``
+    has redundant copies of foundry / process_name / process_nm that
+    the unified schema offloaded to the process-node catalog. The
+    caller passes the resolved node alongside the ComputeProduct.
+
+    Raises ValueError if the ComputeProduct is not a v1 monolithic-KPU
+    shape (multi-die or non-KPU block kinds aren't representable as
+    KPUEntry).
+    """
+    if len(cp.dies) != 1:
+        raise ValueError(
+            f"compute_product_to_kpu_entry: KPUEntry can only represent "
+            f"one die, got {len(cp.dies)} for {cp.id!r}"
+        )
+    die = cp.dies[0]
+    if len(die.blocks) != 1:
+        raise ValueError(
+            f"compute_product_to_kpu_entry: KPUEntry can only represent "
+            f"one KPUBlock per die, got {len(die.blocks)} for {cp.id!r}"
+        )
+    block = die.blocks[0]
+    if not isinstance(block, KPUBlock):
+        raise ValueError(
+            f"compute_product_to_kpu_entry: only KPUBlock is supported, "
+            f"got {type(block).__name__} for {cp.id!r}"
+        )
+
+    return KPUEntry(
+        id=cp.id,
+        name=cp.name,
+        vendor=cp.vendor,
+        process_node_id=die.process_node_id,
+        die=KPUDieSpec(
+            architecture="KPU Tile",
+            foundry=process_node.foundry,
+            process_nm=process_node.node_nm,
+            process_name=process_node.node_name,
+            transistors_billion=die.transistors_billion,
+            die_size_mm2=die.die_size_mm2,
+            is_chiplet=cp.packaging.kind != PackagingKind.MONOLITHIC,
+            num_dies=cp.packaging.num_dies,
+        ),
+        kpu_architecture=KPUArchitecture(
+            total_tiles=block.total_tiles,
+            multi_precision_alu=block.multi_precision_alu,
+            tiles=block.tiles,
+            noc=block.noc,
+            memory=block.memory,
+        ),
+        silicon_bin=die.silicon_bin,
+        clocks=die.clocks,
+        performance=cp.performance,
+        power=KPUPowerSpec(
+            tdp_watts=cp.power.tdp_watts,
+            max_power_watts=cp.power.max_power_watts,
+            min_power_watts=cp.power.min_power_watts,
+            idle_power_watts=cp.power.idle_power_watts,
+            default_thermal_profile=cp.power.default_thermal_profile,
+            thermal_profiles=cp.power.thermal_profiles,
+        ),
+        market=KPUMarket(
+            launch_date=cp.market.launch_date,
+            launch_msrp_usd=cp.market.launch_msrp_usd,
+            target_market=cp.market.target_market,
+            product_family=cp.market.product_family,
+            model_tier=cp.market.model_tier,
+            is_available=cp.market.is_available,
+            is_discontinued=(cp.lifecycle == LifecycleStatus.EOL),
+        ),
+        notes=cp.notes,
+        datasheet_url=cp.datasheet_url,
+        last_updated=cp.last_updated,
     )
 
 

--- a/src/graphs/hardware/kpu_power_model.py
+++ b/src/graphs/hardware/kpu_power_model.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 from embodied_schemas.kpu import KPUEntry, KPUThermalProfile
 from embodied_schemas.process_node import CircuitClass, ProcessNodeEntry
 
+from .compute_product_loader import kpu_entry_to_compute_product
 from .kpu_sku_input import KPUSKUInputSpec
 from .sku_validators.silicon_math import total_chip_leakage_w
 
@@ -164,7 +165,10 @@ def compute_thermal_profile_tdp_breakdown(
     # silicon_bin (it expects a sized chip). The transistor / die fields
     # don't affect leakage math -- only the per-block area does.
     placeholder = _placeholder_entry(spec, profile, node)
-    leakage_w = max(0.0, total_chip_leakage_w(placeholder, node))
+    # Forward-adapt to ComputeProduct: silicon_math has migrated. Bridge
+    # until kpu_power_model itself migrates in a follow-up PR.
+    placeholder_cp = kpu_entry_to_compute_product(placeholder)
+    leakage_w = max(0.0, total_chip_leakage_w(placeholder_cp, node))
 
     # Voltage scaling: dynamic power scales by (V/Vnom)^2. Defaults to
     # nominal_vdd if the profile doesn't pick a Vdd. This is what spreads

--- a/src/graphs/hardware/kpu_sku_generator.py
+++ b/src/graphs/hardware/kpu_sku_generator.py
@@ -49,6 +49,7 @@ from .kpu_power_model import (
     WorkloadAssumption,
     compute_thermal_profile_tdp_w,
 )
+from .compute_product_loader import kpu_entry_to_compute_product
 from .kpu_sku_input import KPUSKUInputSpec
 from .sku_validators.silicon_math import (
     SiliconMathError,
@@ -155,13 +156,16 @@ def generate_kpu_sku(
         datasheet_url=spec.datasheet_url,
         last_updated=spec.last_updated,
     )
+    # Forward-adapt to ComputeProduct: silicon_math has migrated. Bridge
+    # until kpu_sku_generator itself migrates in a follow-up PR.
+    placeholder_cp = kpu_entry_to_compute_product(placeholder_sku)
 
     total_area = 0.0
     total_mtx = 0.0
     unresolved: list[str] = []
     for block in spec.silicon_bin.blocks:
         try:
-            ba = resolve_block_area(block, placeholder_sku, node)
+            ba = resolve_block_area(block, placeholder_cp, node)
         except SiliconMathError as exc:
             unresolved.append(f"{block.name}: {exc}")
             continue
@@ -226,7 +230,7 @@ def generate_kpu_sku(
     )
     max_w = max(p.tdp_watts for p in derived_profiles)
     min_w = min(p.tdp_watts for p in derived_profiles)
-    leakage_w = total_chip_leakage_w(placeholder_sku, node)
+    leakage_w = total_chip_leakage_w(placeholder_cp, node)
     idle_w = round(leakage_w, 2) if leakage_w > 0 else None
 
     power = KPUPowerSpec(

--- a/src/graphs/hardware/silicon_floorplan.py
+++ b/src/graphs/hardware/silicon_floorplan.py
@@ -45,6 +45,7 @@ _logger = logging.getLogger(__name__)
 from embodied_schemas.kpu import KPUEntry, KPUTileSpec
 from embodied_schemas.process_node import CircuitClass, ProcessNodeEntry
 
+from .compute_product_loader import kpu_entry_to_compute_product
 from .sku_validators.silicon_math import (
     SiliconMathError,
     resolve_block_area,
@@ -211,9 +212,13 @@ def _classify_silicon_bin_blocks(
     chip_l3_area = 0.0
     other_blocks: list[tuple[str, float, CircuitClass]] = []
 
+    # Forward-adapt to ComputeProduct: silicon_math has migrated to the
+    # unified schema, but silicon_floorplan still takes KPUEntry from its
+    # callers. Bridge until silicon_floorplan migrates in a follow-up PR.
+    cp = kpu_entry_to_compute_product(sku)
     for block in sku.silicon_bin.blocks:
         try:
-            ba = resolve_block_area(block, sku, node)
+            ba = resolve_block_area(block, cp, node)
         except SiliconMathError as exc:
             # Don't silently drop -- log so the missing area surfaces in
             # the floorplan output, but keep going so a single bad

--- a/src/graphs/hardware/sku_validators/context.py
+++ b/src/graphs/hardware/sku_validators/context.py
@@ -15,13 +15,14 @@ from __future__ import annotations
 from typing import Optional
 
 from embodied_schemas import (
+    ComputeProduct,
     load_cooling_solutions,
-    load_kpus,
     load_process_nodes,
 )
 from embodied_schemas.cooling_solution import CoolingSolutionEntry
-from embodied_schemas.kpu import KPUEntry
 from embodied_schemas.process_node import ProcessNodeEntry
+
+from graphs.hardware.compute_product_loader import load_compute_products_unified
 
 from .framework import ValidatorContext
 
@@ -33,7 +34,7 @@ class ContextError(Exception):
 def build_context_for_kpu(
     sku_id: str,
     *,
-    kpus: Optional[dict[str, KPUEntry]] = None,
+    kpus: Optional[dict[str, ComputeProduct]] = None,
     process_nodes: Optional[dict[str, ProcessNodeEntry]] = None,
     cooling_solutions: Optional[dict[str, CoolingSolutionEntry]] = None,
 ) -> ValidatorContext:
@@ -43,7 +44,9 @@ def build_context_for_kpu(
         sku_id: The KPU SKU id, e.g., ``"kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"``.
         kpus / process_nodes / cooling_solutions: Optional pre-loaded
             catalogs. Tests pass small in-memory dicts here to avoid
-            disk IO; the CLI lets them default to disk loaders.
+            disk IO; the CLI lets them default to disk loaders. The
+            ``kpus`` dict is keyed by SKU id and contains
+            ``ComputeProduct`` instances (v1 KPU monolithic products).
 
     Raises:
         ContextError: if the SKU id isn't found, or its process_node_id
@@ -53,7 +56,7 @@ def build_context_for_kpu(
             them in the standard finding flow.
     """
     if kpus is None:
-        kpus = load_kpus()
+        kpus = load_compute_products_unified()
     if process_nodes is None:
         process_nodes = load_process_nodes()
     if cooling_solutions is None:
@@ -66,12 +69,13 @@ def build_context_for_kpu(
             f"no KPU SKU with id={sku_id!r}. Available: {available}"
         )
 
-    pn = process_nodes.get(sku.process_node_id)
+    process_node_id = sku.dies[0].process_node_id
+    pn = process_nodes.get(process_node_id)
     if pn is None:
         available = ", ".join(sorted(process_nodes)) or "(none)"
         raise ContextError(
             f"SKU {sku_id!r} references process_node_id="
-            f"{sku.process_node_id!r} but it does not resolve. "
+            f"{process_node_id!r} but it does not resolve. "
             f"Available process nodes: {available}"
         )
 

--- a/src/graphs/hardware/sku_validators/context.py
+++ b/src/graphs/hardware/sku_validators/context.py
@@ -69,6 +69,14 @@ def build_context_for_kpu(
             f"no KPU SKU with id={sku_id!r}. Available: {available}"
         )
 
+    # ComputeProduct enforces dies min_length=1 at construction time, but
+    # an instance built with model_construct() (skipping validation) could
+    # still have empty dies. Surface as ContextError so the CLI emits one
+    # clear message instead of an opaque IndexError.
+    if not sku.dies:
+        raise ContextError(
+            f"SKU {sku_id!r} has no dies; expected at least one die"
+        )
     process_node_id = sku.dies[0].process_node_id
     pn = process_nodes.get(process_node_id)
     if pn is None:

--- a/src/graphs/hardware/sku_validators/framework.py
+++ b/src/graphs/hardware/sku_validators/framework.py
@@ -36,8 +36,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Callable, Iterable, List, Optional, Protocol, runtime_checkable
 
+from embodied_schemas import ComputeProduct
 from embodied_schemas.cooling_solution import CoolingSolutionEntry
-from embodied_schemas.kpu import KPUEntry
 from embodied_schemas.process_node import ProcessNodeEntry
 
 
@@ -161,9 +161,11 @@ class ValidatorContext:
     'context per profile' iteration on every validator.
     """
 
-    sku: KPUEntry
-    """The SKU being validated. Today only KPUEntry; future GPU/CPU SKUs
-    will be a Union here."""
+    sku: ComputeProduct
+    """The SKU being validated, as a ComputeProduct. v1 KPU products
+    are monolithic (one Die, one KPUBlock); future chiplet products
+    and other architectures (GPU/CPU) populate the same shape with
+    additional dies and block kinds."""
 
     process_node: ProcessNodeEntry
     """The ProcessNodeEntry referenced by ``sku.process_node_id``."""

--- a/src/graphs/hardware/sku_validators/silicon_math.py
+++ b/src/graphs/hardware/sku_validators/silicon_math.py
@@ -37,8 +37,30 @@ def _kpu_block(cp: ComputeProduct) -> KPUBlock:
 
     Today every KPU ComputeProduct has exactly one Die with one
     KPUBlock; chiplet KPU products will need iteration when they land.
+
+    Raises ``SiliconMathError`` (not IndexError / TypeError) for
+    malformed shape so the validator framework converts the failure
+    into a Finding instead of crashing the validator. ComputeProduct
+    schema enforces dies/blocks min_length=1 at construction, but
+    instances built via ``model_construct()`` can bypass validation.
     """
-    return cp.dies[0].blocks[0]
+    if not cp.dies:
+        raise SiliconMathError(
+            f"compute product {cp.id!r} has no dies; expected one KPU die"
+        )
+    die = cp.dies[0]
+    if not die.blocks:
+        raise SiliconMathError(
+            f"compute product {cp.id!r} die {die.die_id!r} has no blocks; "
+            f"expected one KPUBlock"
+        )
+    block = die.blocks[0]
+    if not isinstance(block, KPUBlock):
+        raise SiliconMathError(
+            f"compute product {cp.id!r} die {die.die_id!r} first block is "
+            f"{type(block).__name__}, expected KPUBlock"
+        )
+    return block
 
 
 # ---------------------------------------------------------------------------

--- a/src/graphs/hardware/sku_validators/silicon_math.py
+++ b/src/graphs/hardware/sku_validators/silicon_math.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from embodied_schemas import ComputeProduct
+from embodied_schemas.compute_product import KPUBlock
 from embodied_schemas.kpu import (
-    KPUEntry,
     SiliconBinBlock,
     TransistorSourceKind,
 )
@@ -31,51 +32,56 @@ class SiliconMathError(Exception):
     Findings rather than crashing."""
 
 
+def _kpu_block(cp: ComputeProduct) -> KPUBlock:
+    """Return the KPUBlock from a v1 monolithic-KPU ``ComputeProduct``.
+
+    Today every KPU ComputeProduct has exactly one Die with one
+    KPUBlock; chiplet KPU products will need iteration when they land.
+    """
+    return cp.dies[0].blocks[0]
+
+
 # ---------------------------------------------------------------------------
 # Architecture-level rollups
 # ---------------------------------------------------------------------------
 
-def total_pe_count(sku: KPUEntry) -> int:
+def total_pe_count(cp: ComputeProduct) -> int:
     """Total PE count summed across every tile class."""
-    return sum(t.total_pes for t in sku.kpu_architecture.tiles)
+    return sum(t.total_pes for t in _kpu_block(cp).tiles)
 
 
-def total_l1_kib(sku: KPUEntry) -> int:
+def total_l1_kib(cp: ComputeProduct) -> int:
     """Total per-PE L1 SRAM in KiB across the chip."""
-    return sku.kpu_architecture.memory.l1_kib_per_pe * total_pe_count(sku)
+    return _kpu_block(cp).memory.l1_kib_per_pe * total_pe_count(cp)
 
 
-def total_l2_kib(sku: KPUEntry) -> int:
+def total_l2_kib(cp: ComputeProduct) -> int:
     """Total per-tile L2 SRAM in KiB across the chip."""
-    return (
-        sku.kpu_architecture.memory.l2_kib_per_tile
-        * sku.kpu_architecture.total_tiles
-    )
+    block = _kpu_block(cp)
+    return block.memory.l2_kib_per_tile * block.total_tiles
 
 
-def total_l3_kib(sku: KPUEntry) -> int:
+def total_l3_kib(cp: ComputeProduct) -> int:
     """Total per-tile L3 SRAM in KiB across the chip."""
-    return (
-        sku.kpu_architecture.memory.l3_kib_per_tile
-        * sku.kpu_architecture.total_tiles
-    )
+    block = _kpu_block(cp)
+    return block.memory.l3_kib_per_tile * block.total_tiles
 
 
-def num_tiles_by_type(sku: KPUEntry) -> dict[str, int]:
+def num_tiles_by_type(cp: ComputeProduct) -> dict[str, int]:
     """Map of tile_type -> num_tiles. Useful for ``count_ref="tile.<type>"``."""
-    return {t.tile_type: t.num_tiles for t in sku.kpu_architecture.tiles}
+    return {t.tile_type: t.num_tiles for t in _kpu_block(cp).tiles}
 
 
-def total_pes_by_tile_type(sku: KPUEntry) -> dict[str, int]:
+def total_pes_by_tile_type(cp: ComputeProduct) -> dict[str, int]:
     """Map of tile_type -> total PE count for that tile class."""
-    return {t.tile_type: t.total_pes for t in sku.kpu_architecture.tiles}
+    return {t.tile_type: t.total_pes for t in _kpu_block(cp).tiles}
 
 
 # ---------------------------------------------------------------------------
 # Transistor count resolution
 # ---------------------------------------------------------------------------
 
-def resolve_block_transistors(block: SiliconBinBlock, sku: KPUEntry) -> float:
+def resolve_block_transistors(block: SiliconBinBlock, cp: ComputeProduct) -> float:
     """Compute the absolute transistor count (in millions) for a silicon_bin
     block, given the SKU's architecture context.
 
@@ -86,7 +92,7 @@ def resolve_block_transistors(block: SiliconBinBlock, sku: KPUEntry) -> float:
       ``per_unit_mtx * total_pes(<tile_type>)``.
     * **PER_KIB**: ``count_ref`` is one of ``l1_total_kib``,
       ``l2_total_kib``, ``l3_total_kib``. Returns
-      ``per_unit_mtx * total_<level>_kib(sku)``.
+      ``per_unit_mtx * total_<level>_kib(cp)``.
     * **PER_ROUTER**: ``count_ref`` is ``"noc"``. Returns
       ``per_unit_mtx * noc.num_routers``.
     * **PER_CONTROLLER**: ``count_ref`` is ``"memory"``. Returns
@@ -121,7 +127,7 @@ def resolve_block_transistors(block: SiliconBinBlock, sku: KPUEntry) -> float:
                 f"got {ts.count_ref!r}"
             )
         tile_type = ts.count_ref.split(".", 1)[1]
-        pes_by_type = total_pes_by_tile_type(sku)
+        pes_by_type = total_pes_by_tile_type(cp)
         if tile_type not in pes_by_type:
             raise SiliconMathError(
                 f"block {block.name!r}: unknown tile_type {tile_type!r}. "
@@ -140,7 +146,7 @@ def resolve_block_transistors(block: SiliconBinBlock, sku: KPUEntry) -> float:
                 f"block {block.name!r}: PER_KIB count_ref must be one of "
                 f"{sorted(kib_resolvers)}, got {ts.count_ref!r}"
             )
-        kib = kib_resolvers[ts.count_ref](sku)
+        kib = kib_resolvers[ts.count_ref](cp)
         return float(ts.per_unit_mtx) * kib
 
     if ts.kind == TransistorSourceKind.PER_ROUTER:
@@ -149,7 +155,7 @@ def resolve_block_transistors(block: SiliconBinBlock, sku: KPUEntry) -> float:
                 f"block {block.name!r}: PER_ROUTER count_ref must be 'noc', "
                 f"got {ts.count_ref!r}"
             )
-        return float(ts.per_unit_mtx) * sku.kpu_architecture.noc.num_routers
+        return float(ts.per_unit_mtx) * _kpu_block(cp).noc.num_routers
 
     if ts.kind == TransistorSourceKind.PER_CONTROLLER:
         if ts.count_ref != "memory":
@@ -159,7 +165,7 @@ def resolve_block_transistors(block: SiliconBinBlock, sku: KPUEntry) -> float:
             )
         return (
             float(ts.per_unit_mtx)
-            * sku.kpu_architecture.memory.memory_controllers
+            * _kpu_block(cp).memory.memory_controllers
         )
 
     raise SiliconMathError(
@@ -183,7 +189,7 @@ class BlockArea:
 
 
 def resolve_block_area(
-    block: SiliconBinBlock, sku: KPUEntry, node: ProcessNodeEntry
+    block: SiliconBinBlock, cp: ComputeProduct, node: ProcessNodeEntry
 ) -> BlockArea:
     """Compute area for one silicon_bin block at the SKU's process node.
 
@@ -197,7 +203,7 @@ def resolve_block_area(
             f"offer library {block.circuit_class.value!r}. Available: "
             f"{sorted(c.value for c in node.densities)}"
         )
-    transistors = resolve_block_transistors(block, sku)
+    transistors = resolve_block_transistors(block, cp)
     density = node.density_for(block.circuit_class).mtx_per_mm2
     return BlockArea(
         name=block.name,
@@ -209,7 +215,7 @@ def resolve_block_area(
 
 
 def resolve_all_block_areas(
-    sku: KPUEntry, node: ProcessNodeEntry
+    cp: ComputeProduct, node: ProcessNodeEntry
 ) -> list[BlockArea]:
     """Resolve every silicon_bin block. Skips blocks whose circuit_class
     is unsupported by the node (the block_library_validity validator
@@ -217,9 +223,9 @@ def resolve_all_block_areas(
     coverage.
     """
     out: list[BlockArea] = []
-    for block in sku.silicon_bin.blocks:
+    for block in cp.dies[0].silicon_bin.blocks:
         try:
-            out.append(resolve_block_area(block, sku, node))
+            out.append(resolve_block_area(block, cp, node))
         except SiliconMathError:
             continue
     return out
@@ -248,7 +254,7 @@ _MEM_PHY_PJ_PER_BYTE_BY_TYPE: dict[str, float] = {
 
 
 def estimate_block_leakage_w(
-    block: SiliconBinBlock, sku: KPUEntry, node: ProcessNodeEntry
+    block: SiliconBinBlock, cp: ComputeProduct, node: ProcessNodeEntry
 ) -> float:
     """Per-block static (leakage) power in watts.
 
@@ -257,7 +263,7 @@ def estimate_block_leakage_w(
     process-node author left the data sparse and we don't invent a value.
     """
     try:
-        ba = resolve_block_area(block, sku, node)
+        ba = resolve_block_area(block, cp, node)
     except SiliconMathError:
         return 0.0
     leakage_density = node.leakage_w_per_mm2.get(block.circuit_class, 0.0)
@@ -266,7 +272,7 @@ def estimate_block_leakage_w(
 
 def estimate_block_peak_dynamic_w(
     block: SiliconBinBlock,
-    sku: KPUEntry,
+    cp: ComputeProduct,
     node: ProcessNodeEntry,
     *,
     clock_mhz: float,
@@ -296,6 +302,7 @@ def estimate_block_peak_dynamic_w(
     uses peak power to detect hotspots that would force throttling.
     """
     name = block.name.lower()
+    kpu = _kpu_block(cp)
 
     # ---- PE blocks ----
     if name.startswith("pe_"):
@@ -304,7 +311,7 @@ def estimate_block_peak_dynamic_w(
             return 0.0
         tile_type = ts.count_ref.removeprefix("tile.")
         tile = next(
-            (t for t in sku.kpu_architecture.tiles if t.tile_type == tile_type),
+            (t for t in kpu.tiles if t.tile_type == tile_type),
             None,
         )
         if tile is None:
@@ -325,7 +332,7 @@ def estimate_block_peak_dynamic_w(
 
     # ---- Memory PHY ----
     if "phy" in name or "mem_phy" in name or name == "memory_phys":
-        mem = sku.kpu_architecture.memory
+        mem = kpu.memory
         pj_per_byte = _MEM_PHY_PJ_PER_BYTE_BY_TYPE.get(
             mem.memory_type.value, 10.0
         )
@@ -334,7 +341,7 @@ def estimate_block_peak_dynamic_w(
     # ---- NoC routers (coarse: 5 % of default TDP) ----
     if name.startswith("noc"):
         # Use the SKU's default-profile TDP as the budget.
-        tdp = sku.power.tdp_watts
+        tdp = cp.power.tdp_watts
         return tdp * 0.05
 
     # ---- Other (control logic, IO pads): leakage-only at v1 ----
@@ -343,7 +350,7 @@ def estimate_block_peak_dynamic_w(
 
 def estimate_block_total_peak_w(
     block: SiliconBinBlock,
-    sku: KPUEntry,
+    cp: ComputeProduct,
     node: ProcessNodeEntry,
     *,
     clock_mhz: float,
@@ -351,16 +358,16 @@ def estimate_block_total_peak_w(
 ) -> float:
     """Per-block total power at peak = leakage + dynamic."""
     return (
-        estimate_block_leakage_w(block, sku, node)
+        estimate_block_leakage_w(block, cp, node)
         + estimate_block_peak_dynamic_w(
-            block, sku, node, clock_mhz=clock_mhz, precision=precision
+            block, cp, node, clock_mhz=clock_mhz, precision=precision
         )
     )
 
 
-def total_chip_leakage_w(sku: KPUEntry, node: ProcessNodeEntry) -> float:
+def total_chip_leakage_w(cp: ComputeProduct, node: ProcessNodeEntry) -> float:
     """Sum of every block's leakage."""
     return sum(
-        estimate_block_leakage_w(b, sku, node)
-        for b in sku.silicon_bin.blocks
+        estimate_block_leakage_w(b, cp, node)
+        for b in cp.dies[0].silicon_bin.blocks
     )

--- a/src/graphs/hardware/sku_validators/validators/area.py
+++ b/src/graphs/hardware/sku_validators/validators/area.py
@@ -44,7 +44,7 @@ class BlockLibraryValidity:
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         findings: List[Finding] = []
         node = ctx.process_node
-        for block in ctx.sku.silicon_bin.blocks:
+        for block in ctx.sku.dies[0].silicon_bin.blocks:
             if node.supports(block.circuit_class):
                 continue
             available = ", ".join(sorted(c.value for c in node.densities))
@@ -86,12 +86,13 @@ class AreaSelfConsistency:
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         findings: List[Finding] = []
         sku = ctx.sku
+        die = sku.dies[0]
         node = ctx.process_node
 
         total_area = 0.0
         total_mtx = 0.0
         unresolved: List[str] = []
-        for block in sku.silicon_bin.blocks:
+        for block in die.silicon_bin.blocks:
             try:
                 ba = resolve_block_area(block, sku, node)
             except SiliconMathError as exc:
@@ -118,7 +119,7 @@ class AreaSelfConsistency:
             return findings
 
         # 1. Area roll-up vs claimed die_size_mm2.
-        claimed_area = sku.die.die_size_mm2
+        claimed_area = die.die_size_mm2
         rel_area = abs(total_area - claimed_area) / claimed_area
         if rel_area >= _AREA_ERROR_REL:
             sev = Severity.ERROR
@@ -147,7 +148,7 @@ class AreaSelfConsistency:
             )
 
         # 2. Transistor roll-up vs claimed transistors_billion.
-        claimed_mtx = sku.die.transistors_billion * 1000.0  # B -> M
+        claimed_mtx = die.transistors_billion * 1000.0  # B -> M
         rel_mtx = abs(total_mtx - claimed_mtx) / claimed_mtx
         if rel_mtx >= _AREA_ERROR_REL:
             sev = Severity.ERROR
@@ -164,7 +165,7 @@ class AreaSelfConsistency:
                     message=(
                         f"silicon_bin sums to {total_mtx/1000:.2f} B "
                         f"transistors but die.transistors_billion = "
-                        f"{sku.die.transistors_billion:.2f} B "
+                        f"{die.transistors_billion:.2f} B "
                         f"({rel_mtx:+.1%} relative error). Tolerance: "
                         f"WARNING above {_AREA_WARN_REL:.0%}, ERROR "
                         f"above {_AREA_ERROR_REL:.0%}."
@@ -196,12 +197,12 @@ class CompositeDensityEnvelope:
     category = ValidatorCategory.AREA
 
     def check(self, ctx: ValidatorContext) -> List[Finding]:
-        sku = ctx.sku
+        die = ctx.sku.dies[0]
         node = ctx.process_node
-        if sku.die.die_size_mm2 <= 0:
+        if die.die_size_mm2 <= 0:
             return []
         composite = (
-            sku.die.transistors_billion * 1000.0 / sku.die.die_size_mm2
+            die.transistors_billion * 1000.0 / die.die_size_mm2
         )
         lo, hi = node.density_envelope()
         if lo <= 0 or hi <= 0:

--- a/src/graphs/hardware/sku_validators/validators/consistency.py
+++ b/src/graphs/hardware/sku_validators/validators/consistency.py
@@ -36,7 +36,8 @@ class TileMixConsistency:
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         findings: List[Finding] = []
         sku = ctx.sku
-        arch = sku.kpu_architecture
+        # v1 KPU monolithic: one Die with one KPUBlock.
+        arch = sku.dies[0].blocks[0]
 
         # 1. Σ(num_tiles) == total_tiles
         sum_tiles = sum(t.num_tiles for t in arch.tiles)
@@ -184,7 +185,7 @@ class CrossRefConsistency:
         #    we surface it here too because it's a foreign-key issue
         #    that AREA-suppressed runs would miss.)
         node = ctx.process_node
-        for block in sku.silicon_bin.blocks:
+        for block in sku.dies[0].silicon_bin.blocks:
             if not node.supports(block.circuit_class):
                 available = ", ".join(
                     sorted(c.value for c in node.densities)

--- a/src/graphs/hardware/sku_validators/validators/electrical.py
+++ b/src/graphs/hardware/sku_validators/validators/electrical.py
@@ -51,7 +51,7 @@ class PowerProfileMonotonicity:
 
         # Boost clock should be at least as fast as the highest profile clock.
         clock_top = max(p.clock_mhz for p in profiles)
-        if ctx.sku.clocks.boost_clock_mhz < clock_top:
+        if ctx.sku.dies[0].clocks.boost_clock_mhz < clock_top:
             findings.append(
                 Finding(
                     validator=self.name,
@@ -59,7 +59,7 @@ class PowerProfileMonotonicity:
                     severity=Severity.WARNING,
                     message=(
                         f"clocks.boost_clock_mhz = "
-                        f"{ctx.sku.clocks.boost_clock_mhz:.0f} MHz is below "
+                        f"{ctx.sku.dies[0].clocks.boost_clock_mhz:.0f} MHz is below "
                         f"the highest thermal-profile clock "
                         f"{clock_top:.0f} MHz. Boost clock should be the "
                         f"chip's maximum advertised frequency."
@@ -69,7 +69,7 @@ class PowerProfileMonotonicity:
 
         # Base clock should be at least as fast as the lowest profile clock.
         clock_bot = min(p.clock_mhz for p in profiles)
-        if ctx.sku.clocks.base_clock_mhz > clock_bot:
+        if ctx.sku.dies[0].clocks.base_clock_mhz > clock_bot:
             findings.append(
                 Finding(
                     validator=self.name,
@@ -77,7 +77,7 @@ class PowerProfileMonotonicity:
                     severity=Severity.INFO,
                     message=(
                         f"clocks.base_clock_mhz = "
-                        f"{ctx.sku.clocks.base_clock_mhz:.0f} MHz exceeds "
+                        f"{ctx.sku.dies[0].clocks.base_clock_mhz:.0f} MHz exceeds "
                         f"the lowest thermal-profile clock "
                         f"{clock_bot:.0f} MHz. Base clock is normally the "
                         f"sustained guaranteed minimum."

--- a/src/graphs/hardware/sku_validators/validators/geometry.py
+++ b/src/graphs/hardware/sku_validators/validators/geometry.py
@@ -28,12 +28,20 @@ from __future__ import annotations
 
 from typing import List
 
+from ...compute_product_loader import compute_product_to_kpu_entry
 from ...silicon_floorplan import (
     derive_kpu_architectural_floorplan,
     derive_kpu_floorplan,
 )
 from .. import ValidatorCategory, ValidatorContext, default_registry
 from ..framework import Finding, Severity
+
+
+def _legacy_sku(ctx: ValidatorContext):
+    """Reverse-adapt ctx.sku (ComputeProduct) to KPUEntry for the
+    silicon_floorplan derivation functions. Bridge until silicon_floorplan
+    accepts ComputeProduct directly (next migration PR)."""
+    return compute_product_to_kpu_entry(ctx.sku, ctx.process_node)
 
 
 # ---------------------------------------------------------------------------
@@ -118,7 +126,7 @@ class FloorplanPitchMatch:
 
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         try:
-            fp = derive_kpu_floorplan(ctx.sku, ctx.process_node)
+            fp = derive_kpu_floorplan(_legacy_sku(ctx), ctx.process_node)
         except Exception as exc:
             return [Finding(
                 validator=self.name,
@@ -188,10 +196,10 @@ class FloorplanWithinDieEnvelope:
 
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         try:
-            fp = derive_kpu_floorplan(ctx.sku, ctx.process_node)
+            fp = derive_kpu_floorplan(_legacy_sku(ctx), ctx.process_node)
         except Exception:
             return []  # Pitch-match validator already reports derivation errors
-        declared = ctx.sku.die.die_size_mm2
+        declared = ctx.sku.dies[0].die_size_mm2
         derived = fp.die_area_mm2
         if declared <= 0 or derived <= 0:
             return []
@@ -237,7 +245,7 @@ class FloorplanAspectRatio:
 
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         try:
-            fp = derive_kpu_floorplan(ctx.sku, ctx.process_node)
+            fp = derive_kpu_floorplan(_legacy_sku(ctx), ctx.process_node)
         except Exception:
             return []
         if fp.die_width_mm <= 0 or fp.die_height_mm <= 0:
@@ -292,7 +300,7 @@ class FloorplanComputeMemoryPitchMatch:
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         try:
             fp = derive_kpu_architectural_floorplan(
-                ctx.sku, ctx.process_node
+                _legacy_sku(ctx), ctx.process_node
             )
         except Exception as exc:
             return [Finding(
@@ -366,7 +374,7 @@ class FloorplanWhitespaceFraction:
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         try:
             fp = derive_kpu_architectural_floorplan(
-                ctx.sku, ctx.process_node
+                _legacy_sku(ctx), ctx.process_node
             )
         except Exception:
             return []  # The pitch validator already reports derivation errors

--- a/src/graphs/hardware/sku_validators/validators/reliability.py
+++ b/src/graphs/hardware/sku_validators/validators/reliability.py
@@ -172,7 +172,7 @@ class Electromigration:
         # Compute total area of resolvable blocks for the proportional
         # current-distribution model.
         total_area_mm2 = 0.0
-        for block in sku.silicon_bin.blocks:
+        for block in sku.dies[0].silicon_bin.blocks:
             try:
                 total_area_mm2 += resolve_block_area(block, sku, node).area_mm2
             except SiliconMathError:
@@ -180,7 +180,7 @@ class Electromigration:
         if total_area_mm2 <= 0:
             return findings
 
-        for block in sku.silicon_bin.blocks:
+        for block in sku.dies[0].silicon_bin.blocks:
             try:
                 ba = resolve_block_area(block, sku, node)
             except SiliconMathError:

--- a/src/graphs/hardware/sku_validators/validators/thermal.py
+++ b/src/graphs/hardware/sku_validators/validators/thermal.py
@@ -134,7 +134,7 @@ class ThermalHotspot:
 
             # ---- Check 3: per-block power density at peak vs cooling ceiling ----
             ceiling = cooling.max_power_density_w_per_mm2
-            for block in sku.silicon_bin.blocks:
+            for block in sku.dies[0].silicon_bin.blocks:
                 try:
                     ba = resolve_block_area(block, sku, node)
                 except SiliconMathError:

--- a/tests/hardware/test_kpu_sku_generator.py
+++ b/tests/hardware/test_kpu_sku_generator.py
@@ -21,6 +21,7 @@ from embodied_schemas import (
     load_process_nodes,
 )
 
+from graphs.hardware.compute_product_loader import kpu_entry_to_compute_product
 from graphs.hardware.kpu_sku_generator import (
     GeneratorError,
     apply_pe_array_override,
@@ -159,8 +160,12 @@ def test_generated_sku_validates_clean(sku_id, catalogs):
         spec,
         process_nodes=catalogs["process_nodes"],
     )
+    # generate_kpu_sku still returns a KPUEntry (its own migration is a
+    # later PR). The validator framework now takes ComputeProduct, so
+    # forward-adapt before constructing the context.
+    regen_cp = kpu_entry_to_compute_product(regen)
     ctx = ValidatorContext(
-        sku=regen,
+        sku=regen_cp,
         process_node=catalogs["process_nodes"][regen.process_node_id],
         cooling_solutions=catalogs["cooling_solutions"],
     )

--- a/tests/hardware/test_silicon_floorplan.py
+++ b/tests/hardware/test_silicon_floorplan.py
@@ -28,6 +28,7 @@ from embodied_schemas import (
     load_process_nodes,
 )
 
+from graphs.hardware.compute_product_loader import load_compute_products_unified
 from graphs.hardware.silicon_floorplan import (
     derive_kpu_architectural_floorplan,
     derive_kpu_floorplan,
@@ -55,7 +56,17 @@ ALL_KPU_IDS = sorted(load_kpus().keys())
 
 @pytest.fixture(scope="module")
 def kpus():
+    """Legacy KPUEntry catalog. Used by derive_kpu_floorplan / derive_
+    kpu_architectural_floorplan, which still take KPUEntry until their
+    own migration PR. Validator tests use the ``cps`` fixture below."""
     return load_kpus()
+
+
+@pytest.fixture(scope="module")
+def cps():
+    """ComputeProduct catalog. Used to construct ValidatorContext, which
+    after the sku_validators migration takes ``sku: ComputeProduct``."""
+    return load_compute_products_unified()
 
 
 @pytest.fixture(scope="module")
@@ -228,7 +239,7 @@ def test_geometry_validators_registered():
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
 def test_geometry_validators_dont_error_on_real_skus(
-    sku_id, kpus, nodes, cooling
+    sku_id, cps, nodes, cooling
 ):
     """Stage 8 stance: WARN-max during heuristic-v1 development.
 
@@ -236,10 +247,10 @@ def test_geometry_validators_dont_error_on_real_skus(
     geometry validators -- otherwise the Phase 6 catalog gate fails.
     Tighten thresholds to ERROR-level once the heuristic is calibrated.
     """
-    sku = kpus[sku_id]
+    sku = cps[sku_id]
     ctx = ValidatorContext(
         sku=sku,
-        process_node=nodes[sku.process_node_id],
+        process_node=nodes[sku.dies[0].process_node_id],
         cooling_solutions=cooling,
     )
     findings = default_registry.run_category(ctx, ValidatorCategory.GEOMETRY)
@@ -250,7 +261,7 @@ def test_geometry_validators_dont_error_on_real_skus(
     )
 
 
-def test_pitch_match_warns_on_t768(kpus, nodes, cooling):
+def test_pitch_match_warns_on_t768(cps, nodes, cooling):
     """T768 has the most aggressive per-class pitch differences in the
     catalog -- the floorplan_pitch_match validator must fire on it.
 
@@ -258,10 +269,10 @@ def test_pitch_match_warns_on_t768(kpus, nodes, cooling):
     accidentally hides the T768 pitch mismatch (e.g., by inflating
     INT8 per-PE area), this test fails so we notice.
     """
-    sku = kpus["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
+    sku = cps["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
     ctx = ValidatorContext(
         sku=sku,
-        process_node=nodes[sku.process_node_id],
+        process_node=nodes[sku.dies[0].process_node_id],
         cooling_solutions=cooling,
     )
     findings = default_registry.run_one("floorplan_pitch_match", ctx)
@@ -424,13 +435,13 @@ def test_arch_what_if_all_int8_smaller_than_all_matrix(kpus, nodes):
     )
 
 
-def test_compute_memory_pitch_match_warns_on_t768(kpus, nodes, cooling):
+def test_compute_memory_pitch_match_warns_on_t768(cps, nodes, cooling):
     """T768's compute tiles range from 0.175 mm (INT8) to 0.508 mm
     (Matrix); memory pitch is ~0.142 mm. The C/M pitch validator
     must fire on at least one tile class for T768."""
-    sku = kpus["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
+    sku = cps["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
     ctx = ValidatorContext(
-        sku=sku, process_node=nodes[sku.process_node_id],
+        sku=sku, process_node=nodes[sku.dies[0].process_node_id],
         cooling_solutions=cooling,
     )
     findings = default_registry.run_one(
@@ -443,12 +454,12 @@ def test_compute_memory_pitch_match_warns_on_t768(kpus, nodes, cooling):
     )
 
 
-def test_whitespace_validator_warns_on_t768(kpus, nodes, cooling):
+def test_whitespace_validator_warns_on_t768(cps, nodes, cooling):
     """T768 has 76% architectural whitespace (Matrix tiles dominate
     the unified pitch). Whitespace validator must fire."""
-    sku = kpus["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
+    sku = cps["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
     ctx = ValidatorContext(
-        sku=sku, process_node=nodes[sku.process_node_id],
+        sku=sku, process_node=nodes[sku.dies[0].process_node_id],
         cooling_solutions=cooling,
     )
     findings = default_registry.run_one("floorplan_whitespace_fraction", ctx)

--- a/tests/hardware/test_sku_validators_phase2b.py
+++ b/tests/hardware/test_sku_validators_phase2b.py
@@ -44,8 +44,39 @@ def ctx() -> ValidatorContext:
 
 
 def _ctx_with_sku(ctx: ValidatorContext, **sku_updates) -> ValidatorContext:
-    """Return a new context with sku replaced by the perturbed version."""
+    """Return a new context with sku replaced by the perturbed version.
+
+    For top-level ComputeProduct field updates (e.g., performance, power,
+    market). For per-die mutations (silicon_bin, clocks, die_size_mm2)
+    use ``_ctx_with_die``; for KPUBlock mutations (tiles, total_tiles,
+    noc, memory) use ``_ctx_with_block``."""
     new_sku = ctx.sku.model_copy(update=sku_updates)
+    return ValidatorContext(
+        sku=new_sku,
+        process_node=ctx.process_node,
+        cooling_solutions=ctx.cooling_solutions,
+    )
+
+
+def _ctx_with_die(ctx: ValidatorContext, **die_updates) -> ValidatorContext:
+    """Return a new context with the (single) Die replaced. v1 KPU
+    monolithic always has exactly one Die under cp.dies[0]."""
+    new_die = ctx.sku.dies[0].model_copy(update=die_updates)
+    new_sku = ctx.sku.model_copy(update={"dies": [new_die]})
+    return ValidatorContext(
+        sku=new_sku,
+        process_node=ctx.process_node,
+        cooling_solutions=ctx.cooling_solutions,
+    )
+
+
+def _ctx_with_block(ctx: ValidatorContext, **block_updates) -> ValidatorContext:
+    """Return a new context with the (single) KPUBlock replaced. v1 KPU
+    monolithic always has exactly one KPUBlock under cp.dies[0].blocks[0]."""
+    die = ctx.sku.dies[0]
+    new_block = die.blocks[0].model_copy(update=block_updates)
+    new_die = die.model_copy(update={"blocks": [new_block]})
+    new_sku = ctx.sku.model_copy(update={"dies": [new_die]})
     return ValidatorContext(
         sku=new_sku,
         process_node=ctx.process_node,
@@ -95,8 +126,7 @@ def test_tile_mix_consistency_catches_bad_int8_tops(ctx):
 
 def test_tile_mix_consistency_catches_total_tiles_mismatch(ctx):
     """Σtile.num_tiles must equal total_tiles."""
-    bad_arch = ctx.sku.kpu_architecture.model_copy(update={"total_tiles": 999})
-    bad_ctx = _ctx_with_sku(ctx, kpu_architecture=bad_arch)
+    bad_ctx = _ctx_with_block(ctx, total_tiles=999)
     findings = _findings_for("tile_mix_consistency", bad_ctx)
     assert any(
         f.severity == Severity.ERROR and "total_tiles" in f.message
@@ -146,7 +176,7 @@ def test_cross_ref_catches_dangling_cooling_id(ctx):
 def test_cross_ref_catches_unsupported_circuit_class(ctx):
     """A silicon_bin block tagged with a CircuitClass the node doesn't
     offer (e.g., SRAM_HP on a node without dual-port SRAM)."""
-    blocks = list(ctx.sku.silicon_bin.blocks)
+    blocks = list(ctx.sku.dies[0].silicon_bin.blocks)
     blocks[0] = SiliconBinBlock(
         name="bogus",
         circuit_class=CircuitClass.SRAM_HP,  # tsmc_n16 doesn't list HP-SRAM
@@ -154,8 +184,8 @@ def test_cross_ref_catches_unsupported_circuit_class(ctx):
             kind=TransistorSourceKind.FIXED, mtx=1.0
         ),
     )
-    bad_bin = ctx.sku.silicon_bin.model_copy(update={"blocks": blocks})
-    bad_ctx = _ctx_with_sku(ctx, silicon_bin=bad_bin)
+    bad_bin = ctx.sku.dies[0].silicon_bin.model_copy(update={"blocks": blocks})
+    bad_ctx = _ctx_with_die(ctx, silicon_bin=bad_bin)
     findings = _findings_for("cross_ref_consistency", bad_ctx)
     assert any(
         f.severity == Severity.ERROR
@@ -203,7 +233,7 @@ def test_power_monotonicity_passes_real_sku(ctx):
 def test_block_library_validity_catches_unsupported_class(ctx):
     """Same as the cross_ref check, but exposed in the AREA category for
     users who --filter to AREA."""
-    blocks = list(ctx.sku.silicon_bin.blocks)
+    blocks = list(ctx.sku.dies[0].silicon_bin.blocks)
     blocks.append(
         SiliconBinBlock(
             name="bogus_ull",
@@ -213,8 +243,8 @@ def test_block_library_validity_catches_unsupported_class(ctx):
             ),
         )
     )
-    bad_bin = ctx.sku.silicon_bin.model_copy(update={"blocks": blocks})
-    bad_ctx = _ctx_with_sku(ctx, silicon_bin=bad_bin)
+    bad_bin = ctx.sku.dies[0].silicon_bin.model_copy(update={"blocks": blocks})
+    bad_ctx = _ctx_with_die(ctx, silicon_bin=bad_bin)
     findings = _findings_for("block_library_validity", bad_ctx)
     assert any(
         f.severity == Severity.ERROR and f.block == "bogus_ull"
@@ -234,10 +264,9 @@ def test_block_library_validity_passes_when_class_supported(ctx):
 
 def test_area_self_consistency_catches_inflated_die(ctx):
     """Doubling claimed die_size while leaving silicon_bin alone -> ERROR."""
-    bad_die = ctx.sku.die.model_copy(
-        update={"die_size_mm2": ctx.sku.die.die_size_mm2 * 2.0}
+    bad_ctx = _ctx_with_die(
+        ctx, die_size_mm2=ctx.sku.dies[0].die_size_mm2 * 2.0
     )
-    bad_ctx = _ctx_with_sku(ctx, die=bad_die)
     findings = _findings_for("area_self_consistency", bad_ctx)
     assert any(
         f.severity == Severity.ERROR and "die.die_size_mm2" in f.message
@@ -247,10 +276,9 @@ def test_area_self_consistency_catches_inflated_die(ctx):
 
 def test_area_self_consistency_catches_minor_mismatch_as_warning(ctx):
     """A 10% die_size error sits in the WARN band (5-25%)."""
-    bad_die = ctx.sku.die.model_copy(
-        update={"die_size_mm2": ctx.sku.die.die_size_mm2 * 1.10}
+    bad_ctx = _ctx_with_die(
+        ctx, die_size_mm2=ctx.sku.dies[0].die_size_mm2 * 1.10
     )
-    bad_ctx = _ctx_with_sku(ctx, die=bad_die)
     findings = _findings_for("area_self_consistency", bad_ctx)
     assert any(
         f.severity == Severity.WARNING and "die.die_size_mm2" in f.message
@@ -270,10 +298,9 @@ def test_area_self_consistency_passes_real_sku(ctx):
 def test_composite_density_catches_above_node_max(ctx):
     """Claim 100 B transistors on a 50 mm^2 die at TSMC N16 -> 2000
     Mtx/mm^2 composite, way above N16's max library density (60)."""
-    bad_die = ctx.sku.die.model_copy(
-        update={"transistors_billion": 100.0, "die_size_mm2": 50.0}
+    bad_ctx = _ctx_with_die(
+        ctx, transistors_billion=100.0, die_size_mm2=50.0
     )
-    bad_ctx = _ctx_with_sku(ctx, die=bad_die)
     findings = _findings_for("composite_density_envelope", bad_ctx)
     assert any(
         f.severity == Severity.ERROR and "exceeds" in f.message


### PR DESCRIPTION
## Why

Step 3 of the consumer migration. The \`sku_validators\` package — the deepest single-step migration so far — now operates on \`ComputeProduct\` end-to-end. \`ValidatorContext.sku\` changes type from \`KPUEntry\` to \`ComputeProduct\`; every validator and silicon-math helper updates its field-access patterns accordingly.

Followed Option A (single coherent PR, 10 modules) per agreement. Splitting at the type boundary would have created a temporary state where the loader returns ComputeProduct but consumers all immediately convert back to KPUEntry — pure overhead.

## Modules migrated

| Module | Change |
|---|---|
| \`framework.py\` | \`ValidatorContext.sku: KPUEntry\` → \`ComputeProduct\` |
| \`context.py\` | \`load_kpus\` → \`load_compute_products_unified\`; process_node lookup uses \`cp.dies[0].process_node_id\` |
| \`silicon_math.py\` | All 13 functions take \`cp: ComputeProduct\`; new \`_kpu_block(cp)\` helper handles \`cp.dies[0].blocks[0]\` |
| \`validators/area.py\` | \`ctx.sku.silicon_bin\` → \`ctx.sku.dies[0].silicon_bin\`; \`ctx.sku.die.*\` → \`ctx.sku.dies[0].*\` |
| \`validators/consistency.py\` | \`ctx.sku.kpu_architecture\` → \`ctx.sku.dies[0].blocks[0]\` |
| \`validators/electrical.py\` | \`ctx.sku.clocks\` → \`ctx.sku.dies[0].clocks\` (5 sites) |
| \`validators/geometry.py\` | Field updates + uses \`_legacy_sku()\` reverse adapter at the 5 \`derive_kpu_*floorplan\` call sites |
| \`validators/reliability.py\` | \`sku.silicon_bin\` → \`sku.dies[0].silicon_bin\` |
| \`validators/thermal.py\` | \`sku.silicon_bin\` → \`sku.dies[0].silicon_bin\` |

## Bridge modules (explicit migration debt — deleted in their own PRs)

| File | Bridge type | Goes away with |
|---|---|---|
| \`compute_product_loader.py\` | New \`compute_product_to_kpu_entry()\` reverse adapter (90 lines) | When all unmigrated consumers migrate |
| \`silicon_floorplan.py\` | Forward-adapt \`KPUEntry → ComputeProduct\` before \`resolve_block_area\` (silicon_math now requires ComputeProduct) | silicon_floorplan migration PR |
| \`kpu_sku_generator.py\` | Forward-adapt at \`resolve_block_area\` and \`total_chip_leakage_w\` call sites | generator migration PR |
| \`kpu_power_model.py\` | Forward-adapt before \`total_chip_leakage_w\` call | power-model migration PR |

The reverse + forward adapters are minimal (one line each at the call site) and explicitly commented as bridges. Each disappears as the corresponding downstream consumer migrates.

## Tests fixed

- **\`test_silicon_floorplan.py\`**: New \`cps\` fixture for \`ValidatorContext\`-using tests; \`kpus\` fixture retained for \`derive_kpu_floorplan\` tests (KPUEntry consumer)
- **\`test_sku_validators_phase2b.py\`**: New \`_ctx_with_die\` / \`_ctx_with_block\` helpers replace the per-test \`model_copy\` hand-rolling that referenced the legacy \`.kpu_architecture\` / \`.die\` / \`.silicon_bin\` attribute names. The 6 fixture-mutation tests use the new helpers; the test bodies stay readable.
- **\`test_kpu_sku_generator.py\`**: Forward-adapt the generator output before constructing \`ValidatorContext\` (generator still returns KPUEntry)

## Verification

- ✅ 692/692 hardware tests pass
- ✅ 2,696/2,696 unit tests pass under \`pytest -n 4\` (1:16 wall clock locally)
- ✅ All sku_validator tests (91 across framework + catalog + phase2b/phase2cd) green
- ✅ Silicon floorplan tests (194) green
- ✅ No regressions

## Migration sequence (this PR is step 3 of ~7)

- [x] PR #160 — \`show_kpu.py\` + \`show_compute_product.py\`
- [x] PR #161 — \`list_kpus.py\`
- [x] **\`sku_validators/*\`** (10 files) — this PR
- [ ] \`silicon_floorplan.py\` + \`show_floorplan.py\` (bundled, deletes the forward-adapt bridge)
- [ ] \`kpu_power_model.py\` (deletes its forward-adapt bridge)
- [ ] \`kpu_sku_input.py\` + \`kpu_sku_generator.py\` + \`cli/generate_kpu_sku.py\` (deletes that bridge)
- [ ] \`cli/validate_sku.py\` (now trivial after this PR)
- [ ] \`models/accelerators/kpu_yaml_loader.py\` (mapper backbone)
- [ ] cleanup PR — delete \`data/kpus/\`, reduce \`load_kpus()\` to a shim, delete \`compute_product_to_kpu_entry\`

## Test plan

- [x] Hardware test suite green (692/692)
- [x] Full suite green under -n 4 (2,696 tests in 1:16)
- [x] Validator framework, catalog gate, phase2b/phase2cd all pass
- [x] Silicon floorplan tests pass (194)
- [x] No \`KPUEntry\` references left in sku_validators/ (verified)
- [ ] PR CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal hardware product data model to support future multi-block and multi-die processor architectures
  * Updated silicon area calculations, power estimation, thermal analysis, and validation framework
  * Enhanced test coverage for geometry, electrical, and reliability validators

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/162)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->