### PR TITLE
refactor(hardware): migrate kpu_yaml_loader (the mapper backbone) to ComputeProduct

### DIFF
--- a/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
+++ b/src/graphs/hardware/models/accelerators/kpu_yaml_loader.py
@@ -46,14 +46,15 @@ from __future__ import annotations
 from typing import Optional
 
 from embodied_schemas import (
-    KPUEntry,
+    ComputeProduct,
     KPUTileScheduleClass as YamlScheduleClass,
-    load_kpus,
     load_process_nodes,
 )
+from embodied_schemas.compute_product import KPUBlock
 from embodied_schemas.process_node import CircuitClass, ProcessNodeEntry
 
 from ...architectural_energy import KPUTileEnergyModel
+from ...compute_product_loader import load_compute_products_unified
 from ...fabric_model import SoCFabricModel, Topology
 from ...resource_model import (
     ClockDomain,
@@ -69,6 +70,14 @@ from ...resource_model import (
     TileSpecialization,
     get_base_alu_energy,
 )
+
+
+def _kpu_block(cp: ComputeProduct) -> KPUBlock:
+    """Return the KPUBlock from a v1 monolithic-KPU ``ComputeProduct``.
+
+    Mirrors the helper in ``sku_validators.silicon_math``: chiplet KPU
+    products will need iteration when they land."""
+    return cp.dies[0].blocks[0]
 
 
 class KPUYamlLoaderError(Exception):
@@ -264,7 +273,7 @@ def _fabric_energy_scaling(
 # ---------------------------------------------------------------------------
 
 def _build_tile_energy_model(
-    sku: KPUEntry, node: ProcessNodeEntry, *, default_clock_hz: float
+    cp: ComputeProduct, node: ProcessNodeEntry, *, default_clock_hz: float
 ) -> KPUTileEnergyModel:
     """Construct a KPUTileEnergyModel from the YAML SKU + process node.
 
@@ -272,7 +281,7 @@ def _build_tile_energy_model(
 
     * Architectural shape (num_tiles, mesh, L1/L2/L3 sizes,
       DRAM bandwidth, clock) -- direct read from
-      ``sku.kpu_architecture``.
+      ``_kpu_block(cp)``.
     * ``pes_per_tile`` -- the dominant tile class's PE count
       (``num_tiles`` x array). The energy model uses this for routing,
       L1 sizing, and per-tile compute energy; the dominant class's
@@ -287,7 +296,7 @@ def _build_tile_energy_model(
       placeholders matching the existing factory values; PR (later)
       will swap for a per-process-node SRAM table when PDK data lands.
     """
-    arch = sku.kpu_architecture
+    arch = _kpu_block(cp)
     mem = arch.memory
 
     # Dominant tile class -- the one with the highest num_tiles. In all
@@ -352,7 +361,7 @@ def _build_tile_energy_model(
 
 
 def _build_soc_fabric(
-    sku: KPUEntry, node: ProcessNodeEntry
+    cp: ComputeProduct, node: ProcessNodeEntry
 ) -> SoCFabricModel:
     """Construct a SoCFabricModel from the YAML SKU's NoC declaration.
 
@@ -371,7 +380,7 @@ def _build_soc_fabric(
       analyzer treats them as approximations and is robust to
       modest differences.
     """
-    arch = sku.kpu_architecture
+    arch = _kpu_block(cp)
     noc = arch.noc
 
     topology_key = noc.topology.lower()
@@ -395,8 +404,8 @@ def _build_soc_fabric(
         routing_distance_factor=1.2,  # typical XY routing with detours
         low_confidence=low_confidence,
         provenance=(
-            f"{sku.name} NoC from "
-            f"embodied-schemas:kpus/{sku.vendor}/{sku.id}.yaml "
+            f"{cp.name} NoC from "
+            f"embodied-schemas:kpus/{cp.vendor}/{cp.id}.yaml "
             f"(kpu_architecture.noc); on-chip SRAM + per-hop energy "
             f"are node-agnostic v1 placeholders"
         ),
@@ -406,7 +415,7 @@ def _build_soc_fabric(
 def load_kpu_resource_model_from_yaml(
     base_id: str,
     *,
-    kpus: Optional[dict[str, KPUEntry]] = None,
+    kpus: Optional[dict[str, ComputeProduct]] = None,
     process_nodes: Optional[dict[str, ProcessNodeEntry]] = None,
 ) -> HardwareResourceModel:
     """Build a ``HardwareResourceModel`` for ``base_id`` from the YAML catalog.
@@ -422,45 +431,45 @@ def load_kpu_resource_model_from_yaml(
             ``process_node_id`` doesn't resolve.
     """
     if kpus is None:
-        kpus = load_kpus()
+        kpus = load_compute_products_unified()
     if process_nodes is None:
         process_nodes = load_process_nodes()
 
-    sku = kpus.get(base_id)
-    if sku is None:
+    cp = kpus.get(base_id)
+    if cp is None:
         raise KPUYamlLoaderError(
             f"no KPU SKU with id={base_id!r}. Available: "
             f"{', '.join(sorted(kpus))}"
         )
-    node = process_nodes.get(sku.process_node_id)
+    node = process_nodes.get(cp.dies[0].process_node_id)
     if node is None:
         raise KPUYamlLoaderError(
             f"SKU {base_id!r} references process_node_id="
-            f"{sku.process_node_id!r} which does not resolve"
+            f"{cp.dies[0].process_node_id!r} which does not resolve"
         )
 
     # Default profile gives the sustained clock used for fabric core_frequency_hz
     # and for ClockDomain.sustained_clock_hz.
     default_profile = next(
-        (p for p in sku.power.thermal_profiles
-         if p.name == sku.power.default_thermal_profile),
+        (p for p in cp.power.thermal_profiles
+         if p.name == cp.power.default_thermal_profile),
         None,
     )
     if default_profile is None:
         raise KPUYamlLoaderError(
             f"SKU {base_id!r}: default_thermal_profile "
-            f"{sku.power.default_thermal_profile!r} is not in "
+            f"{cp.power.default_thermal_profile!r} is not in "
             f"thermal_profiles"
         )
     default_clock_hz = default_profile.clock_mhz * 1e6
-    boost_clock_hz = sku.clocks.boost_clock_mhz * 1e6
-    base_clock_hz = sku.clocks.base_clock_mhz * 1e6
+    boost_clock_hz = cp.dies[0].clocks.boost_clock_mhz * 1e6
+    base_clock_hz = cp.dies[0].clocks.base_clock_mhz * 1e6
 
     # ------------------------------------------------------------------
     # Build ComputeFabric per tile class (peak throughput vehicle)
     # ------------------------------------------------------------------
     compute_fabrics: list[ComputeFabric] = []
-    for tile in sku.kpu_architecture.tiles:
+    for tile in _kpu_block(cp).tiles:
         ops_dict = _precision_dict_from_yaml(tile.ops_per_tile_per_clock)
         if not ops_dict:
             continue
@@ -499,7 +508,7 @@ def load_kpu_resource_model_from_yaml(
         dvfs_enabled=True,
     )
     tile_specializations: list[TileSpecialization] = []
-    for tile in sku.kpu_architecture.tiles:
+    for tile in _kpu_block(cp).tiles:
         ops_dict = _precision_dict_from_yaml(tile.ops_per_tile_per_clock)
         if not ops_dict:
             continue
@@ -531,13 +540,13 @@ def load_kpu_resource_model_from_yaml(
     # ------------------------------------------------------------------
     # Determine which precisions any tile claims to support.
     supported_precisions: set[Precision] = set()
-    for tile in sku.kpu_architecture.tiles:
+    for tile in _kpu_block(cp).tiles:
         supported_precisions.update(
             _precision_dict_from_yaml(tile.ops_per_tile_per_clock).keys()
         )
 
     thermal_operating_points: dict[str, ThermalOperatingPoint] = {}
-    for profile in sku.power.thermal_profiles:
+    for profile in cp.power.thermal_profiles:
         # Per-profile clock domain so calc_peak / calc_sustained reflect
         # the profile's actual frequency.
         profile_clock_domain = ClockDomain(
@@ -565,7 +574,7 @@ def load_kpu_resource_model_from_yaml(
                 )
             )
         profile_compute = KPUComputeResource(
-            total_tiles=sku.kpu_architecture.total_tiles,
+            total_tiles=_kpu_block(cp).total_tiles,
             tile_specializations=profile_specializations,
         )
 
@@ -631,7 +640,7 @@ def load_kpu_resource_model_from_yaml(
     # ------------------------------------------------------------------
     # Memory + cache fields
     # ------------------------------------------------------------------
-    mem = sku.kpu_architecture.memory
+    mem = _kpu_block(cp).memory
     peak_bandwidth_bps = mem.memory_bandwidth_gbps * 1e9
     main_memory_bytes = int(mem.memory_size_gb * 1024**3)
     l3_per_tile_bytes = mem.l3_kib_per_tile * 1024
@@ -662,7 +671,7 @@ def load_kpu_resource_model_from_yaml(
     # by mappers that compute parallelism budgets.
     threads_per_unit = max(
         (t.pe_array_rows * t.pe_array_cols
-         for t in sku.kpu_architecture.tiles),
+         for t in _kpu_block(cp).tiles),
         default=1,
     )
 
@@ -687,17 +696,17 @@ def load_kpu_resource_model_from_yaml(
     # KPUTileEnergyModel + SoCFabricModel (Phase 4b PR 2)
     # ------------------------------------------------------------------
     tile_energy_model = _build_tile_energy_model(
-        sku, node, default_clock_hz=default_clock_hz
+        cp, node, default_clock_hz=default_clock_hz
     )
-    soc_fabric = _build_soc_fabric(sku, node)
+    soc_fabric = _build_soc_fabric(cp, node)
 
     # ------------------------------------------------------------------
     # Construct the model
     # ------------------------------------------------------------------
     model = HardwareResourceModel(
-        name=sku.name,
+        name=cp.name,
         hardware_type=HardwareType.KPU,
-        compute_units=sku.kpu_architecture.total_tiles,
+        compute_units=_kpu_block(cp).total_tiles,
         threads_per_unit=threads_per_unit,
         warps_per_unit=0,
         peak_bandwidth=peak_bandwidth_bps,
@@ -711,7 +720,7 @@ def load_kpu_resource_model_from_yaml(
         precision_profiles=precision_profiles,
         default_precision=Precision.INT8,
         thermal_operating_points=thermal_operating_points,
-        default_thermal_profile=sku.power.default_thermal_profile,
+        default_thermal_profile=cp.power.default_thermal_profile,
         min_occupancy=0.3,
         max_concurrent_kernels=4,
         wave_quantization=2,
@@ -734,7 +743,7 @@ def load_kpu_resource_model_from_yaml(
     model.l2_topology = "per-unit"
     model.l3_present = True
     model.l3_cache_total = (
-        mem.l3_kib_per_tile * 1024 * sku.kpu_architecture.total_tiles
+        mem.l3_kib_per_tile * 1024 * _kpu_block(cp).total_tiles
     )
     model.coherence_protocol = "none"
 
@@ -753,13 +762,13 @@ def load_kpu_resource_model_from_yaml(
     # tie back to the YAML file path and the M0.5 KPU dataflow-tile
     # abstraction that drives these conventions.
     yaml_source = (
-        f"embodied-schemas:kpus/{sku.vendor}/{sku.id}.yaml"
+        f"embodied-schemas:kpus/{cp.vendor}/{cp.id}.yaml"
     )
     from graphs.core.confidence import EstimationConfidence
     _PROVENANCE = EstimationConfidence.theoretical(
         score=0.85,
         source=(
-            f"{sku.name} M0.5 dataflow-tile abstraction; derived from {yaml_source}"
+            f"{cp.name} M0.5 dataflow-tile abstraction; derived from {yaml_source}"
         ),
     )
     for key in (

--- a/tests/hardware/test_kpu_yaml_loader.py
+++ b/tests/hardware/test_kpu_yaml_loader.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import pytest
 
-from embodied_schemas import load_kpus, load_process_nodes
+from embodied_schemas import load_process_nodes
+
+from graphs.hardware.compute_product_loader import load_compute_products_unified
 
 from graphs.hardware.mappers.accelerators.kpu import KPUMapper
 from graphs.hardware.models.accelerators.kpu_yaml_loader import (
@@ -33,7 +35,7 @@ from graphs.hardware.resource_model import (
 @pytest.fixture(scope="module")
 def catalogs():
     return {
-        "kpus": load_kpus(),
+        "kpus": load_compute_products_unified(),
         "process_nodes": load_process_nodes(),
     }
 
@@ -60,14 +62,14 @@ def test_loader_returns_kpu_hardware_type(sku_id, catalogs):
 def test_loader_compute_units_matches_total_tiles(sku_id, catalogs):
     m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
     sku = catalogs["kpus"][sku_id]
-    assert m.compute_units == sku.kpu_architecture.total_tiles
+    assert m.compute_units == sku.dies[0].blocks[0].total_tiles
 
 
 @pytest.mark.parametrize("sku_id", SKU_IDS)
 def test_loader_one_fabric_per_tile_class(sku_id, catalogs):
     m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
     sku = catalogs["kpus"][sku_id]
-    assert len(m.compute_fabrics) == len(sku.kpu_architecture.tiles)
+    assert len(m.compute_fabrics) == len(sku.dies[0].blocks[0].tiles)
 
 
 @pytest.mark.parametrize("sku_id", SKU_IDS)
@@ -125,7 +127,7 @@ def test_loader_bf16_peak_matches_yaml(sku_id, catalogs):
 def test_loader_memory_bandwidth_matches_yaml(sku_id, catalogs):
     m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
     sku = catalogs["kpus"][sku_id]
-    expected = sku.kpu_architecture.memory.memory_bandwidth_gbps * 1e9
+    expected = sku.dies[0].blocks[0].memory.memory_bandwidth_gbps * 1e9
     assert m.peak_bandwidth == expected
 
 
@@ -133,7 +135,7 @@ def test_loader_memory_bandwidth_matches_yaml(sku_id, catalogs):
 def test_loader_main_memory_matches_yaml(sku_id, catalogs):
     m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
     sku = catalogs["kpus"][sku_id]
-    expected = int(sku.kpu_architecture.memory.memory_size_gb * 1024**3)
+    expected = int(sku.dies[0].blocks[0].memory.memory_size_gb * 1024**3)
     assert m.main_memory == expected
 
 
@@ -143,7 +145,7 @@ def test_loader_l1_per_tile_is_l3_kib_per_tile(sku_id, catalogs):
     to YAML's per-tile L3 scratchpad."""
     m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
     sku = catalogs["kpus"][sku_id]
-    expected = sku.kpu_architecture.memory.l3_kib_per_tile * 1024
+    expected = sku.dies[0].blocks[0].memory.l3_kib_per_tile * 1024
     assert m.l1_cache_per_unit == expected
 
 
@@ -176,7 +178,10 @@ def test_loader_unknown_base_id_raises(catalogs):
 def test_loader_unresolved_process_node_raises(catalogs):
     """Hand-craft a SKU pointing at a non-existent process node."""
     real = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    bad_sku = real.model_copy(update={"process_node_id": "nonexistent"})
+    # process_node_id lives on the die in the unified schema; mutate it
+    # there to test the loader's resolution error path.
+    bad_die = real.dies[0].model_copy(update={"process_node_id": "nonexistent"})
+    bad_sku = real.model_copy(update={"dies": [bad_die]})
     with pytest.raises(KPUYamlLoaderError, match="does not resolve"):
         load_kpu_resource_model_from_yaml(
             bad_sku.id,
@@ -203,7 +208,7 @@ def test_tile_energy_model_architectural_shape_matches_yaml(sku_id, catalogs):
     clock are all direct reads from the SKU YAML."""
     m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
     sku = catalogs["kpus"][sku_id]
-    arch = sku.kpu_architecture
+    arch = sku.dies[0].blocks[0]
     tem = m.tile_energy_model
     assert tem.num_tiles == arch.total_tiles
     assert tem.tile_mesh_dimensions == (arch.noc.mesh_rows, arch.noc.mesh_cols)
@@ -226,7 +231,7 @@ def test_tile_energy_model_pes_per_tile_uses_dominant_class(sku_id, catalogs):
     INT8-primary class."""
     m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
     sku = catalogs["kpus"][sku_id]
-    dominant = max(sku.kpu_architecture.tiles, key=lambda t: t.num_tiles)
+    dominant = max(sku.dies[0].blocks[0].tiles, key=lambda t: t.num_tiles)
     expected = dominant.pe_array_rows * dominant.pe_array_cols
     assert m.tile_energy_model.pes_per_tile == expected
 
@@ -290,14 +295,14 @@ def test_soc_fabric_topology_and_dimensions_match_yaml(sku_id, catalogs):
     from graphs.hardware.fabric_model import Topology
     m = load_kpu_resource_model_from_yaml(sku_id, **catalogs)
     sku = catalogs["kpus"][sku_id]
-    noc = sku.kpu_architecture.noc
+    noc = sku.dies[0].blocks[0].noc
     fab = m.soc_fabric
     # All 4 Stillwater SKUs use mesh_2d
     assert fab.topology == Topology.MESH_2D
     assert fab.low_confidence is False
     assert fab.mesh_dimensions == (noc.mesh_rows, noc.mesh_cols)
     assert fab.flit_size_bytes == noc.flit_bytes
-    assert fab.controller_count == sku.kpu_architecture.total_tiles
+    assert fab.controller_count == sku.dies[0].blocks[0].total_tiles
     if noc.bisection_bandwidth_gbps is not None:
         assert fab.bisection_bandwidth_gbps == noc.bisection_bandwidth_gbps
 
@@ -309,12 +314,15 @@ def test_soc_fabric_unknown_topology_marks_low_confidence(catalogs):
     is updated."""
     from graphs.hardware.fabric_model import Topology
     real = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    bad_arch = real.kpu_architecture.model_copy(
-        update={"noc": real.kpu_architecture.noc.model_copy(
+    # KPUBlock now lives at cp.dies[0].blocks[0]; mutate the noc through it.
+    block = real.dies[0].blocks[0]
+    bad_block = block.model_copy(
+        update={"noc": block.noc.model_copy(
             update={"topology": "future_topology_3d_torus"}
         )}
     )
-    bad_sku = real.model_copy(update={"kpu_architecture": bad_arch})
+    bad_die = real.dies[0].model_copy(update={"blocks": [bad_block]})
+    bad_sku = real.model_copy(update={"dies": [bad_die]})
     m = load_kpu_resource_model_from_yaml(
         bad_sku.id,
         kpus={bad_sku.id: bad_sku},
@@ -331,12 +339,14 @@ def test_soc_fabric_lossy_torus_mapping_marks_low_confidence(catalogs):
     formulas) see the approximation."""
     from graphs.hardware.fabric_model import Topology
     real = catalogs["kpus"]["kpu_t256_32x32_lp5x16_16nm_tsmc_ffp"]
-    arch = real.kpu_architecture.model_copy(
-        update={"noc": real.kpu_architecture.noc.model_copy(
+    block = real.dies[0].blocks[0]
+    bad_block = block.model_copy(
+        update={"noc": block.noc.model_copy(
             update={"topology": "torus_2d"}
         )}
     )
-    bad_sku = real.model_copy(update={"kpu_architecture": arch})
+    bad_die = real.dies[0].model_copy(update={"blocks": [bad_block]})
+    bad_sku = real.model_copy(update={"dies": [bad_die]})
     m = load_kpu_resource_model_from_yaml(
         bad_sku.id,
         kpus={bad_sku.id: bad_sku},
@@ -470,7 +480,7 @@ def test_tile_energy_model_mac_fallback_is_node_scaled(catalogs):
     m_n16 = load_kpu_resource_model_from_yaml(
         real.id,
         kpus={real.id: real},
-        process_nodes={real.process_node_id: sparse_n16},
+        process_nodes={real.dies[0].process_node_id: sparse_n16},
     )
 
     # Same SKU, but pretend it's on TSMC N5 (much smaller node).
@@ -485,7 +495,7 @@ def test_tile_energy_model_mac_fallback_is_node_scaled(catalogs):
     m_n5 = load_kpu_resource_model_from_yaml(
         real.id,
         kpus={real.id: real},
-        process_nodes={real.process_node_id: sparse_n5},
+        process_nodes={real.dies[0].process_node_id: sparse_n5},
     )
 
     # N5 is a smaller node than N16 -> fallback MAC energy must be lower.


### PR DESCRIPTION
## Why

Step 8 of the consumer migration — **the last \`src/\`-side migration** before the cleanup PR. The loader that turns a SKU YAML into a \`HardwareResourceModel\` (consumed by the four \`kpu_t{64,128,256,768}\` mapper factories) now reads \`ComputeProduct\` from the unified loader instead of \`KPUEntry\`.

After this PR, no \`src/\` consumer touches \`load_kpus()\` / \`KPUEntry\` directly except the \`compute_product_loader.py\` adapter itself.

## API changes

\`\`\`diff
  def load_kpu_resource_model_from_yaml(
      base_id: str,
      *,
-     kpus: Optional[dict[str, KPUEntry]] = None,
+     kpus: Optional[dict[str, ComputeProduct]] = None,
      process_nodes: ...,
  ) -> HardwareResourceModel:
\`\`\`

Defaults to \`load_compute_products_unified()\` when omitted. The four \`kpu_t*\` factory wrappers don't pass \`kpus\` — they continue to work unchanged.

Internal helper signatures: \`_build_tile_energy_model(cp, ...)\` and \`_build_soc_fabric(cp, ...)\` (was \`sku: KPUEntry\`).

## Field-access updates

| Legacy | Unified |
|---|---|
| \`sku.kpu_architecture\` | \`_kpu_block(cp)\` (new local helper) |
| \`sku.silicon_bin\` | \`cp.dies[0].silicon_bin\` |
| \`sku.process_node_id\` | \`cp.dies[0].process_node_id\` |
| \`sku.id\` / \`sku.name\` / \`sku.vendor\` | \`cp.id\` / \`cp.name\` / \`cp.vendor\` |
| \`sku.power.*\` | \`cp.power.*\` (location unchanged) |
| \`sku.clocks\` | \`cp.dies[0].clocks\` |

## Tests

- \`test_kpu_yaml_loader.py\` fixture switched to \`load_compute_products_unified\`
- All \`sku.X\` assertions updated to the new field paths
- \`test_loader_unresolved_process_node_raises\`: now mutates \`die.process_node_id\` via \`dies[0].model_copy + dies\` replacement (the field moved off the top-level)
- \`test_soc_fabric_unknown_topology\` / \`lossy_torus\` tests: now mutate the \`KPUBlock\`'s \`noc\` via \`dies[0].blocks[0]\` traversal
- \`test_tile_energy_model_mac_fallback_is_node_scaled\`: \`real.process_node_id\` → \`real.dies[0].process_node_id\` (2 sites)

## Verification

- ✅ 91/91 \`kpu_yaml_loader\` tests pass
- ✅ 692/692 hardware tests pass
- ✅ 2,696/2,696 unit tests pass under \`pytest -n 4\` (1:29 wall clock locally)
- ✅ Loader smoke: \`load_kpu_resource_model_from_yaml('kpu_t256_...')\` produces a \`HardwareResourceModel\` with expected \`compute_units=256\`, 3 fabrics, 3 thermal profiles, and the right precision set

## Migration sequence (this PR is step 8 of ~8)

- [x] PR #160 — \`show_kpu.py\` + \`show_compute_product.py\`
- [x] PR #161 — \`list_kpus.py\`
- [x] PR #162 — \`sku_validators/*\` (10 files)
- [x] PR #164 — \`silicon_floorplan.py\` + \`show_floorplan.py\`
- [x] PR #165 — \`kpu_power_model.py\`
- [x] PR #166 — \`kpu_sku_generator\` + \`cli/generate_kpu_sku\`
- [x] PR #167 — \`cli/validate_sku.py\`
- [x] **\`models/accelerators/kpu_yaml_loader.py\`** — this PR
- [ ] **cleanup PR** — delete \`data/kpus/\`, reduce \`load_kpus()\` to a shim, delete \`compute_product_to_kpu_entry\`

After this PR, NO \`src/\` consumer touches \`load_kpus()\` / \`KPUEntry\` directly except the \`compute_product_loader.py\` adapter itself. The cleanup PR deletes \`data/kpus/\`, makes \`load_kpus()\` a shim that adapts ComputeProduct back to KPUEntry (for any external user still on the old API), and removes \`compute_product_to_kpu_entry\` (no internal consumer).

## Test plan

- [x] kpu_yaml_loader tests green (91 tests)
- [x] Hardware suite green
- [x] Full suite green
- [x] Loader smoke
- [ ] PR CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)