### PR TITLE
ci: bump embodied-schemas pin to PR #18 merge SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,8 @@ jobs:
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
-          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
+          #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
+          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
           path: embodied-schemas
           fetch-depth: 1
 
@@ -157,7 +158,8 @@ jobs:
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
-          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
+          #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
+          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
           path: embodied-schemas
           fetch-depth: 1
 
@@ -256,7 +258,8 @@ jobs:
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
-          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
+          #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
+          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
           path: embodied-schemas
           fetch-depth: 1
 
@@ -352,7 +355,8 @@ jobs:
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
-          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
+          #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
+          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
           path: embodied-schemas
           fetch-depth: 1
 
@@ -421,7 +425,8 @@ jobs:
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
-          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
+          #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
+          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
           path: embodied-schemas
           fetch-depth: 1
 
@@ -478,7 +483,8 @@ jobs:
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
-          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
+          #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
+          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,7 +48,8 @@ jobs:
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
-          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
+          #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
+          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -97,7 +97,8 @@ jobs:
           #   PR #15 (60f210d) ComputeProduct v1 schema (KPU-only, additive)
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
-          ref: 845a9f2939fa8a49df16c203f1be72a54f838578
+          #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
+          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
           path: embodied-schemas
           fetch-depth: 1
 


### PR DESCRIPTION
## Why

Bumps the embodied-schemas CI pin from \`845a9f2\` (PR #17, last point with both catalogs present) to \`181d725\` (PR #18, \`data/kpus/\` retired + \`load_kpus()\` shim).

The graphs codebase is now fully on the ComputeProduct path:
- 8 \`src/\` consumer migrations merged (PRs #160-168)
- \`compute_product_loader.py\` simplified, dead adapters deleted (PR #169)
- No internal consumer touches \`load_kpus()\` at all in \`src/\`; all catalog data flows in via \`load_compute_products()\` / \`load_compute_products_unified()\`

This pin bump locks CI on the clean post-migration state of embodied-schemas.

## Diff

8 pin sites updated (6 in \`ci.yml\`, 1 in \`v4-validation.yml\`, 1 in \`coverage.yml\`):

\`\`\`diff
  #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
+ #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
- ref: 845a9f2939fa8a49df16c203f1be72a54f838578
+ ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
\`\`\`

## Verification

- ✅ All 8 pin sites updated; YAML parses cleanly across all 3 workflow files
- ✅ Local smoke against the new pin: 684/684 hardware tests pass
- ✅ The graphs codebase doesn't rely on \`data/kpus/\` being populated (only \`load_compute_products()\` data), so the shim's behavior change is transparent

## Migration sequence — done

| # | PR | Title | Status |
|---|---|---|---|
| 1 | graphs#160 | show_kpu + show_compute_product | merged |
| 2 | graphs#161 | list_kpus | merged |
| 3 | graphs#162 | sku_validators/* (10 files) | merged |
| 4 | graphs#164 | silicon_floorplan + show_floorplan | merged |
| 5 | graphs#165 | kpu_power_model | merged |
| 6 | graphs#166 | kpu_sku_generator + cli/generate_kpu_sku | merged |
| 7 | graphs#167 | cli/validate_sku | merged |
| 8 | graphs#168 | models/accelerators/kpu_yaml_loader | merged |
| 9a | graphs#169 | simplify compute_product_loader | merged |
| 9b | embodied-schemas#18 | retire data/kpus/; shim | merged |
| **9c** | **this PR** | **bump embodied-schemas pin** | **open** |

After this lands, the v1 ComputeProduct migration is functionally complete on the CI side: every workflow runs against the canonical schema with no legacy fallbacks active.

## Test plan

- [x] All pin sites updated (verified via grep)
- [x] YAML parses
- [x] Local hardware test suite green against the new pin
- [x] PR CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)