### PR TITLE
refactor(hardware): migrate silicon_floorplan + show_floorplan to ComputeProduct

### DIFF
--- a/cli/show_floorplan.py
+++ b/cli/show_floorplan.py
@@ -46,9 +46,10 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from embodied_schemas import load_kpus, load_process_nodes
+from embodied_schemas import load_process_nodes
 from embodied_schemas.process_node import CircuitClass
 
+from graphs.hardware.compute_product_loader import load_compute_products_unified
 from graphs.hardware.silicon_floorplan import (
     ArchitecturalFloorplan,
     ArchTile,
@@ -681,7 +682,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    kpus = load_kpus()
+    kpus = load_compute_products_unified()
     if args.list:
         for kid in sorted(kpus):
             print(kid)
@@ -696,14 +697,15 @@ def main() -> int:
 
     sku = kpus[args.sku_id]
     nodes = load_process_nodes()
-    if sku.process_node_id not in nodes:
+    process_node_id = sku.dies[0].process_node_id
+    if process_node_id not in nodes:
         print(
             f"error: SKU references unknown process_node_id "
-            f"{sku.process_node_id!r}",
+            f"{process_node_id!r}",
             file=sys.stderr,
         )
         return 2
-    node = nodes[sku.process_node_id]
+    node = nodes[process_node_id]
 
     fmt = _detect_format(args.output, args.json)
 

--- a/src/graphs/hardware/silicon_floorplan.py
+++ b/src/graphs/hardware/silicon_floorplan.py
@@ -42,14 +42,24 @@ from typing import Optional
 
 _logger = logging.getLogger(__name__)
 
-from embodied_schemas.kpu import KPUEntry, KPUTileSpec
+from embodied_schemas import ComputeProduct
+from embodied_schemas.compute_product import KPUBlock
+from embodied_schemas.kpu import KPUTileSpec
 from embodied_schemas.process_node import CircuitClass, ProcessNodeEntry
 
-from .compute_product_loader import kpu_entry_to_compute_product
 from .sku_validators.silicon_math import (
     SiliconMathError,
     resolve_block_area,
 )
+
+
+def _kpu_block(cp: ComputeProduct) -> KPUBlock:
+    """Return the KPUBlock from a v1 monolithic-KPU ``ComputeProduct``.
+
+    v1 KPU products are monolithic (one Die, one KPUBlock); chiplet KPU
+    products will need iteration when they land. Mirrored from
+    ``sku_validators.silicon_math._kpu_block``."""
+    return cp.dies[0].blocks[0]
 
 
 # ---------------------------------------------------------------------------
@@ -157,7 +167,7 @@ class Floorplan:
 # ---------------------------------------------------------------------------
 
 def _per_tile_pe_area_mm2(
-    sku: KPUEntry,
+    cp: ComputeProduct,
     node: ProcessNodeEntry,
     tile: KPUTileSpec,
     pe_blocks_by_tile_type: dict[str, float],
@@ -174,7 +184,7 @@ def _per_tile_pe_area_mm2(
 
 
 def _per_tile_sram_area_mm2(
-    sku: KPUEntry,
+    cp: ComputeProduct,
     node: ProcessNodeEntry,
     chip_l2_area_mm2: float,
     chip_l3_area_mm2: float,
@@ -185,14 +195,14 @@ def _per_tile_sram_area_mm2(
     per-tile L3 (256 KiB scratchpad). silicon_bin reports them as
     chip-wide aggregates; per-tile is aggregate / num_tiles.
     """
-    total_tiles = sku.kpu_architecture.total_tiles
+    total_tiles = _kpu_block(cp).total_tiles
     if total_tiles <= 0:
         return 0.0
     return (chip_l2_area_mm2 + chip_l3_area_mm2) / total_tiles
 
 
 def _classify_silicon_bin_blocks(
-    sku: KPUEntry, node: ProcessNodeEntry
+    cp: ComputeProduct, node: ProcessNodeEntry
 ) -> tuple[
     dict[str, float],         # pe_area by tile_type
     float,                    # chip-wide L2 area
@@ -212,11 +222,7 @@ def _classify_silicon_bin_blocks(
     chip_l3_area = 0.0
     other_blocks: list[tuple[str, float, CircuitClass]] = []
 
-    # Forward-adapt to ComputeProduct: silicon_math has migrated to the
-    # unified schema, but silicon_floorplan still takes KPUEntry from its
-    # callers. Bridge until silicon_floorplan migrates in a follow-up PR.
-    cp = kpu_entry_to_compute_product(sku)
-    for block in sku.silicon_bin.blocks:
+    for block in cp.dies[0].silicon_bin.blocks:
         try:
             ba = resolve_block_area(block, cp, node)
         except SiliconMathError as exc:
@@ -229,7 +235,7 @@ def _classify_silicon_bin_blocks(
             # finding.
             _logger.warning(
                 "silicon_floorplan: skipping block %r in sku %r: %s",
-                block.name, sku.id, exc,
+                block.name, cp.id, exc,
             )
             continue
         ts = block.transistor_source
@@ -261,7 +267,7 @@ _CONTROL_CORNER_FRACTION = 0.05  # Of die_height for the control square
 
 
 def derive_kpu_floorplan(
-    sku: KPUEntry, node: ProcessNodeEntry
+    cp: ComputeProduct, node: ProcessNodeEntry
 ) -> Floorplan:
     """Heuristic 2D floorplan for a KPU SKU.
 
@@ -289,20 +295,20 @@ def derive_kpu_floorplan(
     overlaps. NoC routers are *not* placed as separate blocks --
     in real silicon they're embedded inside the tile envelopes.
     """
-    arch = sku.kpu_architecture
+    arch = _kpu_block(cp)
 
     # 1. Bucket silicon_bin blocks
     pe_by_tile_type, chip_l2_area, chip_l3_area, other_blocks = (
-        _classify_silicon_bin_blocks(sku, node)
+        _classify_silicon_bin_blocks(cp, node)
     )
 
     # 2. Per-tile-class pitch
     per_tile_sram = _per_tile_sram_area_mm2(
-        sku, node, chip_l2_area, chip_l3_area
+        cp, node, chip_l2_area, chip_l3_area
     )
     tile_pitches: dict[str, TilePitch] = {}
     for tile in arch.tiles:
-        pe_area = _per_tile_pe_area_mm2(sku, node, tile, pe_by_tile_type)
+        pe_area = _per_tile_pe_area_mm2(cp, node, tile, pe_by_tile_type)
         total = pe_area + per_tile_sram
         pitch = math.sqrt(total) if total > 0 else 0.0
         tile_pitches[tile.tile_type] = TilePitch(
@@ -351,7 +357,7 @@ def derive_kpu_floorplan(
     mesh_origin_y = _IO_RING_THICKNESS_MM
     blocks.extend(
         _place_compute_mesh(
-            sku, mesh_origin_x, mesh_origin_y, unified_pitch
+            cp, mesh_origin_x, mesh_origin_y, unified_pitch
         )
     )
 
@@ -375,8 +381,8 @@ def derive_kpu_floorplan(
     ))
 
     return Floorplan(
-        sku_id=sku.id,
-        sku_name=sku.name,
+        sku_id=cp.id,
+        sku_name=cp.name,
         die_width_mm=die_width,
         die_height_mm=die_height,
         blocks=blocks,
@@ -444,7 +450,7 @@ def _place_io_ring(
 
 
 def _place_compute_mesh(
-    sku: KPUEntry,
+    cp: ComputeProduct,
     origin_x_mm: float,
     origin_y_mm: float,
     pitch_mm: float,
@@ -455,10 +461,10 @@ def _place_compute_mesh(
     order (INT8-primary first, then BF16-primary, then Matrix), each
     class taking ``num_tiles`` consecutive grid positions.
     """
-    arch = sku.kpu_architecture
+    arch = _kpu_block(cp)
     if not arch.tiles:
         raise ValueError(
-            f"sku {sku.id!r}: kpu_architecture.tiles is empty; cannot "
+            f"sku {cp.id!r}: kpu_architecture.tiles is empty; cannot "
             f"place a compute mesh"
         )
     mesh_rows = arch.noc.mesh_rows
@@ -854,7 +860,7 @@ class ArchitecturalFloorplan:
 
 # Default memory-controller arity when the SKU memory spec doesn't
 # expose a distinct count. The architectural derivation prefers
-# ``sku.kpu_architecture.memory.memory_controllers`` when present.
+# ``_kpu_block(cp).memory.memory_controllers`` when present.
 _DEFAULT_NUM_MEMORY_CONTROLLERS = 4
 
 
@@ -931,7 +937,7 @@ def _per_channel_phy_dims(memory_type: str, width_bits: int) -> tuple[float, flo
 
 
 def derive_kpu_architectural_floorplan(
-    sku: KPUEntry, node: ProcessNodeEntry
+    cp: ComputeProduct, node: ProcessNodeEntry
 ) -> ArchitecturalFloorplan:
     """Produce the architectural-role floorplan for a KPU SKU.
 
@@ -957,10 +963,10 @@ def derive_kpu_architectural_floorplan(
        impact on die geometry.
     6. IO ring + control corner unchanged from v1.
     """
-    arch = sku.kpu_architecture
+    arch = _kpu_block(cp)
     mem = arch.memory
     pe_by_tile_type, chip_l2_area, chip_l3_area, other_blocks = (
-        _classify_silicon_bin_blocks(sku, node)
+        _classify_silicon_bin_blocks(cp, node)
     )
     total_compute_tiles = arch.total_tiles
 
@@ -1117,8 +1123,8 @@ def derive_kpu_architectural_floorplan(
     )
 
     return ArchitecturalFloorplan(
-        sku_id=sku.id,
-        sku_name=sku.name,
+        sku_id=cp.id,
+        sku_name=cp.name,
         die_width_mm=die_width,
         die_height_mm=die_height,
         blocks=blocks,

--- a/src/graphs/hardware/sku_validators/validators/geometry.py
+++ b/src/graphs/hardware/sku_validators/validators/geometry.py
@@ -28,20 +28,12 @@ from __future__ import annotations
 
 from typing import List
 
-from ...compute_product_loader import compute_product_to_kpu_entry
 from ...silicon_floorplan import (
     derive_kpu_architectural_floorplan,
     derive_kpu_floorplan,
 )
 from .. import ValidatorCategory, ValidatorContext, default_registry
 from ..framework import Finding, Severity
-
-
-def _legacy_sku(ctx: ValidatorContext):
-    """Reverse-adapt ctx.sku (ComputeProduct) to KPUEntry for the
-    silicon_floorplan derivation functions. Bridge until silicon_floorplan
-    accepts ComputeProduct directly (next migration PR)."""
-    return compute_product_to_kpu_entry(ctx.sku, ctx.process_node)
 
 
 # ---------------------------------------------------------------------------
@@ -126,7 +118,7 @@ class FloorplanPitchMatch:
 
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         try:
-            fp = derive_kpu_floorplan(_legacy_sku(ctx), ctx.process_node)
+            fp = derive_kpu_floorplan(ctx.sku, ctx.process_node)
         except Exception as exc:
             return [Finding(
                 validator=self.name,
@@ -196,7 +188,7 @@ class FloorplanWithinDieEnvelope:
 
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         try:
-            fp = derive_kpu_floorplan(_legacy_sku(ctx), ctx.process_node)
+            fp = derive_kpu_floorplan(ctx.sku, ctx.process_node)
         except Exception:
             return []  # Pitch-match validator already reports derivation errors
         declared = ctx.sku.dies[0].die_size_mm2
@@ -245,7 +237,7 @@ class FloorplanAspectRatio:
 
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         try:
-            fp = derive_kpu_floorplan(_legacy_sku(ctx), ctx.process_node)
+            fp = derive_kpu_floorplan(ctx.sku, ctx.process_node)
         except Exception:
             return []
         if fp.die_width_mm <= 0 or fp.die_height_mm <= 0:
@@ -300,7 +292,7 @@ class FloorplanComputeMemoryPitchMatch:
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         try:
             fp = derive_kpu_architectural_floorplan(
-                _legacy_sku(ctx), ctx.process_node
+                ctx.sku, ctx.process_node
             )
         except Exception as exc:
             return [Finding(
@@ -374,7 +366,7 @@ class FloorplanWhitespaceFraction:
     def check(self, ctx: ValidatorContext) -> List[Finding]:
         try:
             fp = derive_kpu_architectural_floorplan(
-                _legacy_sku(ctx), ctx.process_node
+                ctx.sku, ctx.process_node
             )
         except Exception:
             return []  # The pitch validator already reports derivation errors

--- a/tests/hardware/test_silicon_floorplan.py
+++ b/tests/hardware/test_silicon_floorplan.py
@@ -24,7 +24,6 @@ import pytest
 
 from embodied_schemas import (
     load_cooling_solutions,
-    load_kpus,
     load_process_nodes,
 )
 
@@ -47,7 +46,7 @@ SHOW_FLOORPLAN_CLI = REPO_ROOT / "cli" / "show_floorplan.py"
 
 # Auto-discovery: test against every KPU SKU in the catalog. New SKUs
 # get covered automatically, matching the Phase 6 catalog gate pattern.
-ALL_KPU_IDS = sorted(load_kpus().keys())
+ALL_KPU_IDS = sorted(load_compute_products_unified().keys())
 
 
 # ---------------------------------------------------------------------------
@@ -55,17 +54,11 @@ ALL_KPU_IDS = sorted(load_kpus().keys())
 # ---------------------------------------------------------------------------
 
 @pytest.fixture(scope="module")
-def kpus():
-    """Legacy KPUEntry catalog. Used by derive_kpu_floorplan / derive_
-    kpu_architectural_floorplan, which still take KPUEntry until their
-    own migration PR. Validator tests use the ``cps`` fixture below."""
-    return load_kpus()
-
-
-@pytest.fixture(scope="module")
 def cps():
-    """ComputeProduct catalog. Used to construct ValidatorContext, which
-    after the sku_validators migration takes ``sku: ComputeProduct``."""
+    """ComputeProduct catalog. Used by derive_kpu_floorplan,
+    derive_kpu_architectural_floorplan, and ValidatorContext --
+    everything in this module operates on ComputeProduct now that
+    silicon_floorplan + sku_validators have migrated."""
     return load_compute_products_unified()
 
 
@@ -90,21 +83,21 @@ def _register():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_floorplan_has_positive_dimensions(sku_id, kpus, nodes):
+def test_floorplan_has_positive_dimensions(sku_id, cps, nodes):
     """Every SKU produces a die with positive width / height / area.
 
     Catches the case where a missing silicon_bin block (no PHY, no IO,
     etc.) would zero-out a die dimension.
     """
-    sku = kpus[sku_id]
-    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
+    sku = cps[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.dies[0].process_node_id])
     assert fp.die_width_mm > 0, f"{sku_id} has non-positive die width"
     assert fp.die_height_mm > 0, f"{sku_id} has non-positive die height"
     assert fp.die_area_mm2 > 0
 
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_floorplan_compute_tile_count_matches_mesh(sku_id, kpus, nodes):
+def test_floorplan_compute_tile_count_matches_mesh(sku_id, cps, nodes):
     """``mesh_rows x mesh_cols`` compute tiles must be placed.
 
     The KPU NoC mesh is what defines the tile count -- if the
@@ -112,9 +105,9 @@ def test_floorplan_compute_tile_count_matches_mesh(sku_id, kpus, nodes):
     don't sum to the mesh capacity (real bug) or the layout heuristic
     silently dropped tiles (also a bug).
     """
-    sku = kpus[sku_id]
-    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
-    arch = sku.kpu_architecture
+    sku = cps[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.dies[0].process_node_id])
+    arch = sku.dies[0].blocks[0]
     expected = arch.noc.mesh_rows * arch.noc.mesh_cols
     assert len(fp.compute_tiles()) == expected, (
         f"{sku_id}: placed {len(fp.compute_tiles())} compute tiles, "
@@ -123,12 +116,12 @@ def test_floorplan_compute_tile_count_matches_mesh(sku_id, kpus, nodes):
 
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_floorplan_every_compute_tile_has_class(sku_id, kpus, nodes):
+def test_floorplan_every_compute_tile_has_class(sku_id, cps, nodes):
     """Every compute tile must carry a tile_class label so geometry
     validators can group findings by class."""
-    sku = kpus[sku_id]
-    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
-    declared_classes = {t.tile_type for t in sku.kpu_architecture.tiles}
+    sku = cps[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.dies[0].process_node_id])
+    declared_classes = {t.tile_type for t in sku.dies[0].blocks[0].tiles}
     for block in fp.compute_tiles():
         assert block.tile_class is not None, (
             f"{sku_id}: compute tile {block.name} missing tile_class"
@@ -140,14 +133,14 @@ def test_floorplan_every_compute_tile_has_class(sku_id, kpus, nodes):
 
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_floorplan_compute_tiles_dont_overlap(sku_id, kpus, nodes):
+def test_floorplan_compute_tiles_dont_overlap(sku_id, cps, nodes):
     """Compute tiles in the mesh must be axis-aligned, non-overlapping.
 
     Uses the mesh row/col ordering implicit in the tile name format
     ``tile[r,c]`` and checks neighbouring tiles share an edge.
     """
-    sku = kpus[sku_id]
-    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
+    sku = cps[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.dies[0].process_node_id])
     tiles = fp.compute_tiles()
 
     # All tiles share the same width and height (unified pitch)
@@ -183,13 +176,13 @@ def test_floorplan_compute_tiles_dont_overlap(sku_id, kpus, nodes):
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
 def test_floorplan_unified_pitch_dominates_tile_class_pitches(
-    sku_id, kpus, nodes
+    sku_id, cps, nodes
 ):
     """The unified mesh pitch is the max across tile classes -- no
     class can have a pitch greater than the unified pitch (otherwise
     larger tiles would overflow the mesh cell)."""
-    sku = kpus[sku_id]
-    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
+    sku = cps[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.dies[0].process_node_id])
     for tile_class, tp in fp.tile_pitches.items():
         assert tp.pitch_mm <= fp.unified_pitch_mm + 1e-6, (
             f"{sku_id}: tile class {tile_class!r} pitch {tp.pitch_mm} "
@@ -198,15 +191,15 @@ def test_floorplan_unified_pitch_dominates_tile_class_pitches(
 
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_floorplan_total_block_area_close_to_die_area(sku_id, kpus, nodes):
+def test_floorplan_total_block_area_close_to_die_area(sku_id, cps, nodes):
     """Total placed-block area must be at most the die area.
 
     Whitespace is allowed; overlap is not. ``total_block_area > die_area``
     means the floorplanner placed overlapping rectangles or computed
     the die envelope incorrectly.
     """
-    sku = kpus[sku_id]
-    fp = derive_kpu_floorplan(sku, nodes[sku.process_node_id])
+    sku = cps[sku_id]
+    fp = derive_kpu_floorplan(sku, nodes[sku.dies[0].process_node_id])
     # Allow 1% slop for floating-point rounding in the IO ring corners
     assert fp.total_block_area_mm2() <= fp.die_area_mm2 * 1.01, (
         f"{sku_id}: blocks total {fp.total_block_area_mm2():.2f} mm^2 "
@@ -355,31 +348,31 @@ def test_show_floorplan_cli_list_mode():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_arch_floorplan_has_positive_dimensions(sku_id, kpus, nodes):
-    sku = kpus[sku_id]
-    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+def test_arch_floorplan_has_positive_dimensions(sku_id, cps, nodes):
+    sku = cps[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.dies[0].process_node_id])
     assert fp.die_width_mm > 0
     assert fp.die_height_mm > 0
     assert fp.die_area_mm2 > 0
 
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_arch_floorplan_compute_memory_one_to_one(sku_id, kpus, nodes):
+def test_arch_floorplan_compute_memory_one_to_one(sku_id, cps, nodes):
     """Architectural pairing: 1 memory tile per compute tile (each
     compute tile owns its L3). The checkerboard layout depends on
     this 1:1 invariant."""
-    sku = kpus[sku_id]
-    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
-    assert len(fp.compute_tiles()) == sku.kpu_architecture.total_tiles
-    assert len(fp.memory_tiles()) == sku.kpu_architecture.total_tiles
+    sku = cps[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.dies[0].process_node_id])
+    assert len(fp.compute_tiles()) == sku.dies[0].blocks[0].total_tiles
+    assert len(fp.memory_tiles()) == sku.dies[0].blocks[0].total_tiles
 
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_arch_floorplan_distributes_memory_controllers(sku_id, kpus, nodes):
+def test_arch_floorplan_distributes_memory_controllers(sku_id, cps, nodes):
     """Memory controllers must be placed (default 4) and distributed
     around the periphery (no two on top of each other)."""
-    sku = kpus[sku_id]
-    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    sku = cps[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.dies[0].process_node_id])
     ctrls = fp.memory_controllers()
     assert len(ctrls) >= 1, f"{sku_id}: no memory controllers placed"
     # Each controller has positive area
@@ -403,11 +396,11 @@ def test_arch_floorplan_distributes_memory_controllers(sku_id, kpus, nodes):
 
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_arch_floorplan_what_if_one_per_class(sku_id, kpus, nodes):
+def test_arch_floorplan_what_if_one_per_class(sku_id, cps, nodes):
     """What-if estimates: one entry per declared compute tile class."""
-    sku = kpus[sku_id]
-    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
-    declared_classes = {t.tile_type for t in sku.kpu_architecture.tiles}
+    sku = cps[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.dies[0].process_node_id])
+    declared_classes = {t.tile_type for t in sku.dies[0].blocks[0].tiles}
     estimated_classes = {wi.tile_class for wi in fp.what_if}
     assert estimated_classes == declared_classes, (
         f"{sku_id}: what-if covers {estimated_classes}, "
@@ -415,15 +408,15 @@ def test_arch_floorplan_what_if_one_per_class(sku_id, kpus, nodes):
     )
 
 
-def test_arch_what_if_all_int8_smaller_than_all_matrix(kpus, nodes):
+def test_arch_what_if_all_int8_smaller_than_all_matrix(cps, nodes):
     """The whole point of the what-if: an all-INT8 mesh should be
     notably smaller than an all-Matrix mesh, because INT8 PE area
     is much less than Matrix PE area. If this stops being true, the
     silicon_bin coefficients have drifted in a way the architect
     should know about.
     """
-    sku = kpus["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
-    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    sku = cps["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.dies[0].process_node_id])
     by_class = {wi.tile_class: wi for wi in fp.what_if}
     assert "INT8-primary" in by_class
     assert "Matrix" in by_class
@@ -518,14 +511,14 @@ def test_show_floorplan_cli_view_circuit_falls_back_to_old():
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
 def test_arch_true_2d_checkerboard_interior_compute_has_4_memory_neighbors(
-    sku_id, kpus, nodes
+    sku_id, cps, nodes
 ):
     """True 2D checkerboard: every interior compute tile has exactly
     4 memory tile neighbours (N/S/E/W). Catches regressions to
     column-pair (1 neighbour) or row-pair patterns.
     """
-    sku = kpus[sku_id]
-    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    sku = cps[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.dies[0].process_node_id])
     compute_tiles = fp.compute_tiles()
     memory_tiles = fp.memory_tiles()
     assert compute_tiles and memory_tiles
@@ -537,8 +530,8 @@ def test_arch_true_2d_checkerboard_interior_compute_has_4_memory_neighbors(
     # Pick an interior compute tile by parsing its checkerboard
     # coordinates ``compute[r,c]`` (encoded into the name). Interior
     # = at least one row/col away from every mesh edge.
-    mesh_rows = sku.kpu_architecture.noc.mesh_rows
-    mesh_cols_phys = 2 * sku.kpu_architecture.noc.mesh_cols
+    mesh_rows = sku.dies[0].blocks[0].noc.mesh_rows
+    mesh_cols_phys = 2 * sku.dies[0].blocks[0].noc.mesh_cols
     target = None
     import re
     for ct in compute_tiles:
@@ -571,13 +564,13 @@ def test_arch_true_2d_checkerboard_interior_compute_has_4_memory_neighbors(
 
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_mc_count_equals_memory_controllers_field(sku_id, kpus, nodes):
+def test_mc_count_equals_memory_controllers_field(sku_id, cps, nodes):
     """MC count comes from ``memory.memory_controllers``, not from a
     silicon_bin estimate or default. T256 (16 LPDDR ch), T128 (8),
     T64 (4), T768 (8 HBM stacks)."""
-    sku = kpus[sku_id]
-    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
-    declared = sku.kpu_architecture.memory.memory_controllers
+    sku = cps[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.dies[0].process_node_id])
+    declared = sku.dies[0].blocks[0].memory.memory_controllers
     assert fp.num_memory_controllers == declared, (
         f"{sku_id}: floorplan placed {fp.num_memory_controllers} MCs, "
         f"YAML declares {declared}"
@@ -586,10 +579,10 @@ def test_mc_count_equals_memory_controllers_field(sku_id, kpus, nodes):
     assert len(fp.memory_channels) == declared
 
 
-def test_lpddr_mc_is_long_narrow_stripe(kpus, nodes):
+def test_lpddr_mc_is_long_narrow_stripe(cps, nodes):
     """LPDDR PHY blocks are narrow stripes (~5:1 aspect)."""
-    sku = kpus["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]  # LPDDR5
-    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    sku = cps["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]  # LPDDR5
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.dies[0].process_node_id])
     for mc in fp.memory_controllers():
         long = max(mc.width_mm, mc.height_mm)
         short = min(mc.width_mm, mc.height_mm)
@@ -600,15 +593,15 @@ def test_lpddr_mc_is_long_narrow_stripe(kpus, nodes):
         )
 
 
-def test_hbm_mc_is_squarer_than_lpddr(kpus, nodes):
+def test_hbm_mc_is_squarer_than_lpddr(cps, nodes):
     """HBM PHY blocks are squarer (~1.5:1 aspect) than LPDDR (~5:1)."""
-    lpddr_sku = kpus["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    hbm_sku = kpus["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
+    lpddr_sku = cps["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
+    hbm_sku = cps["kpu_t768_16x8_hbm3x16_7nm_tsmc_hpc"]
     fp_lpddr = derive_kpu_architectural_floorplan(
-        lpddr_sku, nodes[lpddr_sku.process_node_id]
+        lpddr_sku, nodes[lpddr_sku.dies[0].process_node_id]
     )
     fp_hbm = derive_kpu_architectural_floorplan(
-        hbm_sku, nodes[hbm_sku.process_node_id]
+        hbm_sku, nodes[hbm_sku.dies[0].process_node_id]
     )
     def aspect(mc):
         long = max(mc.width_mm, mc.height_mm)
@@ -623,11 +616,11 @@ def test_hbm_mc_is_squarer_than_lpddr(kpus, nodes):
 
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_dram_channels_placed_outside_die(sku_id, kpus, nodes):
+def test_dram_channels_placed_outside_die(sku_id, cps, nodes):
     """Every memory channel sits beyond the die boundary on its
     respective edge; channels are not inside the die."""
-    sku = kpus[sku_id]
-    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
+    sku = cps[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.dies[0].process_node_id])
     for ch in fp.memory_channels:
         if ch.edge == "top":
             assert ch.y_mm >= fp.die_height_mm - 1e-6, (
@@ -646,15 +639,15 @@ def test_dram_channels_placed_outside_die(sku_id, kpus, nodes):
 
 
 @pytest.mark.parametrize("sku_id", ALL_KPU_IDS)
-def test_mc_dimensions_independent_of_mesh_size(sku_id, kpus, nodes):
+def test_mc_dimensions_independent_of_mesh_size(sku_id, cps, nodes):
     """MC area is determined by memory type + channel width, NOT by
     compute mesh size. Catch regressions to the v1 behaviour where
     MC side = sqrt(total_phy_area / num_controllers) shrunk with
     smaller meshes.
     """
-    sku = kpus[sku_id]
-    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.process_node_id])
-    mem = sku.kpu_architecture.memory
+    sku = cps[sku_id]
+    fp = derive_kpu_architectural_floorplan(sku, nodes[sku.dies[0].process_node_id])
+    mem = sku.dies[0].blocks[0].memory
     if mem.memory_controllers <= 0 or mem.memory_bus_bits <= 0:
         return
     # PHY/channel area should match the memory-type lookup; if the


### PR DESCRIPTION
## Why

Step 4 of the consumer migration. Migrates the silicon-floorplan pipeline end-to-end onto the unified \`ComputeProduct\` interface.

This PR retires two of the three migration-debt bridges introduced in PR #162:
- \`silicon_floorplan\`'s forward-adapt to ComputeProduct (because silicon_floorplan itself now takes ComputeProduct directly)
- \`geometry.py\`'s \`_legacy_sku\` reverse-adapt (because the \`derive_kpu_*floorplan\` functions now accept ComputeProduct)

The remaining bridges in \`kpu_power_model\` and \`kpu_sku_generator\` get retired in their own follow-up PRs.

> Replaces closed PR #163, which auto-closed when its stacked base (PR #162) was deleted on squash-merge. Same content, rebased onto main.

## What changed

### \`src/graphs/hardware/silicon_floorplan.py\`

| Before | After |
|---|---|
| 6 functions with \`sku: KPUEntry\` | 6 functions with \`cp: ComputeProduct\` |
| \`sku.kpu_architecture.*\` (4 sites) | \`_kpu_block(cp).*\` via local helper |
| \`sku.silicon_bin\` | \`cp.dies[0].silicon_bin\` |
| \`sku.id\` / \`sku.name\` | \`cp.id\` / \`cp.name\` |
| Forward-adapt \`kpu_entry_to_compute_product(sku)\` at line 218 | **deleted** — silicon_math gets the same \`cp\` directly |
| Imports \`KPUEntry\`, \`kpu_entry_to_compute_product\` | Imports \`ComputeProduct\`, \`KPUBlock\` |

### \`cli/show_floorplan.py\`

- \`load_kpus()\` → \`load_compute_products_unified()\`
- \`sku.process_node_id\` → \`sku.dies[0].process_node_id\`

### \`src/graphs/hardware/sku_validators/validators/geometry.py\`

- Deletes the \`_legacy_sku(ctx)\` helper + \`compute_product_to_kpu_entry\` import (added in #162)
- 5 call sites (\`derive_kpu_floorplan(_legacy_sku(ctx), ...)\` → \`derive_kpu_floorplan(ctx.sku, ...)\`)

### \`tests/hardware/test_silicon_floorplan.py\`

- Drops the \`kpus\` fixture (no longer needed)
- \`cps\` is the sole catalog fixture
- \`ALL_KPU_IDS\` now uses \`load_compute_products_unified\`
- All 15 test signatures use \`cps\`; field accesses on \`sku\` updated to \`sku.dies[0].blocks[0].*\` / \`sku.dies[0].process_node_id\`

## Verification

- ✅ 194/194 silicon_floorplan tests pass
- ✅ 692/692 hardware tests pass
- ✅ \`show_floorplan\` CLI smoke (text/\`--list\`/JSON) produces sensible output

## Migration sequence (this PR is step 4 of ~7)

- [x] PR #160 — \`show_kpu.py\` + \`show_compute_product.py\`
- [x] PR #161 — \`list_kpus.py\`
- [x] PR #162 — \`sku_validators/*\` (10 files)
- [x] **\`silicon_floorplan.py\` + \`show_floorplan.py\`** — this PR
- [ ] \`kpu_power_model.py\` (deletes its forward-adapt bridge)
- [ ] \`kpu_sku_input.py\` + \`kpu_sku_generator.py\` + \`cli/generate_kpu_sku.py\`
- [ ] \`cli/validate_sku.py\`
- [ ] \`models/accelerators/kpu_yaml_loader.py\`
- [ ] cleanup PR — delete \`data/kpus/\`, reduce \`load_kpus()\` to a shim, delete \`compute_product_to_kpu_entry\`

## Test plan

- [x] Hardware test suite green
- [x] Silicon floorplan tests green
- [x] CLI smoke
- [x] PR CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)