### PR TITLE
refactor(cli): migrate validate_sku to load_compute_products_unified

### DIFF
--- a/cli/validate_sku.py
+++ b/cli/validate_sku.py
@@ -170,9 +170,9 @@ def _run_catalog_sweep(args: argparse.Namespace, validator_count: int) -> int:
     a per-SKU table to stdout. Returns non-zero on any ERROR finding
     (or any WARNING if ``--strict``).
     """
-    from embodied_schemas import load_kpus
+    from graphs.hardware.compute_product_loader import load_compute_products_unified
     try:
-        kpus = load_kpus()
+        kpus = load_compute_products_unified()
     except Exception as exc:
         print(f"error: failed to load KPU catalog: {exc}", file=sys.stderr)
         return 2


### PR DESCRIPTION
## Why

Step 7 of the consumer migration. Single-line loader swap.

The CLI's single-SKU mode (\`validate_sku.py <id>\`) already went through \`build_context_for_kpu\` (migrated in PR #162) so the validators got ComputeProduct via that path. Only the \`--all\` catalog-sweep path was still calling \`load_kpus()\` directly to enumerate SKU ids — that's what this PR fixes.

## Diff

\`\`\`diff
- from embodied_schemas import load_kpus
+ from graphs.hardware.compute_product_loader import load_compute_products_unified
  try:
-     kpus = load_kpus()
+     kpus = load_compute_products_unified()
\`\`\`

The downstream loop just does \`for sku_id in sorted(kpus): build_context_for_kpu(sku_id)\` — \`build_context_for_kpu\` already takes the SKU id and looks up the ComputeProduct from the unified loader internally, so no other changes needed.

## Verification

- ✅ Single-SKU mode (\`validate_sku.py kpu_t256_...\`) works
- ✅ Catalog sweep (\`validate_sku.py --all\`) reports all 12 SKUs as "ok", 0 errors, 96 warnings (DVFS-throttle/whitespace WARNs — expected, same as before)
- ✅ 692/692 hardware tests pass

## Migration sequence (this PR is step 7 of ~8)

- [x] PR #160 — \`show_kpu.py\` + \`show_compute_product.py\`
- [x] PR #161 — \`list_kpus.py\`
- [x] PR #162 — \`sku_validators/*\` (10 files)
- [x] PR #164 — \`silicon_floorplan.py\` + \`show_floorplan.py\`
- [x] PR #165 — \`kpu_power_model.py\`
- [x] PR #166 — \`kpu_sku_generator\` + \`cli/generate_kpu_sku\`
- [x] **\`cli/validate_sku.py\`** — this PR
- [ ] \`models/accelerators/kpu_yaml_loader.py\` (mapper backbone)
- [ ] cleanup PR — delete \`data/kpus/\`, reduce \`load_kpus()\` to a shim, delete \`compute_product_to_kpu_entry\`

## Test plan

- [x] CLI smoke (single + sweep)
- [x] Hardware test suite green
- [x] PR CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)