### PR TITLE
fix(roofline): generalize weight-stationarity to CPU (LLC residency)

### DIFF
--- a/src/graphs/estimation/roofline.py
+++ b/src/graphs/estimation/roofline.py
@@ -1774,53 +1774,100 @@ class RooflineAnalyzer:
         # Other hardware: default to moderate efficiency
         return 0.5
 
+    def _on_chip_weight_budget_bytes(self) -> int:
+        """On-chip storage available to hold weights resident across calls.
+
+        Architecture-specific because the same numeric "cache" plays a
+        different role on each:
+
+        * **KPU**: aggregate scratchpad fabric = ``compute_units x
+          l1_cache_per_unit + l2_cache_total``. The dataflow runtime
+          partitions weights across the tile mesh; the entire fabric is
+          a coherent weight pool by design.
+        * **CPU**: shared LLC (``l2_cache_total`` = L3/LLC by the M1
+          schema convention used in this codebase, see CPU mapper
+          comments). Per-core L1 is excluded -- 32 KiB x N cores doesn't
+          aggregate into a coherent weight pool, and the LLC dominates
+          for any reasonably-sized matrix.
+        * **Other (GPU, DSP, ...)**: 0. GPUs have programmer-managed
+          shared memory per SM that doesn't aggregate into a global
+          weight pool, so the conservative streaming model applies.
+          (Per-launch L2 set-aside is possible on Hopper+ but isn't
+          modeled here yet -- conservative is the right default until
+          we have a per-mapper opt-in.)
+
+        Reserves 20 % of the chosen capacity for the activation working
+        set; the remaining 80 % is the actual weight budget.
+        """
+        rm = self.resource_model
+        hw_type = rm.hardware_type.name
+
+        if hw_type == "KPU":
+            on_chip = rm.compute_units * rm.l1_cache_per_unit + rm.l2_cache_total
+        elif hw_type == "CPU":
+            # l2_cache_total = LLC by codebase convention. Per-core L1 is
+            # too small to aggregate into a coherent weight pool.
+            on_chip = rm.l2_cache_total
+        else:
+            return 0
+
+        return max(0, int(on_chip * 0.8))
+
     def _dram_traffic_bytes(self, sg: SubgraphDescriptor) -> int:
         """Bytes that actually cross the DRAM boundary for a subgraph.
 
-        For most hardware this is just ``input + output + weight`` -- the
-        roofline assumes weights stream through DRAM each call.
+        Default: ``input + output + weight`` -- the roofline's classical
+        cold-start assumption that weights stream through DRAM each call.
 
-        For weight-stationary accelerators (KPU), the architecture
-        double-buffers weight prefetch with compute: while layer N runs on
-        weights already resident in the tile fabric, layer N+1's weights are
-        fetched from DRAM in parallel. As long as a subgraph's weight
-        footprint fits in the aggregate on-chip capacity (sum of per-tile
-        L1 + shared L2), the weight load fully overlaps the previous
-        layer's compute and does NOT contribute to this subgraph's memory
-        floor. Per-subgraph DRAM traffic is then just the activation in/out.
+        For chips with enough on-chip storage to hold the subgraph's
+        weights resident, the steady-state behavior is different:
 
-        When per-subgraph weights exceed the on-chip budget, the prefetch
-        cannot fully hide weight loads -- model that as ``ceil(weight /
-        weight_budget)`` outer passes that each load a weight slab.
+        * **KPU**: the dataflow runtime explicitly double-buffers weight
+          prefetch with compute. While layer N runs on weights resident in
+          the tile fabric, layer N+1's weights are fetched from DRAM in
+          parallel. As long as a subgraph's weight footprint fits in the
+          aggregate on-chip capacity, the weight load fully overlaps the
+          previous layer's compute and does NOT contribute to this
+          subgraph's memory floor.
+        * **CPU**: in steady-state inference the L3 captures weight reuse.
+          For a workload whose weights fit in LLC, the cold-start cost
+          (one DRAM read of the matrix) amortizes away over many
+          inferences and only the activation stream crosses DRAM.
 
-        Without this hook (issue #51), transformer workloads get scored as
-        bandwidth-bound on KPU even though the dataflow is specifically
-        designed to keep weights resident.
+        When per-subgraph weights exceed the on-chip budget, the
+        prefetch / cache cannot fully hide weight loads -- model that as
+        ``ceil(weight / weight_budget)`` outer passes that each load a
+        weight slab. The activation stream cycles through every slab,
+        but each weight byte is still loaded only once total.
+
+        Other hardware (GPU, DSP, ...) keeps the cold-start streaming
+        model. See ``_on_chip_weight_budget_bytes`` for the per-arch
+        rationale.
+
+        Without this hook (issue #51), transformer-class workloads get
+        scored as bandwidth-bound on KPU and CPU even though their
+        dataflow / cache hierarchy is specifically designed to keep
+        weights resident.
         """
         base = sg.total_input_bytes + sg.total_output_bytes
         weight_bytes = sg.total_weight_bytes
