### PR TITLE
refactor(hardware): migrate kpu_sku_generator to ComputeProduct

### DIFF
--- a/cli/generate_kpu_sku.py
+++ b/cli/generate_kpu_sku.py
@@ -45,13 +45,14 @@ from typing import Optional
 
 import yaml
 
-from embodied_schemas import load_cooling_solutions, load_kpus, load_process_nodes
+from embodied_schemas import load_cooling_solutions, load_process_nodes
 
+from graphs.hardware.compute_product_loader import load_compute_products_unified
 from graphs.hardware.kpu_sku_generator import (
     GeneratorError,
     apply_pe_array_override,
     generate_kpu_sku,
-    input_spec_from_kpu_entry,
+    input_spec_from_compute_product,
 )
 from graphs.hardware.kpu_sku_input import KPUSKUInputSpec
 from graphs.hardware.sku_validators import (
@@ -148,7 +149,7 @@ def main() -> int:
             return 2
     else:
         try:
-            kpus = load_kpus()
+            kpus = load_compute_products_unified()
         except Exception as exc:
             print(f"error: failed to load KPU catalog: {exc}", file=sys.stderr)
             return 2
@@ -160,7 +161,7 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 2
-        spec = input_spec_from_kpu_entry(existing)
+        spec = input_spec_from_compute_product(existing)
 
     # Apply PE-array override (after spec load, before generation).
     if args.pe_array:
@@ -202,7 +203,7 @@ def main() -> int:
         load_validators()
         ctx = ValidatorContext(
             sku=entry,
-            process_node=process_nodes[entry.process_node_id],
+            process_node=process_nodes[entry.dies[0].process_node_id],
             cooling_solutions=cooling_solutions,
         )
         findings = default_registry.run_all(ctx)

--- a/src/graphs/hardware/kpu_sku_generator.py
+++ b/src/graphs/hardware/kpu_sku_generator.py
@@ -1,12 +1,11 @@
 """KPU SKU generator.
 
-Turns a ``KPUSKUInputSpec`` into a fully-populated ``KPUEntry`` by
+Turns a ``KPUSKUInputSpec`` into a fully-populated ``ComputeProduct`` by
 computing the roll-up fields from the architectural / silicon_bin / NoC
 inputs and the referenced ``ProcessNodeEntry``:
 
-* ``die.transistors_billion`` -- Σ silicon_bin block transistors / 1000
-* ``die.die_size_mm2`` -- Σ silicon_bin block area (= transistors / density)
-* ``die.{foundry, process_nm, process_name}`` -- copied from ProcessNode
+* ``dies[0].transistors_billion`` -- Σ silicon_bin block transistors / 1000
+* ``dies[0].die_size_mm2`` -- Σ silicon_bin block area (= transistors / density)
 * ``performance.{int8_tops, bf16_tflops, fp32_tflops, int4_tops}`` --
   Σ(tile.num_tiles × ops_per_tile_per_clock) × default-profile clock
 * ``power.{tdp_watts, max_power_watts, min_power_watts,
@@ -17,6 +16,8 @@ inputs and the referenced ``ProcessNodeEntry``:
   TDP is the consequence.
 * ``power.idle_power_watts`` -- chip-wide leakage from ProcessNode
   ``leakage_w_per_mm2`` × per-block area
+* ``lifecycle`` -- derived from ``KPUMarket.is_discontinued`` (legacy
+  market shape on the input spec): EOL if discontinued else PRODUCTION
 
 The generator never modifies architect-provided fields. If
 ``input_spec.silicon_bin`` is incomplete (missing blocks) or
@@ -35,13 +36,24 @@ from __future__ import annotations
 from typing import Optional
 
 from embodied_schemas import (
-    KPUDieSpec,
-    KPUEntry,
-    KPUPowerSpec,
-    KPUTheoreticalPerformance,
+    ComputeProduct,
+    Die,
+    DieRole,
+    KPUBlock,
+    LifecycleStatus,
+    Market,
+    Packaging,
+    PackagingKind,
+    Power,
+    ProductKind,
     load_process_nodes,
 )
-from embodied_schemas.kpu import KPUThermalProfile
+from embodied_schemas.kpu import (
+    KPUArchitecture,
+    KPUMarket,
+    KPUTheoreticalPerformance,
+    KPUThermalProfile,
+)
 from embodied_schemas.process_node import ProcessNodeEntry
 
 from .kpu_power_model import (
@@ -49,7 +61,6 @@ from .kpu_power_model import (
     WorkloadAssumption,
     compute_thermal_profile_tdp_w,
 )
-from .compute_product_loader import kpu_entry_to_compute_product
 from .kpu_sku_input import KPUSKUInputSpec
 from .sku_validators.silicon_math import (
     SiliconMathError,
@@ -66,13 +77,73 @@ class GeneratorError(Exception):
     the failure surface as a cascade of validator findings."""
 
 
+def _placeholder_for_resolution(spec: KPUSKUInputSpec) -> ComputeProduct:
+    """Build a ComputeProduct with placeholder die_size / transistor
+    fields so silicon_math helpers can walk the silicon_bin during
+    transistor-count resolution. Die size and transistor count get
+    filled in with real numbers in the second pass."""
+    return ComputeProduct(
+        id=spec.id,
+        name=spec.name,
+        vendor=spec.vendor,
+        kind=ProductKind.CHIP,
+        packaging=Packaging(
+            kind=PackagingKind.MONOLITHIC,
+            num_dies=1,
+            package_type="monolithic",
+        ),
+        dies=[
+            Die(
+                die_id="kpu_compute",
+                die_role=DieRole.COMPUTE,
+                process_node_id=spec.process_node_id,
+                die_size_mm2=1.0,           # placeholder; recomputed below
+                transistors_billion=1.0,    # placeholder
+                silicon_bin=spec.silicon_bin,
+                clocks=spec.clocks,
+                blocks=[
+                    KPUBlock(
+                        total_tiles=spec.kpu_architecture.total_tiles,
+                        multi_precision_alu=spec.kpu_architecture.multi_precision_alu,
+                        tiles=spec.kpu_architecture.tiles,
+                        noc=spec.kpu_architecture.noc,
+                        memory=spec.kpu_architecture.memory,
+                    )
+                ],
+                interconnects=[],
+            )
+        ],
+        performance=KPUTheoreticalPerformance(
+            int8_tops=0.0, bf16_tflops=0.0, fp32_tflops=0.0,
+        ),
+        power=Power(
+            tdp_watts=1.0,
+            max_power_watts=1.0,
+            min_power_watts=1.0,
+            default_thermal_profile=spec.default_thermal_profile,
+            thermal_profiles=spec.thermal_profiles,
+        ),
+        market=Market(
+            launch_date=spec.market.launch_date,
+            launch_msrp_usd=spec.market.launch_msrp_usd,
+            target_market=spec.market.target_market,
+            product_family=spec.market.product_family,
+            model_tier=spec.market.model_tier,
+            is_available=spec.market.is_available,
+        ),
+        notes=spec.notes,
+        datasheet_url=spec.datasheet_url,
+        last_updated=spec.last_updated,
+    )
+
+
 def generate_kpu_sku(
     spec: KPUSKUInputSpec,
     *,
     process_nodes: Optional[dict[str, ProcessNodeEntry]] = None,
     workload: Optional[WorkloadAssumption] = None,
-) -> KPUEntry:
-    """Produce a fully-populated KPUEntry from an input spec.
+) -> ComputeProduct:
+    """Produce a fully-populated ComputeProduct from an input spec.
 
     Args:
         spec: The architect-authored input.
@@ -115,50 +186,11 @@ def generate_kpu_sku(
         )
 
     # ---- Roll up silicon_bin -> die ----
-    # We pass a *temporary* KPUEntry-shaped object to silicon_math
-    # because resolve_block_area() walks kpu_architecture for
-    # PER_PE / PER_KIB / PER_ROUTER / PER_CONTROLLER expansions. We
-    # build a placeholder die then fill in the real numbers; the spec's
-    # KPUEntry construction at the end re-uses these.
-    placeholder_die = KPUDieSpec(
-        architecture="KPU Tile",
-        foundry=node.foundry,
-        process_nm=node.node_nm,
-        process_name=node.node_name,
-        transistors_billion=1.0,    # placeholder; overwritten below
-        die_size_mm2=1.0,           # placeholder
-        is_chiplet=False,
-        num_dies=1,
-    )
-    placeholder_perf = KPUTheoreticalPerformance(
-        int8_tops=0.0, bf16_tflops=0.0, fp32_tflops=0.0,
-    )
-    placeholder_power = KPUPowerSpec(
-        tdp_watts=default_profile.tdp_watts,
-        max_power_watts=default_profile.tdp_watts,
-        min_power_watts=default_profile.tdp_watts,
-        default_thermal_profile=spec.default_thermal_profile,
-        thermal_profiles=spec.thermal_profiles,
-    )
-    placeholder_sku = KPUEntry(
-        id=spec.id,
-        name=spec.name,
-        vendor=spec.vendor,
-        process_node_id=spec.process_node_id,
-        die=placeholder_die,
-        kpu_architecture=spec.kpu_architecture,
-        silicon_bin=spec.silicon_bin,
-        clocks=spec.clocks,
-        performance=placeholder_perf,
-        power=placeholder_power,
-        market=spec.market,
-        notes=spec.notes,
-        datasheet_url=spec.datasheet_url,
-        last_updated=spec.last_updated,
-    )
-    # Forward-adapt to ComputeProduct: silicon_math has migrated. Bridge
-    # until kpu_sku_generator itself migrates in a follow-up PR.
-    placeholder_cp = kpu_entry_to_compute_product(placeholder_sku)
+    # Build a placeholder ComputeProduct so silicon_math helpers can walk
+    # kpu_architecture for PER_PE / PER_KIB / PER_ROUTER / PER_CONTROLLER
+    # expansions. The placeholder has bogus die_size/transistors, which
+    # we replace with the rolled-up values from the silicon_bin pass.
+    placeholder_cp = _placeholder_for_resolution(spec)
 
     total_area = 0.0
     total_mtx = 0.0
@@ -180,16 +212,8 @@ def generate_kpu_sku(
             else "silicon_bin is empty or every block has 0 area."
         )
 
-    die = KPUDieSpec(
-        architecture="KPU Tile",
-        foundry=node.foundry,
-        process_nm=node.node_nm,
-        process_name=node.node_name,
-        transistors_billion=round(total_mtx / 1000.0, 3),
-        die_size_mm2=round(total_area, 1),
-        is_chiplet=False,
-        num_dies=1,
-    )
+    derived_die_size_mm2 = round(total_area, 1)
+    derived_transistors_billion = round(total_mtx / 1000.0, 3)
 
     # ---- Performance roll-up at default profile clock ----
     clock_hz = default_profile.clock_mhz * 1e6
@@ -233,7 +257,7 @@ def generate_kpu_sku(
     leakage_w = total_chip_leakage_w(placeholder_cp, node)
     idle_w = round(leakage_w, 2) if leakage_w > 0 else None
 
-    power = KPUPowerSpec(
+    power = Power(
         tdp_watts=derived_default.tdp_watts,
         max_power_watts=max_w,
         min_power_watts=min_w,
@@ -242,19 +266,53 @@ def generate_kpu_sku(
         thermal_profiles=derived_profiles,
     )
 
-    # ---- Construct the final KPUEntry ----
-    return KPUEntry(
+    # ---- Construct the final ComputeProduct ----
+    return ComputeProduct(
         id=spec.id,
         name=spec.name,
         vendor=spec.vendor,
-        process_node_id=spec.process_node_id,
-        die=die,
-        kpu_architecture=spec.kpu_architecture,
-        silicon_bin=spec.silicon_bin,
-        clocks=spec.clocks,
+        kind=ProductKind.CHIP,
+        packaging=Packaging(
+            kind=PackagingKind.MONOLITHIC,
+            num_dies=1,
+            package_type="monolithic",
+        ),
+        lifecycle=(
+            LifecycleStatus.EOL
+            if spec.market.is_discontinued
+            else LifecycleStatus.PRODUCTION
+        ),
+        dies=[
+            Die(
+                die_id="kpu_compute",
+                die_role=DieRole.COMPUTE,
+                process_node_id=spec.process_node_id,
+                die_size_mm2=derived_die_size_mm2,
+                transistors_billion=derived_transistors_billion,
+                silicon_bin=spec.silicon_bin,
+                clocks=spec.clocks,
+                blocks=[
+                    KPUBlock(
+                        total_tiles=spec.kpu_architecture.total_tiles,
+                        multi_precision_alu=spec.kpu_architecture.multi_precision_alu,
+                        tiles=spec.kpu_architecture.tiles,
+                        noc=spec.kpu_architecture.noc,
+                        memory=spec.kpu_architecture.memory,
+                    )
+                ],
+                interconnects=[],
+            )
+        ],
         performance=performance,
         power=power,
-        market=spec.market,
+        market=Market(
+            launch_date=spec.market.launch_date,
+            launch_msrp_usd=spec.market.launch_msrp_usd,
+            target_market=spec.market.target_market,
+            product_family=spec.market.product_family,
+            model_tier=spec.market.model_tier,
+            is_available=spec.market.is_available,
+        ),
         notes=spec.notes,
         datasheet_url=spec.datasheet_url,
         last_updated=spec.last_updated,
@@ -316,25 +374,45 @@ def apply_pe_array_override(
     return spec.model_copy(update={"kpu_architecture": new_arch})
 
 
-def input_spec_from_kpu_entry(entry: KPUEntry) -> KPUSKUInputSpec:
-    """Extract a KPUSKUInputSpec from an existing KPUEntry.
+def input_spec_from_compute_product(cp: ComputeProduct) -> KPUSKUInputSpec:
+    """Extract a KPUSKUInputSpec from an existing ComputeProduct.
 
     Used by tests for round-trip verification (load existing YAML ->
     extract spec -> regenerate -> diff against original) and by the CLI
     when an architect wants to start from an existing SKU as a template.
+
+    Translates the ComputeProduct's per-die structure back to the
+    spec's flat shape. v1 KPU monolithic products are assumed (one Die,
+    one KPUBlock); the input spec doesn't model multi-die yet.
     """
+    die = cp.dies[0]
+    block = die.blocks[0]
     return KPUSKUInputSpec(
-        id=entry.id,
-        name=entry.name,
-        vendor=entry.vendor,
-        process_node_id=entry.process_node_id,
-        kpu_architecture=entry.kpu_architecture,
-        silicon_bin=entry.silicon_bin,
-        clocks=entry.clocks,
-        thermal_profiles=entry.power.thermal_profiles,
-        default_thermal_profile=entry.power.default_thermal_profile,
-        market=entry.market,
-        notes=entry.notes,
-        datasheet_url=entry.datasheet_url,
-        last_updated=entry.last_updated,
+        id=cp.id,
+        name=cp.name,
+        vendor=cp.vendor,
+        process_node_id=die.process_node_id,
+        kpu_architecture=KPUArchitecture(
+            total_tiles=block.total_tiles,
+            multi_precision_alu=block.multi_precision_alu,
+            tiles=block.tiles,
+            noc=block.noc,
+            memory=block.memory,
+        ),
+        silicon_bin=die.silicon_bin,
+        clocks=die.clocks,
+        thermal_profiles=cp.power.thermal_profiles,
+        default_thermal_profile=cp.power.default_thermal_profile,
+        market=KPUMarket(
+            launch_date=cp.market.launch_date,
+            launch_msrp_usd=cp.market.launch_msrp_usd,
+            target_market=cp.market.target_market,
+            product_family=cp.market.product_family,
+            model_tier=cp.market.model_tier,
+            is_available=cp.market.is_available,
+            is_discontinued=(cp.lifecycle == LifecycleStatus.EOL),
+        ),
+        notes=cp.notes,
+        datasheet_url=cp.datasheet_url,
+        last_updated=cp.last_updated,
     )

--- a/src/graphs/hardware/kpu_sku_generator.py
+++ b/src/graphs/hardware/kpu_sku_generator.py
@@ -384,9 +384,32 @@ def input_spec_from_compute_product(cp: ComputeProduct) -> KPUSKUInputSpec:
     Translates the ComputeProduct's per-die structure back to the
     spec's flat shape. v1 KPU monolithic products are assumed (one Die,
     one KPUBlock); the input spec doesn't model multi-die yet.
+
+    Raises ``GeneratorError`` for shape mismatches (empty dies, empty
+    blocks, non-KPUBlock first block). The Pydantic schema enforces
+    dies/blocks min_length=1 at construction, but instances built via
+    ``model_construct()`` bypass validation -- the explicit checks
+    surface the failure with a clear message rather than IndexError /
+    AttributeError.
     """
+    if not cp.dies:
+        raise GeneratorError(
+            f"input_spec_from_compute_product: ComputeProduct {cp.id!r} "
+            f"has no dies; expected one Die for v1 KPU monolithic"
+        )
     die = cp.dies[0]
+    if not die.blocks:
+        raise GeneratorError(
+            f"input_spec_from_compute_product: ComputeProduct {cp.id!r} "
+            f"die {die.die_id!r} has no blocks; expected one KPUBlock"
+        )
     block = die.blocks[0]
+    if not isinstance(block, KPUBlock):
+        raise GeneratorError(
+            f"input_spec_from_compute_product: ComputeProduct {cp.id!r} "
+            f"die {die.die_id!r} first block is "
+            f"{type(block).__name__}, expected KPUBlock"
+        )
     return KPUSKUInputSpec(
         id=cp.id,
         name=cp.name,

--- a/tests/hardware/test_kpu_sku_generator.py
+++ b/tests/hardware/test_kpu_sku_generator.py
@@ -7,7 +7,7 @@ Coverage:
     real SKUs.
   - GeneratorError on bad inputs (missing process node, bad default
     profile name, empty silicon_bin).
-  - input_spec_from_kpu_entry preserves architect-authored fields.
+  - input_spec_from_compute_product preserves architect-authored fields.
 """
 
 from __future__ import annotations
@@ -17,16 +17,15 @@ import pytest
 from embodied_schemas import (
     KPUSiliconBin,
     load_cooling_solutions,
-    load_kpus,
     load_process_nodes,
 )
 
-from graphs.hardware.compute_product_loader import kpu_entry_to_compute_product
+from graphs.hardware.compute_product_loader import load_compute_products_unified
 from graphs.hardware.kpu_sku_generator import (
     GeneratorError,
     apply_pe_array_override,
     generate_kpu_sku,
-    input_spec_from_kpu_entry,
+    input_spec_from_compute_product,
 )
 from graphs.hardware.sku_validators import (
     Severity,
@@ -42,7 +41,7 @@ load_validators()
 @pytest.fixture(scope="module")
 def catalogs():
     return {
-        "kpus": load_kpus(),
+        "kpus": load_compute_products_unified(),
         "process_nodes": load_process_nodes(),
         "cooling_solutions": load_cooling_solutions(),
     }
@@ -62,7 +61,7 @@ def test_roundtrip_die_within_rounding(sku_id, catalogs):
     """Generator-derived die.transistors_billion and die.die_size_mm2
     must match the YAML's hand-authored values within rounding."""
     original = catalogs["kpus"][sku_id]
-    spec = input_spec_from_kpu_entry(original)
+    spec = input_spec_from_compute_product(original)
     regen = generate_kpu_sku(
         spec,
         process_nodes=catalogs["process_nodes"],
@@ -75,16 +74,16 @@ def test_roundtrip_die_within_rounding(sku_id, catalogs):
     # broken catalog entry, not a generator issue -- fail loudly with
     # a clear message rather than ZeroDivisionError if a future SKU
     # YAML is misauthored.
-    assert original.die.transistors_billion > 0, (
+    assert original.dies[0].transistors_billion > 0, (
         f"{sku_id}: catalog entry has die.transistors_billion <= 0"
     )
-    assert original.die.die_size_mm2 > 0, (
+    assert original.dies[0].die_size_mm2 > 0, (
         f"{sku_id}: catalog entry has die.die_size_mm2 <= 0"
     )
-    assert abs(regen.die.transistors_billion - original.die.transistors_billion) \
-        / original.die.transistors_billion <= 0.02
-    assert abs(regen.die.die_size_mm2 - original.die.die_size_mm2) \
-        / original.die.die_size_mm2 <= 0.02
+    assert abs(regen.dies[0].transistors_billion - original.dies[0].transistors_billion) \
+        / original.dies[0].transistors_billion <= 0.02
+    assert abs(regen.dies[0].die_size_mm2 - original.dies[0].die_size_mm2) \
+        / original.dies[0].die_size_mm2 <= 0.02
 
 
 @pytest.mark.parametrize("sku_id", [
@@ -96,7 +95,7 @@ def test_roundtrip_die_within_rounding(sku_id, catalogs):
 def test_roundtrip_performance_within_rounding(sku_id, catalogs):
     """int8_tops, bf16_tflops, fp32_tflops should round-trip within 1%."""
     original = catalogs["kpus"][sku_id]
-    spec = input_spec_from_kpu_entry(original)
+    spec = input_spec_from_compute_product(original)
     regen = generate_kpu_sku(
         spec,
         process_nodes=catalogs["process_nodes"],
@@ -124,7 +123,7 @@ def test_roundtrip_power_default_tdp_is_derived(sku_id, catalogs):
     0.5W -- the architect tunes (clock, Vdd) per profile so derivation
     lands at the target TDP."""
     original = catalogs["kpus"][sku_id]
-    spec = input_spec_from_kpu_entry(original)
+    spec = input_spec_from_compute_product(original)
     regen = generate_kpu_sku(
         spec,
         process_nodes=catalogs["process_nodes"],
@@ -155,18 +154,16 @@ def test_generated_sku_validates_clean(sku_id, catalogs):
     through the validator framework. WARNINGs are expected (DVFS
     throttle messages)."""
     original = catalogs["kpus"][sku_id]
-    spec = input_spec_from_kpu_entry(original)
+    spec = input_spec_from_compute_product(original)
     regen = generate_kpu_sku(
         spec,
         process_nodes=catalogs["process_nodes"],
     )
-    # generate_kpu_sku still returns a KPUEntry (its own migration is a
-    # later PR). The validator framework now takes ComputeProduct, so
-    # forward-adapt before constructing the context.
-    regen_cp = kpu_entry_to_compute_product(regen)
+    # generate_kpu_sku now returns a ComputeProduct directly; pass to the
+    # ValidatorContext without an adapter.
     ctx = ValidatorContext(
-        sku=regen_cp,
-        process_node=catalogs["process_nodes"][regen.process_node_id],
+        sku=regen,
+        process_node=catalogs["process_nodes"][regen.dies[0].process_node_id],
         cooling_solutions=catalogs["cooling_solutions"],
     )
     findings = default_registry.run_all(ctx)
@@ -184,7 +181,7 @@ def test_generated_sku_validates_clean(sku_id, catalogs):
 def test_unknown_process_node_raises(catalogs):
     """A spec referencing a non-existent process_node_id raises GeneratorError."""
     original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(original).model_copy(
+    spec = input_spec_from_compute_product(original).model_copy(
         update={"process_node_id": "no_such_node"}
     )
     with pytest.raises(GeneratorError, match="does not resolve"):
@@ -197,7 +194,7 @@ def test_unknown_process_node_raises(catalogs):
 def test_bad_default_profile_name_raises(catalogs):
     """default_thermal_profile must name an existing profile."""
     original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(original).model_copy(
+    spec = input_spec_from_compute_product(original).model_copy(
         update={"default_thermal_profile": "9000W"}
     )
     with pytest.raises(GeneratorError, match="not in thermal_profiles"):
@@ -210,7 +207,7 @@ def test_bad_default_profile_name_raises(catalogs):
 def test_empty_silicon_bin_raises(catalogs):
     """A spec with an empty silicon_bin (no resolvable blocks) raises."""
     original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(original).model_copy(
+    spec = input_spec_from_compute_product(original).model_copy(
         update={"silicon_bin": KPUSiliconBin(blocks=[])}
     )
     with pytest.raises(GeneratorError, match="silicon_bin"):
@@ -221,17 +218,31 @@ def test_empty_silicon_bin_raises(catalogs):
 
 
 # ---------------------------------------------------------------------------
-# input_spec_from_kpu_entry preserves architect-authored fields
+# input_spec_from_compute_product preserves architect-authored fields
 # ---------------------------------------------------------------------------
 
 def test_input_spec_preserves_architecture(catalogs):
     original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(original)
-    assert spec.kpu_architecture == original.kpu_architecture
-    assert spec.silicon_bin == original.silicon_bin
+    spec = input_spec_from_compute_product(original)
+    die = original.dies[0]
+    block = die.blocks[0]
+    # KPUArchitecture (legacy spec field) is structurally identical to
+    # KPUBlock (new schema): same total_tiles, multi_precision_alu,
+    # tiles, noc, memory.
+    assert spec.kpu_architecture.total_tiles == block.total_tiles
+    assert spec.kpu_architecture.tiles == block.tiles
+    assert spec.kpu_architecture.noc == block.noc
+    assert spec.kpu_architecture.memory == block.memory
+    assert spec.silicon_bin == die.silicon_bin
     assert spec.thermal_profiles == original.power.thermal_profiles
-    assert spec.market == original.market
-    assert spec.clocks == original.clocks
+    # KPUMarket has is_discontinued; ComputeProduct.market is the new
+    # Market (no is_discontinued -- it lives in cp.lifecycle). Compare
+    # the fields that DO overlap.
+    assert spec.market.target_market == original.market.target_market
+    assert spec.market.product_family == original.market.product_family
+    assert spec.market.model_tier == original.market.model_tier
+    assert spec.market.is_available == original.market.is_available
+    assert spec.clocks == die.clocks
 
 
 def test_input_spec_does_not_carry_die_or_perf_rollups(catalogs):
@@ -239,7 +250,7 @@ def test_input_spec_does_not_carry_die_or_perf_rollups(catalogs):
     field is in KPUEntry but not in KPUSKUInputSpec, the spec is
     correctly minimal."""
     original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(original)
+    spec = input_spec_from_compute_product(original)
     spec_fields = set(type(spec).model_fields)
     assert "die" not in spec_fields
     assert "performance" not in spec_fields
@@ -253,21 +264,21 @@ def test_input_spec_does_not_carry_die_or_perf_rollups(catalogs):
 def test_pe_array_override_is_no_op_when_dims_unchanged(catalogs):
     """Override to the spec's existing PE-array dims must round-trip."""
     original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(original)
+    spec = input_spec_from_compute_product(original)
     rows = spec.kpu_architecture.tiles[0].pe_array_rows
     cols = spec.kpu_architecture.tiles[0].pe_array_cols
     overridden = apply_pe_array_override(spec, rows, cols)
     g_orig = generate_kpu_sku(spec, process_nodes=catalogs["process_nodes"])
     g_over = generate_kpu_sku(overridden, process_nodes=catalogs["process_nodes"])
-    assert g_orig.die.die_size_mm2 == g_over.die.die_size_mm2
-    assert g_orig.die.transistors_billion == g_over.die.transistors_billion
+    assert g_orig.dies[0].die_size_mm2 == g_over.dies[0].die_size_mm2
+    assert g_orig.dies[0].transistors_billion == g_over.dies[0].transistors_billion
     assert g_orig.performance == g_over.performance
 
 
 def test_pe_array_override_preserves_ops_per_pe_ratio(catalogs):
     """Scaling PE-array size must keep ops/PE/clock constant."""
     original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(original)
+    spec = input_spec_from_compute_product(original)
     overridden = apply_pe_array_override(spec, 16, 16)
     for orig_t, new_t in zip(spec.kpu_architecture.tiles, overridden.kpu_architecture.tiles):
         old_pes = orig_t.pe_array_rows * orig_t.pe_array_cols
@@ -281,18 +292,18 @@ def test_pe_array_override_scales_die_area(catalogs):
     """Halving PE-array dims should reduce die area but not below the
     fixed (IO/control/memory_phys) floor."""
     original = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(original)
+    spec = input_spec_from_compute_product(original)
     g_full = generate_kpu_sku(spec, process_nodes=catalogs["process_nodes"])
     g_half = generate_kpu_sku(
         apply_pe_array_override(spec, 16, 16),
         process_nodes=catalogs["process_nodes"],
     )
-    assert g_half.die.die_size_mm2 < g_full.die.die_size_mm2
+    assert g_half.dies[0].die_size_mm2 < g_full.dies[0].die_size_mm2
     assert g_half.performance.int8_tops < g_full.performance.int8_tops
 
 
 def test_pe_array_override_rejects_non_positive_dims(catalogs):
-    spec = input_spec_from_kpu_entry(catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"])
+    spec = input_spec_from_compute_product(catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"])
     with pytest.raises(ValueError):
         apply_pe_array_override(spec, 0, 32)
     with pytest.raises(ValueError):
@@ -310,8 +321,8 @@ def test_tdp_scales_quadratically_with_vdd(catalogs):
     """Dropping Vdd by sqrt(2) should halve the dynamic power; total
     TDP drops by half the dynamic share."""
     sku = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(sku)
-    node = catalogs["process_nodes"][sku.process_node_id]
+    spec = input_spec_from_compute_product(sku)
+    node = catalogs["process_nodes"][sku.dies[0].process_node_id]
     # Take the default profile and run with two Vdds: nominal and nominal/sqrt(2).
     base = sku.power.thermal_profiles[1]  # 30W profile
     high_v = base.model_copy(update={"vdd_v": 0.80})  # ~ Vnom
@@ -326,8 +337,8 @@ def test_tdp_scales_quadratically_with_vdd(catalogs):
 def test_tdp_scales_linearly_with_clock(catalogs):
     """At fixed Vdd, doubling clock doubles dynamic power."""
     sku = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(sku)
-    node = catalogs["process_nodes"][sku.process_node_id]
+    spec = input_spec_from_compute_product(sku)
+    node = catalogs["process_nodes"][sku.dies[0].process_node_id]
     base = sku.power.thermal_profiles[1]
     p_low = base.model_copy(update={"clock_mhz": 500.0, "vdd_v": 0.80})
     p_high = base.model_copy(update={"clock_mhz": 1000.0, "vdd_v": 0.80})
@@ -340,8 +351,8 @@ def test_activity_factor_scales_dynamic(catalogs):
     """Per-profile activity_factor=0.5 should halve dynamic power
     (it's a multiplier on the workload duty cycle)."""
     sku = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(sku)
-    node = catalogs["process_nodes"][sku.process_node_id]
+    spec = input_spec_from_compute_product(sku)
+    node = catalogs["process_nodes"][sku.dies[0].process_node_id]
     base = sku.power.thermal_profiles[1]
     full = base.model_copy(update={"activity_factor": 1.0})
     half = base.model_copy(update={"activity_factor": 0.5})
@@ -356,8 +367,8 @@ def test_pe_array_sweep_tdp_monotonic(catalogs):
     strictly increase with PE count -- the whole point of programmable
     PE arrays for roadmap generation."""
     sku = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    spec = input_spec_from_kpu_entry(sku)
-    node = catalogs["process_nodes"][sku.process_node_id]
+    spec = input_spec_from_compute_product(sku)
+    node = catalogs["process_nodes"][sku.dies[0].process_node_id]
     base = sku.power.thermal_profiles[1]
     sweep = [(16, 16), (24, 24), (32, 32), (40, 40)]
     tdps = []


### PR DESCRIPTION
## Why

Step 6 of the consumer migration. The generator now produces \`ComputeProduct\` directly rather than \`KPUEntry\`, eliminating the **last forward-adapt bridge** introduced in PR #162.

## API changes

\`\`\`diff
- generate_kpu_sku(spec, ...) -> KPUEntry
+ generate_kpu_sku(spec, ...) -> ComputeProduct

- input_spec_from_kpu_entry(entry: KPUEntry) -> KPUSKUInputSpec
+ input_spec_from_compute_product(cp: ComputeProduct) -> KPUSKUInputSpec
\`\`\`

The \`KPUSKUInputSpec\` input shape is **unchanged** — architects continue to author the same fields. The generator still uses \`KPUSKUInputSpec\` internally (\`kpu_architecture\` / \`KPUMarket\` / \`KPUSiliconBin\` etc.) and translates to ComputeProduct on output:

| Input spec field | ComputeProduct destination |
|---|---|
| \`spec.kpu_architecture\` (\`KPUArchitecture\`) | \`cp.dies[0].blocks[0]\` (\`KPUBlock\` — identical fields) |
| \`spec.silicon_bin\` | \`cp.dies[0].silicon_bin\` |
| \`spec.clocks\` | \`cp.dies[0].clocks\` |
| \`spec.thermal_profiles\` | \`cp.power.thermal_profiles\` (with derived TDPs) |
| \`spec.market\` (\`KPUMarket\`) | \`cp.market\` (\`Market\`) + \`cp.lifecycle\` (\`is_discontinued\` → \`EOL\` else \`PRODUCTION\`) |
| (always) | \`cp.packaging\`: monolithic, num_dies=1 (v1 KPUs are single-die) |

## Bridge cleanup

- Drops the \`kpu_entry_to_compute_product\` import + use in the placeholder construction site
- The internal \`_placeholder_for_resolution\` helper now builds a \`ComputeProduct\` directly (replaces the old \`placeholder_sku\` + \`kpu_entry_to_compute_product\` two-step from PR #162's bridge)

**This is the last forward-adapt bridge from PR #162.** All bridges retired now.

## CLI (\`cli/generate_kpu_sku.py\`)

- \`load_kpus\` → \`load_compute_products_unified\`
- \`input_spec_from_kpu_entry\` → \`input_spec_from_compute_product\`
- ValidatorContext: \`regen.process_node_id\` → \`regen.dies[0].process_node_id\`
- YAML output is now ComputeProduct schema (intentional schema change; nothing downstream parses it programmatically)

## Tests

- \`catalogs["kpus"]\` fixture now returns \`ComputeProduct\` instances
- All field accesses on \`original\` / \`regen\` / \`sku\` updated to \`.dies[0].*\` / \`.dies[0].blocks[0].*\` paths
- \`test_input_spec_preserves_architecture\` compares the spec's \`KPUArchitecture\` content against the ComputeProduct's \`KPUBlock\` field-by-field (the two have identical shape but different types)
- \`test_generated_sku_validates_clean\` drops the now-unnecessary \`kpu_entry_to_compute_product\` wrapper — \`generate_kpu_sku\` returns ComputeProduct directly, ready for \`ValidatorContext\`

## Verification

- ✅ 29/29 \`kpu_sku_generator\` tests pass
- ✅ 692/692 hardware tests pass
- ✅ 2,696/2,696 unit tests pass under \`pytest -n 4\` (1:17 wall clock locally)
- ✅ \`cli/generate_kpu_sku.py --from-sku ... --validate\` end-to-end smoke-tested: 0 ERROR findings, 7 WARNINGs (DVFS throttle messages, expected)

## Migration sequence (this PR is step 6 of ~8)

- [x] PR #160 — \`show_kpu.py\` + \`show_compute_product.py\`
- [x] PR #161 — \`list_kpus.py\`
- [x] PR #162 — \`sku_validators/*\` (10 files)
- [x] PR #164 — \`silicon_floorplan.py\` + \`show_floorplan.py\`
- [x] PR #165 — \`kpu_power_model.py\`
- [x] **\`kpu_sku_generator\` + \`kpu_sku_input\` + \`cli/generate_kpu_sku\`** — this PR
- [ ] \`cli/validate_sku.py\` (now trivial)
- [ ] \`models/accelerators/kpu_yaml_loader.py\` (mapper backbone)
- [ ] cleanup PR — delete \`data/kpus/\`, reduce \`load_kpus()\` to a shim, delete \`compute_product_to_kpu_entry\`

After this PR, **all forward-adapt bridges from PR #162 are retired**. The reverse adapter \`compute_product_to_kpu_entry\` remains for any straggler that hasn't migrated yet (none in \`src/\` after this PR; external consumers may still want it). It's deleted in the cleanup PR.

## Test plan

- [x] Generator tests green
- [x] Hardware test suite green
- [x] Full suite green
- [x] CLI smoke (\`--from-sku --validate\`)
- [ ] PR CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Unified product specification system for more consistent SKU and product data generation
  * Enhanced lifecycle and process node tracking for more accurate product definitions
  * Improved data structure consistency across generation and validation pipelines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/166)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->