-        hw_type = self.resource_model.hardware_type.name
 
-        if hw_type == "KPU" and weight_bytes > 0:
-            # Aggregate on-chip = sum of per-tile L1 + shared L2.
-            on_chip = (
-                self.resource_model.compute_units
-                * self.resource_model.l1_cache_per_unit
-                + self.resource_model.l2_cache_total
-            )
-            # Reserve 20% of on-chip for the activation working set.
-            weight_budget = max(1, int(on_chip * 0.8))
-            if weight_bytes <= weight_budget:
-                # Stationary: weight load overlaps previous layer's compute.
-                return base
-            # Weights exceed on-chip: outer-tiled. Each weight byte is still
-            # loaded *once* total (the slabs are different weight tiles, not
-            # the same tile reloaded); what gets repeated is the activation
-            # stream, which has to cycle through each weight slab.
-            outer_loads = max(1, math.ceil(weight_bytes / weight_budget))
-            return base * outer_loads + weight_bytes
+        if weight_bytes <= 0:
+            return base
 
-        return base + weight_bytes
+        weight_budget = self._on_chip_weight_budget_bytes()
+        if weight_budget <= 0:
+            return base + weight_bytes
+
+        if weight_bytes <= weight_budget:
+            # Stationary: weight load overlaps compute / sits in LLC.
+            return base
+        # Weights exceed on-chip: outer-tiled. Each weight byte is still
+        # loaded *once* total (the slabs are different weight tiles, not
+        # the same tile reloaded); what gets repeated is the activation
+        # stream, which has to cycle through each weight slab.
+        outer_loads = max(1, math.ceil(weight_bytes / weight_budget))
+        return base * outer_loads + weight_bytes
 
     def _get_discrete_resource_correction(self, sg: SubgraphDescriptor) -> float:
         """

--- a/tests/hardware/test_kpu_weight_stationarity.py
+++ b/tests/hardware/test_kpu_weight_stationarity.py
@@ -154,16 +154,61 @@ def test_kpu_dram_traffic_handles_zero_weights(kpu_t64_resource_model):
 
 
 # ---------------------------------------------------------------------------
-# Non-KPU hardware is unaffected
+# GPU keeps streaming model (no aggregate weight pool across SMs)
 # ---------------------------------------------------------------------------
 
 
 def test_gpu_dram_traffic_keeps_naive_accounting():
-    """GPU/CPU/etc. retain the conservative input+output+weight accounting.
-    Issue #51 stationarity is a KPU-specific architectural model."""
+    """GPU retains the conservative input+output+weight accounting.
+    Per-SM shared memory doesn't aggregate into a coherent weight pool,
+    and the per-launch L2 set-aside on Hopper+ isn't modeled here yet --
+    streaming is the right default until there's a per-mapper opt-in."""
     from graphs.hardware.mappers.gpu import create_h100_sxm5_80gb_mapper
     rm = create_h100_sxm5_80gb_mapper().resource_model
     analyzer = RooflineAnalyzer(rm, precision=Precision.FP16)
     sg = _make_subgraph(input_b=1_000_000, output_b=1_000_000, weight_b=4 * 1024 * 1024)
     expected_naive = 1_000_000 + 1_000_000 + 4 * 1024 * 1024
     assert analyzer._dram_traffic_bytes(sg) == expected_naive
+
+
+# ---------------------------------------------------------------------------
+# CPU: weight residency in LLC (steady-state inference). Same architectural
+# story as KPU stationarity but via L3 cache instead of explicit dataflow.
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_dram_traffic_excludes_weights_when_they_fit_in_llc():
+    """CPUs with sufficient L3 capture weight reuse in steady state.
+
+    For a workload whose weights fit in LLC, the cold-start DRAM read
+    amortizes away over many inferences and only activation traffic
+    crosses DRAM steady-state. ``l2_cache_total`` carries the LLC value
+    by codebase convention (see CPU mapper comments).
+    """
+    from graphs.hardware.mappers.cpu import create_i7_12700k_mapper
+    rm = create_i7_12700k_mapper().resource_model
+    analyzer = RooflineAnalyzer(rm, precision=Precision.FP16)
+    # i7-12700K has 25 MB L3; an 8 MB matrix fits with room to spare.
+    weight_bytes = 8 * 1024 * 1024
+    sg = _make_subgraph(input_b=4096, output_b=4096, weight_b=weight_bytes)
+    bytes_ = analyzer._dram_traffic_bytes(sg)
+    # input + output only; weights stay resident in LLC.
+    assert bytes_ == 4096 + 4096
+
+
+def test_cpu_dram_traffic_streams_when_weights_exceed_llc():
+    """When weights exceed LLC, the outer-tile model applies the same
+    way as for KPU: ceil(weight/budget) passes, each loading a fresh
+    slab; total weight bytes loaded == nominal weight size."""
+    from graphs.hardware.mappers.cpu import create_i7_12700k_mapper
+    rm = create_i7_12700k_mapper().resource_model
+    analyzer = RooflineAnalyzer(rm, precision=Precision.FP16)
+    # 100 MB weights vs 25 MB L3 -> ceil(100/(25*0.8)) = 5 outer slabs.
+    weight_bytes = 100 * 1024 * 1024
+    activation_bytes = 4096 + 4096
+    sg = _make_subgraph(input_b=4096, output_b=4096, weight_b=weight_bytes)
+    weight_budget = int(rm.l2_cache_total * 0.8)
+    expected_outer = math.ceil(weight_bytes / weight_budget)
+    expected = activation_bytes * expected_outer + weight_bytes
+    assert analyzer._dram_traffic_bytes(sg) == expected
+    assert expected_outer >= 2  # sanity


### PR DESCRIPTION
## Why

The KPU-specific weight-stationarity model from issue #51 captures the fact that, when a subgraph's weights fit in on-chip storage, the weight load is hidden by compute / serviced from the cache hierarchy and doesn't show up as DRAM traffic.

**The same architectural story applies to CPUs in steady-state inference.** When the weight matrix fits in LLC, the cold-start DRAM read amortizes away over many calls and only the activation stream crosses DRAM.

Before this fix, CPU mappers used the conservative streaming model (\`input + output + weight\`) for every subgraph regardless of LLC size. For a workload like a **4M-weight Linear at FP16 (8 MB matrix) on a Ryzen / i7 with 25-128 MB L3**, the model claimed the matrix streamed from DRAM every inference even though it sits in LLC. This systematically understated the architectural advantage of large CPU caches and would have produced misleading apples-to-oranges comparisons against KPU / TPU on memory-bound workloads.

This fix is a prerequisite for the upcoming Jetson + ARM-multi-core + KPU roadmap visualization (single Linear+bias+atan workload across architectures) to honestly compare cache-resident CPU/KPU steady-state against streaming GPU.

## Generalization

| Architecture | On-chip weight pool | Behavior |
|---|---|---|
| **KPU** | aggregate scratchpad: \`compute_units × l1_cache_per_unit + l2_cache_total\` | unchanged — dataflow runtime double-buffers prefetch with compute |
| **CPU** | \`l2_cache_total\` (= LLC by codebase convention) | **new** — LLC captures weight reuse in steady state |
| **GPU / DSP / others** | 0 | unchanged — streaming model |

Code:
- New helper \`_on_chip_weight_budget_bytes()\` returns the architecture-appropriate weight pool
- \`_dram_traffic_bytes()\` applies the same residency / outer-tile logic uniformly, gated by the budget rather than by \`hw_type == "KPU"\`

GPU is **explicitly preserved** on the streaming model because per-SM shared memory doesn't aggregate into a coherent weight pool, and the per-launch L2 set-aside on Hopper+ isn't modeled here yet. Test \`test_gpu_dram_traffic_keeps_naive_accounting\` locks this in.

## Tests

- ✅ \`test_cpu_dram_traffic_excludes_weights_when_they_fit_in_llc\`: 8 MB weights + i7-12700K (25 MB L3) → \`input + output\` only
- ✅ \`test_cpu_dram_traffic_streams_when_weights_exceed_llc\`: 100 MB weights + 25 MB L3 → outer-tile model with \`ceil(100/(25*0.8)) = 5\` slabs, each weight byte loaded once total
- ✅ All existing KPU and GPU tests pass unchanged
- ✅ 686/686 hardware tests pass (+2 new CPU tests)
- ✅ 2,690/2,690 unit tests pass under \`pytest -n 4\` (1:30 wall clock)

## Test plan

- [x] CPU residency tests added
- [x] GPU streaming preserved (test still passes)
- [x] KPU stationarity preserved (existing tests still pass)
- [x] Hardware suite green
- [x] Full suite green
- [x] PR CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined DRAM traffic calculations to improve accuracy across different hardware architectures
  * Enhanced weight-caching optimization for systems with shared processor caches

* **Tests**
  * Expanded test coverage for DRAM traffic accounting validation across multiple processor types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/172)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->