### PR TITLE
feat(cli): jetson roadmap visualization (Orin NX -> AGX Orin -> Thor)

### DIFF
--- a/cli/analyze_jetson_roadmap.py
+++ b/cli/analyze_jetson_roadmap.py
@@ -90,7 +90,10 @@ import torch
 import torch.nn as nn
 
 from graphs.estimation.unified_analyzer import UnifiedAnalyzer
-from graphs.hardware.mappers.cpu import create_ampere_ampereone_192_mapper
+from graphs.hardware.mappers.cpu import (
+    create_ampere_ampereone_192_mapper,
+    create_ampere_ampereone_1core_reference_mapper,
+)
 from graphs.hardware.mappers.gpu import (
     create_jetson_orin_agx_64gb_mapper,
     create_jetson_thor_128gb_mapper,
@@ -221,6 +224,22 @@ PRODUCTS: List[RoadmapProduct] = [
         process_node="TSMC 5nm",
         color="#d62728",   # tab:red
         marker="v",
+    ),
+    # Synthetic single-core reference paired with the 192-core SKU above.
+    # Same architectural unit, num_cores=1. Surfaces what realistic
+    # single-core throughput looks like for issue #175 (CPU mapper
+    # batch=1 fanout overcount). The gap between this bar and the
+    # 192-core bar above shows how much of the multi-core scaling is
+    # genuine vs an artifact of LLC capacity scaling with num_cores.
+    RoadmapProduct(
+        name="AmpereOne 1-core (synthetic ref)",
+        factory=create_ampere_ampereone_1core_reference_mapper,
+        release_date=date(2024, 5, 1),  # paired with the 192-core SKU
+        eol_date=date(2031, 5, 1),
+        architecture="ARM v8.6+ (1c)",
+        process_node="TSMC 5nm",
+        color="#8c564b",   # tab:brown
+        marker="x",
     ),
 ]
 

--- a/cli/analyze_jetson_roadmap.py
+++ b/cli/analyze_jetson_roadmap.py
@@ -90,7 +90,26 @@ import torch
 import torch.nn as nn
 
 from graphs.estimation.unified_analyzer import UnifiedAnalyzer
-from graphs.hardware.mappers.accelerators.kpu import create_kpu_t64_mapper
+from graphs.hardware.mappers.accelerators.kpu import KPUMapper
+from graphs.hardware.models.accelerators.kpu_yaml_loader import (
+    load_kpu_resource_model_from_yaml,
+)
+from graphs.hardware.architectural_energy import KPUTileEnergyAdapter
+
+
+def create_kpu_t64_7nm_mapper() -> KPUMapper:
+    """KPU-T64 on TSMC N7 HPC -- the closest available KPU process node
+    to the Jetsons in this chart (Orin = Samsung 8nm, Thor = TSMC 4NP).
+
+    The standard ``create_kpu_t64_mapper()`` factory loads the 16nm
+    variant which biases the comparison toward older silicon. T64 ships
+    in three process variants in embodied-schemas (16nm / 12nm / 7nm);
+    we load the 7nm SKU directly here for a fairer roadmap-era
+    comparison. A 5nm or 4nm KPU SKU does not yet exist in the catalog.
+    """
+    model = load_kpu_resource_model_from_yaml("kpu_t64_32x32_lp5x4_7nm_tsmc_hpc")
+    model.architecture_energy_model = KPUTileEnergyAdapter(model.tile_energy_model)
+    return KPUMapper(model)
 from graphs.hardware.mappers.cpu import (
     create_ampere_ampereone_1core_reference_mapper,
 )
@@ -233,14 +252,17 @@ PRODUCTS: List[RoadmapProduct] = [
     ),
     # KPU reference SKU. T64 alone is enough to make the comparison
     # legible (it already beats Thor on this workload). T256 deferred
-    # until the avg_power-vs-TDP modeling fix lands.
+    # until the avg_power-vs-TDP modeling fix lands. Process node:
+    # TSMC N7 HPC -- closest available KPU SKU to the chart's Orin
+    # (Samsung 8nm) / Thor (TSMC 4NP) era. A 5nm / 4nm KPU is not yet
+    # in the catalog.
     RoadmapProduct(
         name="Stillwater KPU-T64",
-        factory=create_kpu_t64_mapper,
+        factory=create_kpu_t64_7nm_mapper,
         release_date=date(2027, 1, 1),
         eol_date=date(2037, 1, 1),
         architecture="KPU domain-flow (64 tiles)",
-        process_node="TSMC 16FFP",
+        process_node="TSMC N7 HPC",
         color="#9467bd",   # tab:purple
         marker="P",
     ),

--- a/cli/analyze_jetson_roadmap.py
+++ b/cli/analyze_jetson_roadmap.py
@@ -69,9 +69,11 @@ CSV output includes both metrics so you can pick the framing that
 matches your slide.
 
 Usage:
-  python cli/jetson_roadmap.py --output jetson_roadmap.png
-  python cli/jetson_roadmap.py --output jetson_roadmap.csv
-  python cli/jetson_roadmap.py --precision int8 --output roadmap_int8.png
+  python cli/analyze_jetson_roadmap.py --output jetson_roadmap.png
+  python cli/analyze_jetson_roadmap.py --output jetson_roadmap.csv
+  python cli/analyze_jetson_roadmap.py --output jetson_roadmap.json
+  python cli/analyze_jetson_roadmap.py --output jetson_roadmap.md
+  python cli/analyze_jetson_roadmap.py --precision int8 --output roadmap_int8.png
 """
 
 from __future__ import annotations
@@ -256,34 +258,78 @@ def analyze(
 # Output
 # ---------------------------------------------------------------------------
 
+def _row_dict(r: ProductResult) -> dict:
+    """Per-product dict used by csv/json/md/txt writers. One source of
+    truth so all four formats see identical columns + rounding."""
+    avg_power_w = r.energy_mj / r.latency_ms if r.latency_ms > 0 else 0.0
+    throughput_per_tdp = r.perf_inf_per_s / r.tdp_w if r.tdp_w > 0 else 0.0
+    return {
+        "name": r.product.name,
+        "release_date": r.product.release_date.isoformat(),
+        "architecture": r.product.architecture,
+        "process_node": r.product.process_node,
+        "tdp_w": r.tdp_w,
+        "latency_ms": round(r.latency_ms, 3),
+        "energy_per_inference_mj": round(r.energy_mj, 3),
+        "avg_power_w_during_inference": round(avg_power_w, 2),
+        "perf_inferences_per_sec": round(r.perf_inf_per_s, 1),
+        "energy_efficiency_inferences_per_joule": round(r.intelligence_inf_per_j, 1),
+        "throughput_per_tdp_inferences_per_sec_per_w": round(throughput_per_tdp, 1),
+    }
+
+
+_FIELDS = [
+    "name", "release_date", "architecture", "process_node",
+    "tdp_w", "latency_ms", "energy_per_inference_mj",
+    "avg_power_w_during_inference",
+    "perf_inferences_per_sec",
+    "energy_efficiency_inferences_per_joule",
+    "throughput_per_tdp_inferences_per_sec_per_w",
+]
+
+
 def write_csv(results: List[ProductResult], out: Path) -> None:
-    fields = [
-        "name", "release_date", "architecture", "process_node",
-        "tdp_w", "latency_ms", "energy_per_inference_mj",
-        "avg_power_w_during_inference",
-        "perf_inferences_per_sec",
-        "energy_efficiency_inferences_per_joule",
-        "throughput_per_tdp_inferences_per_sec_per_w",
-    ]
     with out.open("w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=fields)
+        writer = csv.DictWriter(f, fieldnames=_FIELDS)
         writer.writeheader()
         for r in results:
-            avg_power_w = r.energy_mj / r.latency_ms if r.latency_ms > 0 else 0.0
-            throughput_per_tdp = r.perf_inf_per_s / r.tdp_w if r.tdp_w > 0 else 0.0
-            writer.writerow({
-                "name": r.product.name,
-                "release_date": r.product.release_date.isoformat(),
-                "architecture": r.product.architecture,
-                "process_node": r.product.process_node,
-                "tdp_w": r.tdp_w,
-                "latency_ms": round(r.latency_ms, 3),
-                "energy_per_inference_mj": round(r.energy_mj, 3),
-                "avg_power_w_during_inference": round(avg_power_w, 2),
-                "perf_inferences_per_sec": round(r.perf_inf_per_s, 1),
-                "energy_efficiency_inferences_per_joule": round(r.intelligence_inf_per_j, 1),
-                "throughput_per_tdp_inferences_per_sec_per_w": round(throughput_per_tdp, 1),
-            })
+            writer.writerow(_row_dict(r))
+    print(f"info: wrote {out}", file=sys.stderr)
+
+
+def write_json(results: List[ProductResult], out: Path) -> None:
+    import json
+    payload = [_row_dict(r) for r in results]
+    out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"info: wrote {out}", file=sys.stderr)
+
+
+def write_markdown(results: List[ProductResult], out: Path) -> None:
+    headers = _FIELDS
+    rows = [_row_dict(r) for r in results]
+    lines: list[str] = []
+    lines.append("# Jetson industrial roadmap")
+    lines.append("")
+    lines.append("| " + " | ".join(headers) + " |")
+    lines.append("|" + "|".join("---" for _ in headers) + "|")
+    for row in rows:
+        lines.append("| " + " | ".join(str(row[h]) for h in headers) + " |")
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"info: wrote {out}", file=sys.stderr)
+
+
+def write_text(results: List[ProductResult], out: Path) -> None:
+    rows = [_row_dict(r) for r in results]
+    # Column widths from the longer of header / value
+    widths = {h: max(len(h), max((len(str(r[h])) for r in rows), default=0)) for h in _FIELDS}
+    lines: list[str] = []
+    lines.append("Jetson industrial roadmap")
+    lines.append("")
+    lines.append("  " + "  ".join(h.ljust(widths[h]) for h in _FIELDS))
+    lines.append("  " + "  ".join("-" * widths[h] for h in _FIELDS))
+    for row in rows:
+        lines.append("  " + "  ".join(str(row[h]).ljust(widths[h]) for h in _FIELDS))
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
     print(f"info: wrote {out}", file=sys.stderr)
 
 
@@ -451,9 +497,17 @@ def main() -> int:
         )
 
     out = Path(args.output)
-    if out.suffix.lower() == ".csv":
+    suffix = out.suffix.lower()
+    if suffix == ".csv":
         write_csv(results, out)
+    elif suffix == ".json":
+        write_json(results, out)
+    elif suffix in {".md", ".markdown"}:
+        write_markdown(results, out)
+    elif suffix in {".txt", ".text"}:
+        write_text(results, out)
     else:
+        # Default: render plot (covers .png, .pdf, .svg, anything matplotlib accepts)
         write_plot(results, out, workload_name, args.precision.upper())
 
     return 0

--- a/cli/analyze_jetson_roadmap.py
+++ b/cli/analyze_jetson_roadmap.py
@@ -407,84 +407,209 @@ def write_plot(
     workload_name: str,
     precision_label: str,
 ) -> None:
+    """Render the roadmap chart with a broken-axis treatment per panel.
+
+    The chart compares conventional silicon (Jetsons + ARM CPU) against
+    a KPU. The KPU's metrics on this workload are >100x the conventional
+    bars, which collapses the conventional band onto the axis line if
+    plotted on a single linear y-axis. To keep both regimes visible
+    *and* preserve linear semantics within each regime, each metric
+    panel is split into two stacked sub-axes:
+
+      * upper sub-axis: zoomed onto the high-band metric (KPU)
+      * lower sub-axis: zoomed onto the low-band metric (others)
+
+    Diagonal slash markers between the sub-axes indicate the y-axis
+    discontinuity. Bars are drawn on whichever sub-axis their value
+    falls in (bars in the wrong band sit outside ylim and aren't
+    rendered).
+    """
     import matplotlib.pyplot as plt
     import matplotlib.dates as mdates
 
     results = sorted(results, key=lambda r: r.product.release_date)
 
-    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(11, 8.5), sharex=True)
+    # Partition the products into a high-band (>10x the next-largest
+    # value) and the low-band on each metric. In practice the partition
+    # is the same for both metrics here, but we compute it per metric
+    # so the chart degrades gracefully if we add SKUs later.
+    def _partition(values: List[float]) -> tuple[float, float, float]:
+        """Return (low_band_max, high_band_min, gap_factor). Gap factor
+        > 10 means a broken axis is worth it; otherwise we'd just use
+        one axis. Caller decides what to do with the verdict."""
+        s = sorted(values)
+        # Find the largest gap between adjacent sorted values.
+        gaps = [(s[i+1] / max(s[i], 1e-9), i) for i in range(len(s) - 1)]
+        ratio, idx = max(gaps, key=lambda t: t[0])
+        return s[idx], s[idx + 1], ratio
 
-    # Title
+    perf_vals = [r.perf_inf_per_s for r in results]
+    eff_vals = [r.intelligence_inf_per_j for r in results]
+    perf_low_max, perf_high_min, perf_gap = _partition(perf_vals)
+    eff_low_max, eff_high_min, eff_gap = _partition(eff_vals)
+
+    # gridspec: 5 rows = perf-top / perf-bot / SPACER / eff-top /
+    # eff-bot. The middle row is empty so the Performance and Efficiency
+    # panels don't run into each other; without it the Efficiency title
+    # sits flush against the Performance lower band. The high-band rows
+    # get less vertical space because they carry one bar each.
+    fig = plt.figure(figsize=(11, 10.5))
+    gs = fig.add_gridspec(
+        5, 1,
+        height_ratios=[1.2, 2.6, 0.5, 1.2, 2.6],
+        hspace=0.06,
+    )
+    ax_perf_top = fig.add_subplot(gs[0])
+    ax_perf_bot = fig.add_subplot(gs[1], sharex=ax_perf_top)
+    ax_eff_top = fig.add_subplot(gs[3], sharex=ax_perf_top)
+    ax_eff_bot = fig.add_subplot(gs[4], sharex=ax_perf_top)
+
     fig.suptitle(
         f"Compute roadmap @ {precision_label}\n"
         f"Workload: {workload_name}",
         fontsize=12, y=0.995,
     )
 
-    def _draw_lifecycle_bar(ax, r: ProductResult, y: float, with_label: bool) -> None:
-        """Thick horizontal bar from release_date to EOL at the metric's
-        y-value. The bar's position on the calendar axis already implies
-        release and EOL, so no start/end markers and no release/EOL text."""
+    def _draw_lifecycle_bar(axes: tuple, r: ProductResult, y: float,
+                            with_label: bool) -> None:
+        """Draw the bar on BOTH sub-axes; ylim clips to the right band."""
         legend_label = (
             f"{r.product.name} -- "
             f"{r.product.architecture} on {r.product.process_node}, "
             f"{r.tdp_w:.0f}W"
         ) if with_label else None
-        ax.hlines(
-            y=y,
-            xmin=r.product.release_date,
-            xmax=r.product.eol_date,
-            color=r.product.color, linewidth=22, alpha=0.85, zorder=2,
-            label=legend_label,
-        )
-        midpoint = r.product.release_date + (r.product.eol_date - r.product.release_date) / 2
-        ax.annotate(
-            r.product.name,
-            xy=(midpoint, y),
-            ha="center", va="center",
-            color="white", fontsize=10, fontweight="bold", zorder=4,
-        )
+        midpoint = (r.product.release_date
+                    + (r.product.eol_date - r.product.release_date) / 2)
+        for i, ax in enumerate(axes):
+            ax.hlines(
+                y=y,
+                xmin=r.product.release_date,
+                xmax=r.product.eol_date,
+                color=r.product.color, linewidth=22, alpha=0.85, zorder=2,
+                # Only register the legend entry on one sub-axis to
+                # avoid duplicate entries.
+                label=legend_label if i == 0 else None,
+            )
+            ax.annotate(
+                r.product.name,
+                xy=(midpoint, y),
+                ha="center", va="center",
+                color="white", fontsize=10, fontweight="bold", zorder=4,
+            )
 
-    # Panel 1: throughput
+    # Draw bars
     for r in results:
-        _draw_lifecycle_bar(ax1, r, r.perf_inf_per_s, with_label=True)
-    ax1.set_ylabel("Sustained throughput (inferences / sec)")
-    ax1.set_title("Performance over availability window")
-    ax1.grid(True, alpha=0.3)
-    ax1.legend(loc="upper left", fontsize=9, framealpha=0.95)
+        _draw_lifecycle_bar((ax_perf_top, ax_perf_bot), r,
+                            r.perf_inf_per_s, with_label=True)
+        _draw_lifecycle_bar((ax_eff_top, ax_eff_bot), r,
+                            r.intelligence_inf_per_j, with_label=False)
 
-    # Panel 2: energy efficiency
-    for r in results:
-        _draw_lifecycle_bar(ax2, r, r.intelligence_inf_per_j, with_label=False)
-    ax2.set_ylabel("Energy efficiency (inferences / joule)")
-    ax2.set_title("Efficiency over availability window: process + architecture impact")
-    ax2.set_xlabel("Calendar year")
-    ax2.grid(True, alpha=0.3)
+    # Y-axis bands. 18% margin around each cluster so bars float in
+    # whitespace instead of touching the axis edges.
+    def _band_ylim(low: float, high: float) -> tuple[float, float]:
+        span = max(high - low, high * 0.1)
+        return (low - 0.18 * span, high + 0.18 * span)
 
-    # X-axis: fixed 5-year majors at 2020 / 2025 / ... so the axis reads
-    # as a calendar timeline rather than a tight integer scale.
-    ax2.xaxis.set_major_locator(mdates.YearLocator(base=5, month=1, day=1))
-    ax2.xaxis.set_major_formatter(mdates.DateFormatter("%Y"))
-    ax2.xaxis.set_minor_locator(mdates.YearLocator(base=1))
+    # Performance: low band covers everyone <= perf_low_max, high band
+    # covers KPU value(s) >= perf_high_min.
+    perf_lows = [v for v in perf_vals if v <= perf_low_max]
+    perf_highs = [v for v in perf_vals if v >= perf_high_min]
+    ax_perf_bot.set_ylim(*_band_ylim(min(perf_lows), max(perf_lows)))
+    ax_perf_top.set_ylim(*_band_ylim(min(perf_highs), max(perf_highs)))
 
-    # Anchor x-axis to a fixed 2020 -> 2040 window so the bars sit on a
-    # roadmap-style timeline regardless of which SKUs are present.
-    ax2.set_xlim(date(2020, 1, 1), date(2040, 1, 1))
+    eff_lows = [v for v in eff_vals if v <= eff_low_max]
+    eff_highs = [v for v in eff_vals if v >= eff_high_min]
+    ax_eff_bot.set_ylim(*_band_ylim(min(eff_lows), max(eff_lows)))
+    ax_eff_top.set_ylim(*_band_ylim(min(eff_highs), max(eff_highs)))
 
-    # Y-axis: float each bar with whitespace above and below the metric
-    # range. matplotlib's auto-ylim hugs the data tightly with thick
-    # hlines, which makes the top/bottom bars look like they're glued
-    # to the axis. 18% margin gives every bar visual breathing room.
-    for ax, get in ((ax1, lambda r: r.perf_inf_per_s),
-                    (ax2, lambda r: r.intelligence_inf_per_j)):
-        ys = [get(r) for r in results]
-        ymin, ymax = min(ys), max(ys)
-        span = max(ymax - ymin, ymax * 0.1)  # avoid zero-span if all equal
-        ax.set_ylim(ymin - 0.18 * span, ymax + 0.18 * span)
+    # Hide spines / ticks at the broken-axis seam, then add diagonal
+    # slash markers across the seam so the discontinuity reads visually.
+    def _add_break(top_ax, bot_ax) -> None:
+        top_ax.spines["bottom"].set_visible(False)
+        bot_ax.spines["top"].set_visible(False)
+        top_ax.tick_params(axis="x", which="both",
+                           bottom=False, labelbottom=False)
+        # Diagonal "wiggle" -- short slashes at the break boundary on
+        # both sub-axes' left and right spines.
+        d = 0.012
+        kw = dict(color="black", clip_on=False, linewidth=1.2)
+        top_ax.plot((-d, +d), (-d, +d),
+                    transform=top_ax.transAxes, **kw)
+        top_ax.plot((1 - d, 1 + d), (-d, +d),
+                    transform=top_ax.transAxes, **kw)
+        bot_ax.plot((-d, +d), (1 - d, 1 + d),
+                    transform=bot_ax.transAxes, **kw)
+        bot_ax.plot((1 - d, 1 + d), (1 - d, 1 + d),
+                    transform=bot_ax.transAxes, **kw)
+
+    _add_break(ax_perf_top, ax_perf_bot)
+    _add_break(ax_eff_top, ax_eff_bot)
+
+    # Hide the in-between xticks on the inner axes (perf_bot and
+    # eff_top); only the bottom-most axis carries the year labels.
+    ax_perf_bot.tick_params(axis="x", which="both",
+                            bottom=False, labelbottom=False)
+    ax_eff_top.tick_params(axis="x", which="both",
+                           bottom=False, labelbottom=False)
+
+    # Titles, labels, grid
+    ax_perf_top.set_title("Performance over availability window")
+    ax_eff_top.set_title("Efficiency over availability window: "
+                         "process + architecture impact")
+    # Y-labels span the broken pair: anchor on the bottom axis with
+    # adjusted y position so they read as one label per panel.
+    ax_perf_bot.set_ylabel("Sustained throughput (inferences / sec)",
+                           y=0.7)
+    ax_eff_bot.set_ylabel("Energy efficiency (inferences / joule)",
+                          y=0.7)
+    ax_eff_bot.set_xlabel("Calendar year")
+    for ax in (ax_perf_top, ax_perf_bot, ax_eff_top, ax_eff_bot):
+        ax.grid(True, alpha=0.3)
+    # Place the legend BELOW the chart in a 2-column row so it never
+    # collides with bars or the broken-axis seam. Anchored in figure
+    # coordinates so it floats below ax_eff_bot regardless of layout.
+    handles, labels = ax_perf_top.get_legend_handles_labels()
+    fig.legend(
+        handles, labels,
+        loc="lower center",
+        bbox_to_anchor=(0.5, -0.02),
+        bbox_transform=fig.transFigure,
+        fontsize=9, framealpha=0.95, ncol=2,
+    )
+
+    # X-axis: fixed 5-year majors so the axis reads as a calendar
+    # timeline. Anchored to 2020 -> 2040.
+    ax_eff_bot.xaxis.set_major_locator(
+        mdates.YearLocator(base=5, month=1, day=1))
+    ax_eff_bot.xaxis.set_major_formatter(mdates.DateFormatter("%Y"))
+    ax_eff_bot.xaxis.set_minor_locator(mdates.YearLocator(base=1))
+    ax_eff_bot.set_xlim(date(2020, 1, 1), date(2040, 1, 1))
+
+    # Replace the matplotlib "1e6" exponent badge on the top sub-axes
+    # with an inline "M" suffix on each tick label -- reads more
+    # naturally on a perf chart and avoids the exponent floating into
+    # the chart area.
+    from matplotlib.ticker import FuncFormatter
+
+    def _abbrev(value: float, _pos) -> str:
+        if abs(value) >= 1e6:
+            return f"{value / 1e6:.2f}M"
+        if abs(value) >= 100e3:
+            return f"{value / 1e3:.0f}K"
+        if abs(value) >= 1e3:
+            # Keep one decimal under 100K so adjacent ticks like
+            # 23.5K / 24.0K / 24.5K don't all collapse to "24K".
+            return f"{value / 1e3:.1f}K"
+        return f"{value:.0f}"
+
+    for ax in (ax_perf_top, ax_perf_bot, ax_eff_top, ax_eff_bot):
+        ax.yaxis.set_major_formatter(FuncFormatter(_abbrev))
 
     plt.tight_layout(rect=[0, 0, 1, 0.96])
     plt.savefig(out, dpi=120, bbox_inches="tight")
     print(f"info: wrote {out}", file=sys.stderr)
+    print(f"info: perf gap = {perf_gap:.1f}x, "
+          f"eff gap = {eff_gap:.1f}x", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------

--- a/cli/analyze_jetson_roadmap.py
+++ b/cli/analyze_jetson_roadmap.py
@@ -90,8 +90,11 @@ import torch
 import torch.nn as nn
 
 from graphs.estimation.unified_analyzer import UnifiedAnalyzer
+from graphs.hardware.mappers.accelerators.kpu import (
+    create_kpu_t64_mapper,
+    create_kpu_t256_mapper,
+)
 from graphs.hardware.mappers.cpu import (
-    create_ampere_ampereone_192_mapper,
     create_ampere_ampereone_1core_reference_mapper,
 )
 from graphs.hardware.mappers.gpu import (
@@ -215,31 +218,44 @@ PRODUCTS: List[RoadmapProduct] = [
     # would leave each core with ~21K weights of work, well below any
     # reasonable per-core efficiency floor; the mapper should resolve
     # this as a single-core (or few-core) job, not a 192-way fanout.
-    RoadmapProduct(
-        name="Ampere AmpereOne A192",
-        factory=create_ampere_ampereone_192_mapper,
-        release_date=date(2024, 5, 1),  # AmpereOne A192-32X general availability
-        eol_date=date(2031, 5, 1),  # estimate: ~7y server lifecycle (no published EOL)
-        architecture="ARM v8.6+ (192c)",
-        process_node="TSMC 5nm",
-        color="#d62728",   # tab:red
-        marker="v",
-    ),
-    # Synthetic single-core reference paired with the 192-core SKU above.
-    # Same architectural unit, num_cores=1. Surfaces what realistic
-    # single-core throughput looks like for issue #175 (CPU mapper
-    # batch=1 fanout overcount). The gap between this bar and the
-    # 192-core bar above shows how much of the multi-core scaling is
-    # genuine vs an artifact of LLC capacity scaling with num_cores.
+    # Synthetic single-core ARM reference. Issue #175 demonstrated that
+    # the multi-core AmpereOne SKUs report unreliable throughput on
+    # batch=1 matvec (naive compute fanout across all cores), so the
+    # AmpereOne A192 SKU is intentionally omitted from this chart until
+    # the per-operator concurrency cap lands. The 1-core slice is kept
+    # as a useful per-core ARM data point in its own right.
     RoadmapProduct(
         name="AmpereOne 1-core (synthetic ref)",
         factory=create_ampere_ampereone_1core_reference_mapper,
-        release_date=date(2024, 5, 1),  # paired with the 192-core SKU
+        release_date=date(2024, 5, 1),
         eol_date=date(2031, 5, 1),
         architecture="ARM v8.6+ (1c)",
         process_node="TSMC 5nm",
         color="#8c564b",   # tab:brown
         marker="x",
+    ),
+    # KPU reference SKUs. KPU release dates are forward-looking per the
+    # spec ("KPU release dates will be 2027, 2028, 2029"); placing T64
+    # at 2027 and T256 at 2029 with overlapping availability windows.
+    RoadmapProduct(
+        name="Stillwater KPU-T64",
+        factory=create_kpu_t64_mapper,
+        release_date=date(2027, 1, 1),
+        eol_date=date(2037, 1, 1),
+        architecture="KPU domain-flow (64 tiles)",
+        process_node="TSMC 16FFP",
+        color="#9467bd",   # tab:purple
+        marker="P",
+    ),
+    RoadmapProduct(
+        name="Stillwater KPU-T256",
+        factory=create_kpu_t256_mapper,
+        release_date=date(2029, 1, 1),
+        eol_date=date(2039, 1, 1),
+        architecture="KPU domain-flow (256 tiles)",
+        process_node="TSMC 16FFP",
+        color="#17becf",   # tab:cyan
+        marker="*",
     ),
 ]
 

--- a/cli/analyze_jetson_roadmap.py
+++ b/cli/analyze_jetson_roadmap.py
@@ -360,47 +360,34 @@ def write_plot(
     )
 
     def _draw_lifecycle_bar(ax, r: ProductResult, y: float, with_label: bool) -> None:
-        """Horizontal bar from release_date to EOL at metric y-value.
-
-        Bars communicate the *application window* of each SKU: the period
-        where it can actually be designed in. Filled marker at the
-        release-date end (start of availability), open marker at EOL."""
+        """Thick horizontal bar from release_date to EOL at the metric's
+        y-value. The bar's position on the calendar axis already implies
+        release and EOL, so no start/end markers and no release/EOL text."""
         legend_label = (
-            f"{r.product.short_name()} -- "
+            f"{r.product.name} -- "
             f"{r.product.architecture} on {r.product.process_node}, "
-            f"{r.tdp_w:.0f}W "
-            f"({r.product.release_date.year}-{r.product.eol_date.year})"
+            f"{r.tdp_w:.0f}W"
         ) if with_label else None
         ax.hlines(
             y=y,
             xmin=r.product.release_date,
             xmax=r.product.eol_date,
-            color=r.product.color, linewidth=8, alpha=0.85, zorder=2,
+            color=r.product.color, linewidth=22, alpha=0.85, zorder=2,
             label=legend_label,
         )
-        # Filled marker at release (in-market start)
-        ax.scatter(
-            [r.product.release_date], [y],
-            c=r.product.color, marker=r.product.marker, s=160,
-            edgecolors="black", linewidth=1.0, zorder=3,
-        )
-        # Open marker at EOL (end-of-availability)
-        ax.scatter(
-            [r.product.eol_date], [y],
-            facecolors="white", edgecolors=r.product.color,
-            marker=r.product.marker, s=120, linewidth=1.5, zorder=3,
-        )
+        midpoint = r.product.release_date + (r.product.eol_date - r.product.release_date) / 2
         ax.annotate(
-            r.product.short_name(),
-            xy=(r.product.release_date, y),
-            xytext=(8, 8), textcoords="offset points", fontsize=9,
+            r.product.name,
+            xy=(midpoint, y),
+            ha="center", va="center",
+            color="white", fontsize=10, fontweight="bold", zorder=4,
         )
 
     # Panel 1: throughput
     for r in results:
         _draw_lifecycle_bar(ax1, r, r.perf_inf_per_s, with_label=True)
     ax1.set_ylabel("Sustained throughput (inferences / sec)")
-    ax1.set_title("Performance over availability window: release date -> EOL")
+    ax1.set_title("Performance over availability window")
     ax1.grid(True, alpha=0.3)
     ax1.legend(loc="upper left", fontsize=9, framealpha=0.95)
 
@@ -409,21 +396,18 @@ def write_plot(
         _draw_lifecycle_bar(ax2, r, r.intelligence_inf_per_j, with_label=False)
     ax2.set_ylabel("Energy efficiency (inferences / joule)")
     ax2.set_title("Efficiency over availability window: process + architecture impact")
-    ax2.set_xlabel("Calendar year (filled = release / GA, open = EOL)")
+    ax2.set_xlabel("Calendar year")
     ax2.grid(True, alpha=0.3)
 
-    # X-axis formatting -- yearly major ticks, quarterly minors
-    ax2.xaxis.set_major_locator(mdates.YearLocator())
+    # X-axis: fixed 5-year majors at 2020 / 2025 / ... so the axis reads
+    # as a calendar timeline rather than a tight integer scale.
+    ax2.xaxis.set_major_locator(mdates.YearLocator(base=5, month=1, day=1))
     ax2.xaxis.set_major_formatter(mdates.DateFormatter("%Y"))
-    ax2.xaxis.set_minor_locator(mdates.MonthLocator(bymonth=[1, 4, 7, 10]))
+    ax2.xaxis.set_minor_locator(mdates.YearLocator(base=1))
 
-    # Pad the x-axis to cover the full release -> EOL span
-    earliest = min(r.product.release_date for r in results)
-    latest = max(r.product.eol_date for r in results)
-    span_days = (latest - earliest).days
-    pad = max(120, span_days // 30)
-    from datetime import timedelta
-    ax2.set_xlim(earliest - timedelta(days=pad), latest + timedelta(days=pad))
+    # Anchor x-axis to a fixed 2020 -> 2040 window so the bars sit on a
+    # roadmap-style timeline regardless of which SKUs are present.
+    ax2.set_xlim(date(2020, 1, 1), date(2040, 1, 1))
 
     plt.tight_layout(rect=[0, 0, 1, 0.96])
     plt.savefig(out, dpi=120, bbox_inches="tight")

--- a/cli/analyze_jetson_roadmap.py
+++ b/cli/analyze_jetson_roadmap.py
@@ -90,6 +90,7 @@ import torch
 import torch.nn as nn
 
 from graphs.estimation.unified_analyzer import UnifiedAnalyzer
+from graphs.hardware.mappers.cpu import create_ampere_ampereone_192_mapper
 from graphs.hardware.mappers.gpu import (
     create_jetson_orin_agx_64gb_mapper,
     create_jetson_thor_128gb_mapper,
@@ -131,7 +132,7 @@ def build_workload(width: int) -> tuple[nn.Module, torch.Tensor, str]:
 # ---------------------------------------------------------------------------
 
 @dataclass
-class JetsonProduct:
+class RoadmapProduct:
     """One Jetson industrial SKU on the roadmap.
 
     ``factory`` is ``None`` for SKUs whose silicon doesn't have a
@@ -161,8 +162,8 @@ class JetsonProduct:
 # The four-generation industrial-grade Jetson lineage. Dates / EOLs in
 # the module docstring above. Chart x-axis is year-resolution; the day
 # of the month is illustrative.
-JETSONS: List[JetsonProduct] = [
-    JetsonProduct(
+PRODUCTS: List[RoadmapProduct] = [
+    RoadmapProduct(
         name="Jetson TX2i",
         factory=None,  # Pascal resource model not in catalog yet
         release_date=date(2018, 4, 24),
@@ -172,7 +173,7 @@ JETSONS: List[JetsonProduct] = [
         color="#9467bd",   # tab:purple
         marker="D",
     ),
-    JetsonProduct(
+    RoadmapProduct(
         name="Jetson AGX Xavier Industrial",
         factory=None,  # Volta resource model not in catalog yet
         release_date=date(2021, 7, 1),
@@ -182,7 +183,7 @@ JETSONS: List[JetsonProduct] = [
         color="#ff7f0e",   # tab:orange
         marker="s",
     ),
-    JetsonProduct(
+    RoadmapProduct(
         name="Jetson AGX Orin Industrial",
         factory=create_jetson_orin_agx_64gb_mapper,
         release_date=date(2023, 6, 1),  # COMPUTEX 2023 May 29; mid-2023 GA
@@ -193,7 +194,7 @@ JETSONS: List[JetsonProduct] = [
         marker="o",
         factory_proxy_note="Mapper proxy: AGX Orin 64GB commercial",
     ),
-    JetsonProduct(
+    RoadmapProduct(
         name="IGX T5000",
         factory=create_jetson_thor_128gb_mapper,
         release_date=date(2025, 12, 1),  # IGX T5000 SoM GA Dec 2025
@@ -204,6 +205,23 @@ JETSONS: List[JetsonProduct] = [
         marker="^",
         factory_proxy_note="Mapper proxy: Jetson T5000 commercial (same silicon)",
     ),
+    # Reference data point: a 192-core ARM server CPU sized roughly the
+    # same calendar window as the Orin / Thor industrial generation.
+    # Included to sanity-check what the CPU mapper does with a single
+    # batch=1 Linear -- naively splitting 4M weights across 192 cores
+    # would leave each core with ~21K weights of work, well below any
+    # reasonable per-core efficiency floor; the mapper should resolve
+    # this as a single-core (or few-core) job, not a 192-way fanout.
+    RoadmapProduct(
+        name="Ampere AmpereOne A192",
+        factory=create_ampere_ampereone_192_mapper,
+        release_date=date(2024, 5, 1),  # AmpereOne A192-32X general availability
+        eol_date=date(2031, 5, 1),  # estimate: ~7y server lifecycle (no published EOL)
+        architecture="ARM v8.6+ (192c)",
+        process_node="TSMC 5nm",
+        color="#d62728",   # tab:red
+        marker="v",
+    ),
 ]
 
 
@@ -213,7 +231,7 @@ JETSONS: List[JetsonProduct] = [
 
 @dataclass
 class ProductResult:
-    product: JetsonProduct
+    product: RoadmapProduct
     latency_ms: float
     energy_mj: float
     tdp_w: float
@@ -222,7 +240,7 @@ class ProductResult:
 
 
 def analyze(
-    product: JetsonProduct,
+    product: RoadmapProduct,
     model: nn.Module,
     input_tensor: torch.Tensor,
     precision: Precision,
@@ -354,7 +372,7 @@ def write_plot(
 
     # Title
     fig.suptitle(
-        f"NVIDIA Jetson roadmap @ {precision_label}\n"
+        f"Compute roadmap @ {precision_label}\n"
         f"Workload: {workload_name}",
         fontsize=12, y=0.995,
     )
@@ -409,6 +427,17 @@ def write_plot(
     # roadmap-style timeline regardless of which SKUs are present.
     ax2.set_xlim(date(2020, 1, 1), date(2040, 1, 1))
 
+    # Y-axis: float each bar with whitespace above and below the metric
+    # range. matplotlib's auto-ylim hugs the data tightly with thick
+    # hlines, which makes the top/bottom bars look like they're glued
+    # to the axis. 18% margin gives every bar visual breathing room.
+    for ax, get in ((ax1, lambda r: r.perf_inf_per_s),
+                    (ax2, lambda r: r.intelligence_inf_per_j)):
+        ys = [get(r) for r in results]
+        ymin, ymax = min(ys), max(ys)
+        span = max(ymax - ymin, ymax * 0.1)  # avoid zero-span if all equal
+        ax.set_ylim(ymin - 0.18 * span, ymax + 0.18 * span)
+
     plt.tight_layout(rect=[0, 0, 1, 0.96])
     plt.savefig(out, dpi=120, bbox_inches="tight")
     print(f"info: wrote {out}", file=sys.stderr)
@@ -457,8 +486,8 @@ def main() -> int:
     print(file=sys.stderr)
 
     results: List[ProductResult] = []
-    skipped: List[JetsonProduct] = []
-    for p in JETSONS:
+    skipped: List[RoadmapProduct] = []
+    for p in PRODUCTS:
         if p.factory is None:
             skipped.append(p)
             print(

--- a/cli/analyze_jetson_roadmap.py
+++ b/cli/analyze_jetson_roadmap.py
@@ -90,10 +90,7 @@ import torch
 import torch.nn as nn
 
 from graphs.estimation.unified_analyzer import UnifiedAnalyzer
-from graphs.hardware.mappers.accelerators.kpu import (
-    create_kpu_t64_mapper,
-    create_kpu_t256_mapper,
-)
+from graphs.hardware.mappers.accelerators.kpu import create_kpu_t64_mapper
 from graphs.hardware.mappers.cpu import (
     create_ampere_ampereone_1core_reference_mapper,
 )
@@ -234,9 +231,9 @@ PRODUCTS: List[RoadmapProduct] = [
         color="#8c564b",   # tab:brown
         marker="x",
     ),
-    # KPU reference SKUs. KPU release dates are forward-looking per the
-    # spec ("KPU release dates will be 2027, 2028, 2029"); placing T64
-    # at 2027 and T256 at 2029 with overlapping availability windows.
+    # KPU reference SKU. T64 alone is enough to make the comparison
+    # legible (it already beats Thor on this workload). T256 deferred
+    # until the avg_power-vs-TDP modeling fix lands.
     RoadmapProduct(
         name="Stillwater KPU-T64",
         factory=create_kpu_t64_mapper,
@@ -246,16 +243,6 @@ PRODUCTS: List[RoadmapProduct] = [
         process_node="TSMC 16FFP",
         color="#9467bd",   # tab:purple
         marker="P",
-    ),
-    RoadmapProduct(
-        name="Stillwater KPU-T256",
-        factory=create_kpu_t256_mapper,
-        release_date=date(2029, 1, 1),
-        eol_date=date(2039, 1, 1),
-        architecture="KPU domain-flow (256 tiles)",
-        process_node="TSMC 16FFP",
-        color="#17becf",   # tab:cyan
-        marker="*",
     ),
 ]
 

--- a/cli/analyze_jetson_roadmap.py
+++ b/cli/analyze_jetson_roadmap.py
@@ -144,6 +144,7 @@ class JetsonProduct:
     name: str
     factory: Optional[Callable]
     release_date: date
+    eol_date: date
     architecture: str
     process_node: str
     color: str
@@ -165,6 +166,7 @@ JETSONS: List[JetsonProduct] = [
         name="Jetson TX2i",
         factory=None,  # Pascal resource model not in catalog yet
         release_date=date(2018, 4, 24),
+        eol_date=date(2027, 7, 1),  # LTS Jul 2027 (PCN-accelerated, see docstring)
         architecture="Pascal",
         process_node="TSMC 16FF",
         color="#9467bd",   # tab:purple
@@ -174,6 +176,7 @@ JETSONS: List[JetsonProduct] = [
         name="Jetson AGX Xavier Industrial",
         factory=None,  # Volta resource model not in catalog yet
         release_date=date(2021, 7, 1),
+        eol_date=date(2027, 7, 1),  # LTS Jul 2027 (PCN-accelerated, see docstring)
         architecture="Volta",
         process_node="TSMC 12FFN",
         color="#ff7f0e",   # tab:orange
@@ -183,6 +186,7 @@ JETSONS: List[JetsonProduct] = [
         name="Jetson AGX Orin Industrial",
         factory=create_jetson_orin_agx_64gb_mapper,
         release_date=date(2023, 6, 1),  # COMPUTEX 2023 May 29; mid-2023 GA
+        eol_date=date(2033, 7, 1),  # Lifecycle commitment Jul 2033
         architecture="Ampere",
         process_node="Samsung 8nm",
         color="#1f77b4",   # tab:blue
@@ -193,6 +197,7 @@ JETSONS: List[JetsonProduct] = [
         name="IGX T5000",
         factory=create_jetson_thor_128gb_mapper,
         release_date=date(2025, 12, 1),  # IGX T5000 SoM GA Dec 2025
+        eol_date=date(2035, 8, 1),  # Lifecycle commitment Aug 2035
         architecture="Blackwell",
         process_node="TSMC 4NP",
         color="#2ca02c",   # tab:green
@@ -266,6 +271,7 @@ def _row_dict(r: ProductResult) -> dict:
     return {
         "name": r.product.name,
         "release_date": r.product.release_date.isoformat(),
+        "eol_date": r.product.eol_date.isoformat(),
         "architecture": r.product.architecture,
         "process_node": r.product.process_node,
         "tdp_w": r.tdp_w,
@@ -279,7 +285,7 @@ def _row_dict(r: ProductResult) -> dict:
 
 
 _FIELDS = [
-    "name", "release_date", "architecture", "process_node",
+    "name", "release_date", "eol_date", "architecture", "process_node",
     "tdp_w", "latency_ms", "energy_per_inference_mj",
     "avg_power_w_during_inference",
     "perf_inferences_per_sec",
@@ -353,55 +359,57 @@ def write_plot(
         fontsize=12, y=0.995,
     )
 
-    # Panel 1: throughput
-    for r in results:
+    def _draw_lifecycle_bar(ax, r: ProductResult, y: float, with_label: bool) -> None:
+        """Horizontal bar from release_date to EOL at metric y-value.
+
+        Bars communicate the *application window* of each SKU: the period
+        where it can actually be designed in. Filled marker at the
+        release-date end (start of availability), open marker at EOL."""
         legend_label = (
             f"{r.product.short_name()} -- "
             f"{r.product.architecture} on {r.product.process_node}, "
-            f"{r.tdp_w:.0f}W"
-        )
-        ax1.scatter(
-            [r.product.release_date], [r.perf_inf_per_s],
-            c=r.product.color, marker=r.product.marker, s=220,
-            edgecolors="black", linewidth=1.2, zorder=3,
+            f"{r.tdp_w:.0f}W "
+            f"({r.product.release_date.year}-{r.product.eol_date.year})"
+        ) if with_label else None
+        ax.hlines(
+            y=y,
+            xmin=r.product.release_date,
+            xmax=r.product.eol_date,
+            color=r.product.color, linewidth=8, alpha=0.85, zorder=2,
             label=legend_label,
         )
-        ax1.annotate(
-            r.product.short_name(),
-            xy=(r.product.release_date, r.perf_inf_per_s),
-            xytext=(10, -4), textcoords="offset points", fontsize=9,
+        # Filled marker at release (in-market start)
+        ax.scatter(
+            [r.product.release_date], [y],
+            c=r.product.color, marker=r.product.marker, s=160,
+            edgecolors="black", linewidth=1.0, zorder=3,
         )
-    # Connect points with a thin line so the trajectory reads
-    ax1.plot(
-        [r.product.release_date for r in results],
-        [r.perf_inf_per_s for r in results],
-        color="gray", linestyle=":", linewidth=1, alpha=0.5, zorder=1,
-    )
+        # Open marker at EOL (end-of-availability)
+        ax.scatter(
+            [r.product.eol_date], [y],
+            facecolors="white", edgecolors=r.product.color,
+            marker=r.product.marker, s=120, linewidth=1.5, zorder=3,
+        )
+        ax.annotate(
+            r.product.short_name(),
+            xy=(r.product.release_date, y),
+            xytext=(8, 8), textcoords="offset points", fontsize=9,
+        )
+
+    # Panel 1: throughput
+    for r in results:
+        _draw_lifecycle_bar(ax1, r, r.perf_inf_per_s, with_label=True)
     ax1.set_ylabel("Sustained throughput (inferences / sec)")
-    ax1.set_title("Performance: sustained inferences/sec")
+    ax1.set_title("Performance over availability window: release date -> EOL")
     ax1.grid(True, alpha=0.3)
     ax1.legend(loc="upper left", fontsize=9, framealpha=0.95)
 
-    # Panel 2: intelligence/Watt
+    # Panel 2: energy efficiency
     for r in results:
-        ax2.scatter(
-            [r.product.release_date], [r.intelligence_inf_per_j],
-            c=r.product.color, marker=r.product.marker, s=220,
-            edgecolors="black", linewidth=1.2, zorder=3,
-        )
-        ax2.annotate(
-            r.product.short_name(),
-            xy=(r.product.release_date, r.intelligence_inf_per_j),
-            xytext=(10, -4), textcoords="offset points", fontsize=9,
-        )
-    ax2.plot(
-        [r.product.release_date for r in results],
-        [r.intelligence_inf_per_j for r in results],
-        color="gray", linestyle=":", linewidth=1, alpha=0.5, zorder=1,
-    )
+        _draw_lifecycle_bar(ax2, r, r.intelligence_inf_per_j, with_label=False)
     ax2.set_ylabel("Energy efficiency (inferences / joule)")
-    ax2.set_title("Efficiency: process + architecture impact on energy per inference")
-    ax2.set_xlabel("Release date")
+    ax2.set_title("Efficiency over availability window: process + architecture impact")
+    ax2.set_xlabel("Calendar year (filled = release / GA, open = EOL)")
     ax2.grid(True, alpha=0.3)
 
     # X-axis formatting -- yearly major ticks, quarterly minors
@@ -409,11 +417,11 @@ def write_plot(
     ax2.xaxis.set_major_formatter(mdates.DateFormatter("%Y"))
     ax2.xaxis.set_minor_locator(mdates.MonthLocator(bymonth=[1, 4, 7, 10]))
 
-    # Pad the x-axis a bit on each side
+    # Pad the x-axis to cover the full release -> EOL span
     earliest = min(r.product.release_date for r in results)
-    latest = max(r.product.release_date for r in results)
+    latest = max(r.product.eol_date for r in results)
     span_days = (latest - earliest).days
-    pad = max(120, span_days // 10)
+    pad = max(120, span_days // 30)
     from datetime import timedelta
     ax2.set_xlim(earliest - timedelta(days=pad), latest + timedelta(days=pad))
 

--- a/cli/jetson_roadmap.py
+++ b/cli/jetson_roadmap.py
@@ -1,32 +1,72 @@
 #!/usr/bin/env python
-"""NVIDIA Jetson roadmap visualization.
+"""NVIDIA Jetson **industrial** roadmap visualization (embodied / industrial AI).
 
-Plots sustained throughput and intelligence-per-Watt for a single
-``Linear(D, D) + bias + atan(.)`` workload at batch=1, across the three
-relevant Jetson products in chronological release order:
+Targets the four-generation industrial-grade Jetson lineage. Verified
+2026-05-13:
 
-  * Jetson AGX Orin 64GB    (Mar 2022 announce, 2022-Q2 GA, Ampere on Samsung 8nm)
-  * Jetson Orin NX 16GB     (Sep 2022 announce, 2023-Q1 GA, Ampere on Samsung 8nm)
-  * Jetson AGX Thor 128GB   (GTC 2024 announce, 2025 GA, Blackwell on TSMC 4NP)
+  | SKU                          | GPU arch  | Process     | GA date         | EOL                       |
+  |------------------------------|-----------|-------------|-----------------|---------------------------|
+  | Jetson TX2i                  | Pascal    | TSMC 16FF   | Apr 2018        | LTB Jul 2026 / LTS Jul 2027 |
+  | Jetson AGX Xavier Industrial | Volta     | TSMC 12FFN  | Jul 2021        | LTB Jul 2026 / LTS Jul 2027 |
+  | Jetson AGX Orin Industrial   | Ampere    | Samsung 8nm | Mid 2023        | Active (lifecycle through Jul 2033) |
+  | IGX T5000 (Thor industrial)  | Blackwell | TSMC 4NP    | Dec 2025        | Active (lifecycle through Aug 2035) |
 
-Workload: a ``Linear(2048, 2048)`` (4M weights = 4 MB at INT8) plus the
-bias add and an elementwise atan activation. At batch=1 this is solidly
-memory-bandwidth bound on every Jetson (the matrix has to stream from
-LPDDR; on-chip L2 is 2-8 MB and the GPU L2 isn't modeled as a coherent
-weight pool -- per-launch L2 set-aside on Hopper+ isn't covered yet). The
-operator fuses into one subgraph so the 2K-element activation vectors
-stay in registers / shared memory; only the weight matrix and the
-external input/output activations cross the DRAM boundary.
+Sources:
+  TX2i:                  https://forums.developer.nvidia.com/t/jetson-product-eol-updates/370052
+  AGX Xavier Industrial: https://blogs.nvidia.com/blog/jetson-agx-xavier-industrial-use-ai/
+  AGX Orin Industrial:   https://developer.nvidia.com/blog/step-into-the-future-of-industrial-grade-edge-ai-with-nvidia-jetson-agx-orin-industrial
+  IGX T5000:             https://blogs.nvidia.com/blog/igx-thor-processor-physical-ai-industrial-medical-edge/
+  Jetson T5000 (commercial Thor module that IGX T5000 derives from):
+                         https://nvidianews.nvidia.com/news/nvidia-blackwell-powered-jetson-thor-now-available-accelerating-the-age-of-general-robotics
+
+Caveats worth keeping in mind for any slide based on this output:
+
+  1. **Thor industrial branding is split.** NVIDIA does not yet ship a
+     SKU literally named "Jetson AGX Thor Industrial." The industrial /
+     medical-grade Blackwell-Thor platform is **IGX Thor** (IGX T5000
+     SoM, IGX T7000 board kit). The commercial **Jetson T5000** module
+     (Aug 2025 GA) is the same silicon but is NOT industrial-grade
+     (no extended-temp / ECC / functional-safety guarantees). DRIVE AGX
+     Thor (automotive) is dev-kit-only.
+  2. **TX2i / Xavier Industrial EOLs were both accelerated** in an April
+     2026 PCN due to LPDDR4 manufacturer EOL. NVIDIA's lifecycle page
+     may still show stale "available through 2031" entries -- treat the
+     forum PCN as authoritative.
+  3. **No resource models exist in the graphs/ catalog for TX2 or Xavier
+     yet.** This script lists those SKUs as the slide's *intent* but
+     skips them at analysis time with a console warning. Adding TX2
+     (Pascal, 16nm) + Xavier (Volta, 12nm) resource models is tracked
+     separately. The two we do have are mapped via the commercial-grade
+     mapper as a proxy for the industrial sibling -- same silicon,
+     different binning / temp grade / package; performance and energy
+     per workload are essentially identical.
+
+Workload: ``Linear(2048, 2048) + bias + atan`` at batch=1.
+4M weights = 4 MB at INT8. At batch=1 this is solidly memory-bandwidth
+bound on every Jetson (the matrix has to stream from LPDDR; on-chip L2
+is 2-8 MB and the GPU L2 isn't modeled as a coherent weight pool --
+per-launch L2 set-aside on Hopper+ isn't covered here). The operator
+fuses into one subgraph so the 2K-element activation vectors stay in
+registers / shared memory; only the weight matrix and the external
+input/output activations cross the DRAM boundary.
 
 Two metrics are plotted vs release date:
 
   * **Sustained throughput** (inferences / sec) -- 1 / latency
-  * **Intelligence per Watt** (inferences / joule) -- 1 / energy_per_inference
+  * **Energy efficiency** (inferences / joule) -- 1 / energy_per_inference
 
 Both are derived from the existing roofline + energy model
 (``UnifiedAnalyzer``); no measurement here. Each chip is analyzed with
 its mapper's default thermal profile (the closest thing to "stock"
 behavior) and the per-chip TDP appears in the legend for context.
+
+**Note on terminology**: "intelligence per Watt" in NVIDIA's marketing is
+``throughput / TDP`` (industry convention). That's a different number
+from ``inferences / joule`` because the chip rarely runs at its full TDP
+on a small workload; the model here estimates average power as
+``energy / latency``, which for this workload is well below TDP. The
+CSV output includes both metrics so you can pick the framing that
+matches your slide.
 
 Usage:
   python cli/jetson_roadmap.py --output jetson_roadmap.png
@@ -50,7 +90,6 @@ import torch.nn as nn
 from graphs.estimation.unified_analyzer import UnifiedAnalyzer
 from graphs.hardware.mappers.gpu import (
     create_jetson_orin_agx_64gb_mapper,
-    create_jetson_orin_nx_16gb_mapper,
     create_jetson_thor_128gb_mapper,
 )
 from graphs.hardware.resource_model import Precision
@@ -91,50 +130,72 @@ def build_workload(width: int) -> tuple[nn.Module, torch.Tensor, str]:
 
 @dataclass
 class JetsonProduct:
-    """One Jetson on the roadmap."""
+    """One Jetson industrial SKU on the roadmap.
+
+    ``factory`` is ``None`` for SKUs whose silicon doesn't have a
+    resource model in the catalog yet (TX2 / Pascal, Xavier / Volta);
+    those rows still document the slide's intent but are skipped at
+    analysis time with a console warning. ``factory_proxy_note`` says
+    which commercial-grade mapper stands in for the industrial sibling
+    when the two share silicon."""
 
     name: str
-    factory: Callable
+    factory: Optional[Callable]
     release_date: date
     architecture: str
     process_node: str
     color: str
     marker: str
+    factory_proxy_note: str = ""
 
     def short_name(self) -> str:
-        return self.name.replace("Jetson ", "").replace(" 64GB", "").replace(" 16GB", "").replace(" 128GB", "")
+        return (
+            self.name.replace("Jetson ", "")
+            .replace(" Industrial", " Ind.")
+        )
 
 
-# Release dates: announced-at-GTC dates rather than discrete-product GA
-# (which varies by region / form factor / partner). Chart x-axis is
-# year-resolution-ish so a few months of slop doesn't matter.
+# The four-generation industrial-grade Jetson lineage. Dates / EOLs in
+# the module docstring above. Chart x-axis is year-resolution; the day
+# of the month is illustrative.
 JETSONS: List[JetsonProduct] = [
     JetsonProduct(
-        name="Jetson AGX Orin 64GB",
+        name="Jetson TX2i",
+        factory=None,  # Pascal resource model not in catalog yet
+        release_date=date(2018, 4, 24),
+        architecture="Pascal",
+        process_node="TSMC 16FF",
+        color="#9467bd",   # tab:purple
+        marker="D",
+    ),
+    JetsonProduct(
+        name="Jetson AGX Xavier Industrial",
+        factory=None,  # Volta resource model not in catalog yet
+        release_date=date(2021, 7, 1),
+        architecture="Volta",
+        process_node="TSMC 12FFN",
+        color="#ff7f0e",   # tab:orange
+        marker="s",
+    ),
+    JetsonProduct(
+        name="Jetson AGX Orin Industrial",
         factory=create_jetson_orin_agx_64gb_mapper,
-        release_date=date(2022, 4, 1),
+        release_date=date(2023, 6, 1),  # COMPUTEX 2023 May 29; mid-2023 GA
         architecture="Ampere",
         process_node="Samsung 8nm",
         color="#1f77b4",   # tab:blue
         marker="o",
+        factory_proxy_note="Mapper proxy: AGX Orin 64GB commercial",
     ),
     JetsonProduct(
-        name="Jetson Orin NX 16GB",
-        factory=create_jetson_orin_nx_16gb_mapper,
-        release_date=date(2023, 1, 1),
-        architecture="Ampere",
-        process_node="Samsung 8nm",
-        color="#1f77b4",   # tab:blue (same architecture)
-        marker="s",
-    ),
-    JetsonProduct(
-        name="Jetson AGX Thor 128GB",
+        name="IGX T5000",
         factory=create_jetson_thor_128gb_mapper,
-        release_date=date(2025, 9, 1),
+        release_date=date(2025, 12, 1),  # IGX T5000 SoM GA Dec 2025
         architecture="Blackwell",
         process_node="TSMC 4NP",
         color="#2ca02c",   # tab:green
         marker="^",
+        factory_proxy_note="Mapper proxy: Jetson T5000 commercial (same silicon)",
     ),
 ]
 
@@ -199,12 +260,17 @@ def write_csv(results: List[ProductResult], out: Path) -> None:
     fields = [
         "name", "release_date", "architecture", "process_node",
         "tdp_w", "latency_ms", "energy_per_inference_mj",
-        "perf_inferences_per_sec", "intelligence_inferences_per_joule",
+        "avg_power_w_during_inference",
+        "perf_inferences_per_sec",
+        "energy_efficiency_inferences_per_joule",
+        "throughput_per_tdp_inferences_per_sec_per_w",
     ]
     with out.open("w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fields)
         writer.writeheader()
         for r in results:
+            avg_power_w = r.energy_mj / r.latency_ms if r.latency_ms > 0 else 0.0
+            throughput_per_tdp = r.perf_inf_per_s / r.tdp_w if r.tdp_w > 0 else 0.0
             writer.writerow({
                 "name": r.product.name,
                 "release_date": r.product.release_date.isoformat(),
@@ -213,8 +279,10 @@ def write_csv(results: List[ProductResult], out: Path) -> None:
                 "tdp_w": r.tdp_w,
                 "latency_ms": round(r.latency_ms, 3),
                 "energy_per_inference_mj": round(r.energy_mj, 3),
+                "avg_power_w_during_inference": round(avg_power_w, 2),
                 "perf_inferences_per_sec": round(r.perf_inf_per_s, 1),
-                "intelligence_inferences_per_joule": round(r.intelligence_inf_per_j, 1),
+                "energy_efficiency_inferences_per_joule": round(r.intelligence_inf_per_j, 1),
+                "throughput_per_tdp_inferences_per_sec_per_w": round(throughput_per_tdp, 1),
             })
     print(f"info: wrote {out}", file=sys.stderr)
 
@@ -285,8 +353,8 @@ def write_plot(
         [r.intelligence_inf_per_j for r in results],
         color="gray", linestyle=":", linewidth=1, alpha=0.5, zorder=1,
     )
-    ax2.set_ylabel("Intelligence per Watt (inferences / joule)")
-    ax2.set_title("Efficiency: process + architecture impact on intelligence-per-Watt")
+    ax2.set_ylabel("Energy efficiency (inferences / joule)")
+    ax2.set_title("Efficiency: process + architecture impact on energy per inference")
     ax2.set_xlabel("Release date")
     ax2.grid(True, alpha=0.3)
 
@@ -351,16 +419,34 @@ def main() -> int:
     print(file=sys.stderr)
 
     results: List[ProductResult] = []
+    skipped: List[JetsonProduct] = []
     for p in JETSONS:
+        if p.factory is None:
+            skipped.append(p)
+            print(
+                f"  {p.short_name():28s} SKIPPED -- no resource model in catalog "
+                f"({p.architecture}, {p.process_node})",
+                file=sys.stderr,
+            )
+            continue
         r = analyze(p, model, input_tensor, precision, workload_name)
         results.append(r)
         print(
-            f"  {p.short_name():22s} "
+            f"  {p.short_name():28s} "
             f"{r.tdp_w:5.1f}W  "
             f"{r.latency_ms:7.3f} ms  "
             f"{r.energy_mj:7.3f} mJ  "
             f"-> {r.perf_inf_per_s:8.1f} inf/s, "
             f"{r.intelligence_inf_per_j:8.1f} inf/J",
+            file=sys.stderr,
+        )
+
+    if skipped:
+        print(
+            f"\nnote: {len(skipped)} SKU(s) skipped because their silicon's "
+            "resource model is not in the graphs/ catalog yet. The chart's "
+            "data series only covers the analyzable products; the SKU table "
+            "in this script's docstring documents the full intended roadmap.",
             file=sys.stderr,
         )
 

--- a/cli/jetson_roadmap.py
+++ b/cli/jetson_roadmap.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python
+"""NVIDIA Jetson roadmap visualization.
+
+Plots sustained throughput and intelligence-per-Watt for a single
+``Linear(D, D) + bias + atan(.)`` workload at batch=1, across the three
+relevant Jetson products in chronological release order:
+
+  * Jetson AGX Orin 64GB    (Mar 2022 announce, 2022-Q2 GA, Ampere on Samsung 8nm)
+  * Jetson Orin NX 16GB     (Sep 2022 announce, 2023-Q1 GA, Ampere on Samsung 8nm)
+  * Jetson AGX Thor 128GB   (GTC 2024 announce, 2025 GA, Blackwell on TSMC 4NP)
+
+Workload: a ``Linear(2048, 2048)`` (4M weights = 4 MB at INT8) plus the
+bias add and an elementwise atan activation. At batch=1 this is solidly
+memory-bandwidth bound on every Jetson (the matrix has to stream from
+LPDDR; on-chip L2 is 2-8 MB and the GPU L2 isn't modeled as a coherent
+weight pool -- per-launch L2 set-aside on Hopper+ isn't covered yet). The
+operator fuses into one subgraph so the 2K-element activation vectors
+stay in registers / shared memory; only the weight matrix and the
+external input/output activations cross the DRAM boundary.
+
+Two metrics are plotted vs release date:
+
+  * **Sustained throughput** (inferences / sec) -- 1 / latency
+  * **Intelligence per Watt** (inferences / joule) -- 1 / energy_per_inference
+
+Both are derived from the existing roofline + energy model
+(``UnifiedAnalyzer``); no measurement here. Each chip is analyzed with
+its mapper's default thermal profile (the closest thing to "stock"
+behavior) and the per-chip TDP appears in the legend for context.
+
+Usage:
+  python cli/jetson_roadmap.py --output jetson_roadmap.png
+  python cli/jetson_roadmap.py --output jetson_roadmap.csv
+  python cli/jetson_roadmap.py --precision int8 --output roadmap_int8.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Callable, List, Optional
+
+import torch
+import torch.nn as nn
+
+from graphs.estimation.unified_analyzer import UnifiedAnalyzer
+from graphs.hardware.mappers.gpu import (
+    create_jetson_orin_agx_64gb_mapper,
+    create_jetson_orin_nx_16gb_mapper,
+    create_jetson_thor_128gb_mapper,
+)
+from graphs.hardware.resource_model import Precision
+
+
+# ---------------------------------------------------------------------------
+# Workload
+# ---------------------------------------------------------------------------
+
+class Atan(nn.Module):
+    """Elementwise atan as a Module so torch.fx can trace it cleanly."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.atan(x)
+
+
+def build_workload(width: int) -> tuple[nn.Module, torch.Tensor, str]:
+    """Linear(width, width) + bias + atan, batch=1.
+
+    Default width=2048 -> 4,194,304 weights ~= 4 M, the spec's "medium
+    sized linear operator" target. Returns the model, the input tensor,
+    and a display name for the chart.
+    """
+    model = nn.Sequential(
+        nn.Linear(width, width),
+        Atan(),
+    )
+    model.eval()
+    input_tensor = torch.randn(1, width)
+    weights = width * width
+    label = f"Linear({width}x{width})+bias+atan ({weights / 1e6:.1f}M weights, batch=1)"
+    return model, input_tensor, label
+
+
+# ---------------------------------------------------------------------------
+# Product definitions
+# ---------------------------------------------------------------------------
+
+@dataclass
+class JetsonProduct:
+    """One Jetson on the roadmap."""
+
+    name: str
+    factory: Callable
+    release_date: date
+    architecture: str
+    process_node: str
+    color: str
+    marker: str
+
+    def short_name(self) -> str:
+        return self.name.replace("Jetson ", "").replace(" 64GB", "").replace(" 16GB", "").replace(" 128GB", "")
+
+
+# Release dates: announced-at-GTC dates rather than discrete-product GA
+# (which varies by region / form factor / partner). Chart x-axis is
+# year-resolution-ish so a few months of slop doesn't matter.
+JETSONS: List[JetsonProduct] = [
+    JetsonProduct(
+        name="Jetson AGX Orin 64GB",
+        factory=create_jetson_orin_agx_64gb_mapper,
+        release_date=date(2022, 4, 1),
+        architecture="Ampere",
+        process_node="Samsung 8nm",
+        color="#1f77b4",   # tab:blue
+        marker="o",
+    ),
+    JetsonProduct(
+        name="Jetson Orin NX 16GB",
+        factory=create_jetson_orin_nx_16gb_mapper,
+        release_date=date(2023, 1, 1),
+        architecture="Ampere",
+        process_node="Samsung 8nm",
+        color="#1f77b4",   # tab:blue (same architecture)
+        marker="s",
+    ),
+    JetsonProduct(
+        name="Jetson AGX Thor 128GB",
+        factory=create_jetson_thor_128gb_mapper,
+        release_date=date(2025, 9, 1),
+        architecture="Blackwell",
+        process_node="TSMC 4NP",
+        color="#2ca02c",   # tab:green
+        marker="^",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ProductResult:
+    product: JetsonProduct
+    latency_ms: float
+    energy_mj: float
+    tdp_w: float
+    perf_inf_per_s: float
+    intelligence_inf_per_j: float
+
+
+def analyze(
+    product: JetsonProduct,
+    model: nn.Module,
+    input_tensor: torch.Tensor,
+    precision: Precision,
+    workload_name: str,
+) -> ProductResult:
+    """Run UnifiedAnalyzer on one Jetson; derive perf and intelligence/W."""
+    mapper = product.factory()
+    rm = mapper.resource_model
+    default_profile_name = rm.default_thermal_profile
+    tdp_w = rm.thermal_operating_points[default_profile_name].tdp_watts
+
+    analyzer = UnifiedAnalyzer(verbose=False)
+    result = analyzer.analyze_model_with_custom_hardware(
+        model=model,
+        input_tensor=input_tensor,
+        model_name=workload_name,
+        hardware_mapper=mapper,
+        precision=precision,
+    )
+
+    latency_ms = result.total_latency_ms
+    energy_mj = result.energy_per_inference_mj
+    # batch=1 so 1 inference per call:
+    perf = 1000.0 / latency_ms                  # inferences / sec
+    intelligence = 1000.0 / max(energy_mj, 1e-9)  # inferences / joule
+
+    return ProductResult(
+        product=product,
+        latency_ms=latency_ms,
+        energy_mj=energy_mj,
+        tdp_w=tdp_w,
+        perf_inf_per_s=perf,
+        intelligence_inf_per_j=intelligence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def write_csv(results: List[ProductResult], out: Path) -> None:
+    fields = [
+        "name", "release_date", "architecture", "process_node",
+        "tdp_w", "latency_ms", "energy_per_inference_mj",
+        "perf_inferences_per_sec", "intelligence_inferences_per_joule",
+    ]
+    with out.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for r in results:
+            writer.writerow({
+                "name": r.product.name,
+                "release_date": r.product.release_date.isoformat(),
+                "architecture": r.product.architecture,
+                "process_node": r.product.process_node,
+                "tdp_w": r.tdp_w,
+                "latency_ms": round(r.latency_ms, 3),
+                "energy_per_inference_mj": round(r.energy_mj, 3),
+                "perf_inferences_per_sec": round(r.perf_inf_per_s, 1),
+                "intelligence_inferences_per_joule": round(r.intelligence_inf_per_j, 1),
+            })
+    print(f"info: wrote {out}", file=sys.stderr)
+
+
+def write_plot(
+    results: List[ProductResult],
+    out: Path,
+    workload_name: str,
+    precision_label: str,
+) -> None:
+    import matplotlib.pyplot as plt
+    import matplotlib.dates as mdates
+
+    results = sorted(results, key=lambda r: r.product.release_date)
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(11, 8.5), sharex=True)
+
+    # Title
+    fig.suptitle(
+        f"NVIDIA Jetson roadmap @ {precision_label}\n"
+        f"Workload: {workload_name}",
+        fontsize=12, y=0.995,
+    )
+
+    # Panel 1: throughput
+    for r in results:
+        legend_label = (
+            f"{r.product.short_name()} -- "
+            f"{r.product.architecture} on {r.product.process_node}, "
+            f"{r.tdp_w:.0f}W"
+        )
+        ax1.scatter(
+            [r.product.release_date], [r.perf_inf_per_s],
+            c=r.product.color, marker=r.product.marker, s=220,
+            edgecolors="black", linewidth=1.2, zorder=3,
+            label=legend_label,
+        )
+        ax1.annotate(
+            r.product.short_name(),
+            xy=(r.product.release_date, r.perf_inf_per_s),
+            xytext=(10, -4), textcoords="offset points", fontsize=9,
+        )
+    # Connect points with a thin line so the trajectory reads
+    ax1.plot(
+        [r.product.release_date for r in results],
+        [r.perf_inf_per_s for r in results],
+        color="gray", linestyle=":", linewidth=1, alpha=0.5, zorder=1,
+    )
+    ax1.set_ylabel("Sustained throughput (inferences / sec)")
+    ax1.set_title("Performance: sustained inferences/sec")
+    ax1.grid(True, alpha=0.3)
+    ax1.legend(loc="upper left", fontsize=9, framealpha=0.95)
+
+    # Panel 2: intelligence/Watt
+    for r in results:
+        ax2.scatter(
+            [r.product.release_date], [r.intelligence_inf_per_j],
+            c=r.product.color, marker=r.product.marker, s=220,
+            edgecolors="black", linewidth=1.2, zorder=3,
+        )
+        ax2.annotate(
+            r.product.short_name(),
+            xy=(r.product.release_date, r.intelligence_inf_per_j),
+            xytext=(10, -4), textcoords="offset points", fontsize=9,
+        )
+    ax2.plot(
+        [r.product.release_date for r in results],
+        [r.intelligence_inf_per_j for r in results],
+        color="gray", linestyle=":", linewidth=1, alpha=0.5, zorder=1,
+    )
+    ax2.set_ylabel("Intelligence per Watt (inferences / joule)")
+    ax2.set_title("Efficiency: process + architecture impact on intelligence-per-Watt")
+    ax2.set_xlabel("Release date")
+    ax2.grid(True, alpha=0.3)
+
+    # X-axis formatting -- yearly major ticks, quarterly minors
+    ax2.xaxis.set_major_locator(mdates.YearLocator())
+    ax2.xaxis.set_major_formatter(mdates.DateFormatter("%Y"))
+    ax2.xaxis.set_minor_locator(mdates.MonthLocator(bymonth=[1, 4, 7, 10]))
+
+    # Pad the x-axis a bit on each side
+    earliest = min(r.product.release_date for r in results)
+    latest = max(r.product.release_date for r in results)
+    span_days = (latest - earliest).days
+    pad = max(120, span_days // 10)
+    from datetime import timedelta
+    ax2.set_xlim(earliest - timedelta(days=pad), latest + timedelta(days=pad))
+
+    plt.tight_layout(rect=[0, 0, 1, 0.96])
+    plt.savefig(out, dpi=120, bbox_inches="tight")
+    print(f"info: wrote {out}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+PRECISION_BY_NAME = {
+    "fp32": Precision.FP32,
+    "fp16": Precision.FP16,
+    "int8": Precision.INT8,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--output", required=True,
+        help="Output path. PNG (or any matplotlib format) generates the chart; "
+             ".csv writes the underlying numbers.",
+    )
+    parser.add_argument(
+        "--precision", default="int8", choices=sorted(PRECISION_BY_NAME),
+        help="Inference precision (default int8 -- the only precision all "
+             "three Jetsons declare today; Thor's resource model is INT8-only "
+             "in the current graphs/ catalog. fp16/fp32 work for Orin NX and "
+             "AGX Orin but raise on Thor).",
+    )
+    parser.add_argument(
+        "--width", type=int, default=2048,
+        help="Linear width N (Linear(N, N) -> N^2 weights). "
+             "Default 2048 -> 4M weights.",
+    )
+    args = parser.parse_args()
+
+    precision = PRECISION_BY_NAME[args.precision]
+    model, input_tensor, workload_name = build_workload(args.width)
+
+    print(f"workload: {workload_name}", file=sys.stderr)
+    print(f"precision: {args.precision}", file=sys.stderr)
+    print(file=sys.stderr)
+
+    results: List[ProductResult] = []
+    for p in JETSONS:
+        r = analyze(p, model, input_tensor, precision, workload_name)
+        results.append(r)
+        print(
+            f"  {p.short_name():22s} "
+            f"{r.tdp_w:5.1f}W  "
+            f"{r.latency_ms:7.3f} ms  "
+            f"{r.energy_mj:7.3f} mJ  "
+            f"-> {r.perf_inf_per_s:8.1f} inf/s, "
+            f"{r.intelligence_inf_per_j:8.1f} inf/J",
+            file=sys.stderr,
+        )
+
+    out = Path(args.output)
+    if out.suffix.lower() == ".csv":
+        write_csv(results, out)
+    else:
+        write_plot(results, out, workload_name, args.precision.upper())
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/graphs/hardware/mappers/__init__.py
+++ b/src/graphs/hardware/mappers/__init__.py
@@ -59,6 +59,7 @@ def _init_registry():
         create_amd_epyc_turin_mapper,
         create_ampere_ampereone_192_mapper,
         create_ampere_ampereone_128_mapper,
+        create_ampere_ampereone_1core_reference_mapper,
         create_i7_12700k_mapper,
         create_jetson_orin_agx_cpu_mapper,
     )
@@ -269,6 +270,14 @@ def _init_registry():
             "description": "Ampere AmpereOne (128 cores)",
             "default_tdp_w": 250.0,
             "memory_gb": 512.0,
+        },
+        "Ampere-AmpereOne-1core-ref": {
+            "factory": create_ampere_ampereone_1core_reference_mapper,
+            "category": "cpu",
+            "vendor": "Ampere",
+            "description": "Ampere AmpereOne single-core reference (synthetic, see issue #175)",
+            "default_tdp_w": 5.0,
+            "memory_gb": 64.0,
         },
 
         # =====================================================================

--- a/src/graphs/hardware/mappers/cpu.py
+++ b/src/graphs/hardware/mappers/cpu.py
@@ -1247,6 +1247,29 @@ def create_ampere_ampereone_192_mapper() -> CPUMapper:
     return CPUMapper(model)
 
 
+def create_ampere_ampereone_1core_reference_mapper() -> CPUMapper:
+    """Single-core AmpereOne *reference design* (synthetic).
+
+    NOT a shipping product -- Ampere only sells full-die AmpereOne parts.
+    This factory returns a one-core slice of the same architectural unit
+    (ARM v8.6+ Neoverse-class core, TSMC 5nm, same SIMD width) as a
+    reference data point for sanity-checking what multi-core SKUs
+    "should" look like on workloads that can't fan out across all cores
+    (e.g. batch=1 matvec). Filed as part of the validation strategy on
+    issue #175 (CPU mapper batch=1 fanout overcount).
+
+    See ``ampere_ampereone_1core_reference_resource_model`` for the
+    rationale behind the 5W TDP estimate and the 512 KB L2 / 80 GB/s
+    memory bandwidth choices.
+    """
+    from ..models.datacenter.ampere_ampereone_1core_reference import (
+        ampere_ampereone_1core_reference_resource_model,
+    )
+
+    model = ampere_ampereone_1core_reference_resource_model()
+    return CPUMapper(model)
+
+
 def create_intel_xeon_platinum_8490h_mapper() -> CPUMapper:
     """
     Create CPU mapper for Intel Xeon Platinum 8490H (Sapphire Rapids).

--- a/src/graphs/hardware/models/datacenter/ampere_ampereone_1core_reference.py
+++ b/src/graphs/hardware/models/datacenter/ampere_ampereone_1core_reference.py
@@ -1,0 +1,40 @@
+from .cpu_arm import cpu_arm_resource_model
+from ...resource_model import HardwareResourceModel
+
+
+def ampere_ampereone_1core_reference_resource_model() -> HardwareResourceModel:
+    """Single-core AmpereOne reference design (synthetic).
+
+    NOT a shipping product. Ampere only sells full-die AmpereOne parts
+    (128c / 192c / 96c). This factory returns a one-core slice of the
+    same architectural unit -- same core IP (ARM v8.6+ Neoverse-class),
+    same process node (TSMC 5nm), same per-core SIMD width -- as a
+    reference data point for sanity-checking what the 192-core SKU
+    "should" look like on workloads that can't realistically fan out
+    across all cores (e.g. batch=1 matvec).
+
+    Use case: filed as part of issue #175 (CPU mapper batch=1 fanout
+    overcount). The 192-core SKU should not report 192x the throughput
+    of this single-core reference on a workload that's geometrically
+    incapable of using more than a handful of cores.
+
+    TDP estimate: 350W / 192c = ~1.8 W/core core-side. Round up to 5 W
+    to absorb a per-core share of uncore (memory controllers, mesh
+    interconnect, idle floor). This is an estimate, not a datasheet
+    value -- the real per-core power isn't separately spec'd.
+
+    L2: cpu_arm_resource_model parameterises l2_cache_total as
+    num_cores * 512 KB, so this single-core variant has 512 KB of L2
+    available -- which is exactly what one core would have in isolation.
+    Memory bandwidth: helper's hardcoded 80 GB/s default. A single core
+    can't saturate >100 GB/s anyway, so this is fine for the reference
+    role even though the real AmpereOne datasheet quotes 332.8 GB/s
+    aggregate (separately tracked in issue #175).
+    """
+    return cpu_arm_resource_model(
+        num_cores=1,
+        process_node_nm=5,
+        scalar_freq_ghz=3.6,
+        name_suffix="AmpereOne-1core-ref",
+        tdp_watts=5.0,
+    )

--- a/validation/hardware/test_ampere_ampereone_1core_reference.py
+++ b/validation/hardware/test_ampere_ampereone_1core_reference.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+"""Validate the synthetic AmpereOne 1-core reference mapper.
+
+This is a *reference* design, not a shipping product (Ampere only sells
+full-die parts). The validation has two jobs:
+
+1. Confirm the mapper loads with sane core / cache / bandwidth /
+   precision values that match a one-core slice of an AmpereOne 192.
+
+2. Pin the comparison ratio between the 1-core reference and the
+   192-core SKU on a single batch=1 matvec, which is the workload that
+   surfaced issue #175 (CPU mapper batch=1 fanout overcount). At the
+   time of writing the 192-core reports ~12x the 1-core throughput on
+   this workload -- almost entirely a memory-hierarchy effect (LLC
+   capacity scales with cores), not a compute parallelism effect. If
+   the ratio swings dramatically (e.g. back toward 192x as compute
+   fanout, or down to ~1x if a per-operator cap is added), this test
+   becomes the canary.
+"""
+
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.graphs.estimation.unified_analyzer import UnifiedAnalyzer
+from src.graphs.hardware.mappers.cpu import (
+    create_ampere_ampereone_192_mapper,
+    create_ampere_ampereone_1core_reference_mapper,
+)
+from src.graphs.hardware.resource_model import Precision
+
+
+class Atan(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.atan(x)
+
+
+def test_resource_model_shape() -> bool:
+    """Sanity-check the 1-core reference's resource model."""
+    print("=" * 78)
+    print("Test 1: 1-core reference resource model shape")
+    print("=" * 78)
+
+    mapper = create_ampere_ampereone_1core_reference_mapper()
+    rm = mapper.resource_model
+
+    checks = [
+        ("compute_units == 1", rm.compute_units == 1),
+        ("name carries '1core' marker", "1core" in rm.name.lower()),
+        ("L2 == 512 KB (one core's slice)", rm.l2_cache_total == 512 * 1024),
+        ("peak_bandwidth == 80 GB/s (helper default)",
+         rm.peak_bandwidth == 80e9),
+        ("INT8 supported", Precision.INT8 in rm.precision_profiles),
+        ("INT8 peak ops/sec > 0",
+         rm.precision_profiles[Precision.INT8].peak_ops_per_sec > 0),
+        ("INT8 peak ops/sec < 1 TOPS (one core, not the full die)",
+         rm.precision_profiles[Precision.INT8].peak_ops_per_sec < 1e12),
+    ]
+
+    all_passed = True
+    for name, passed in checks:
+        marker = "PASS" if passed else "FAIL"
+        print(f"  [{marker}] {name}")
+        if not passed:
+            all_passed = False
+    print()
+    return all_passed
+
+
+def test_192_to_1_core_ratio_on_batch1_linear() -> bool:
+    """Pin the 192-core / 1-core throughput ratio on batch=1 matvec.
+
+    This is the regression that locks in issue #175's diagnosis. If the
+    mapper acquires a per-operator concurrency cap, this ratio will
+    drop toward 1.0; if compute fanout is removed entirely, it will
+    converge on the LLC-residency ratio. Either is a real change; the
+    test prints the ratio and gates only on a wide sanity band so it
+    doesn't break under reasonable refinement.
+    """
+    print("=" * 78)
+    print("Test 2: 192-core vs 1-core ratio on batch=1 Linear(2048,2048)+atan")
+    print("=" * 78)
+
+    model = nn.Sequential(nn.Linear(2048, 2048), Atan()).eval()
+    inp = torch.randn(1, 2048)
+
+    a = UnifiedAnalyzer()
+
+    one_core = a.analyze_model_with_custom_hardware(
+        model=model, input_tensor=inp, model_name="lin2k+atan",
+        hardware_mapper=create_ampere_ampereone_1core_reference_mapper(),
+        precision=Precision.INT8,
+    )
+    full_die = a.analyze_model_with_custom_hardware(
+        model=model, input_tensor=inp, model_name="lin2k+atan",
+        hardware_mapper=create_ampere_ampereone_192_mapper(),
+        precision=Precision.INT8,
+    )
+
+    one_core_tp = 1000.0 / one_core.total_latency_ms
+    full_die_tp = 1000.0 / full_die.total_latency_ms
+    ratio = full_die_tp / one_core_tp
+
+    print(f"  1-core ref throughput:   {one_core_tp:>10.0f} inf/s")
+    print(f"  192-core throughput:     {full_die_tp:>10.0f} inf/s")
+    print(f"  ratio (192c / 1c):       {ratio:>10.2f}x")
+    print()
+
+    # Wide sanity band -- the test exists to flag *direction* changes.
+    # Today the ratio is ~12x. A per-operator cap (issue #175) should
+    # pull it toward 1-3x. Naive linear compute fanout would push it
+    # toward 192x. Anything in [1.0, 50] is a defensible regime; outside
+    # that band, we want to know.
+    checks = [
+        ("1-core throughput finite and positive",
+         one_core_tp > 0 and one_core_tp < 1e9),
+        ("192-core throughput finite and positive",
+         full_die_tp > 0 and full_die_tp < 1e9),
+        ("Ratio in [1.0, 50] sanity band (today: ~12x)",
+         1.0 <= ratio <= 50.0),
+    ]
+
+    all_passed = True
+    for name, passed in checks:
+        marker = "PASS" if passed else "FAIL"
+        print(f"  [{marker}] {name}")
+        if not passed:
+            all_passed = False
+    print()
+    return all_passed
+
+
+def main() -> int:
+    print()
+    results = [
+        test_resource_model_shape(),
+        test_192_to_1_core_ratio_on_batch1_linear(),
+    ]
+    print("=" * 78)
+    if all(results):
+        print("All checks PASSED")
+        return 0
+    print(f"FAILED: {sum(1 for r in results if not r)} of {len(results)} checks")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Roadmap-slide visualization showing the process + architecture progression across NVIDIA's Jetson family on a single canonical workload. Ships as a CLI so it can be regenerated as new chips land or as the underlying hardware models get refined.

## What

\`cli/jetson_roadmap.py\` plots two metrics vs release date for three Jetson products:

| Product | Date | Architecture | Process | TDP |
|---|---|---|---|---:|
| AGX Orin 64GB | 2022-04 | Ampere | Samsung 8nm | 30 W |
| Orin NX 16GB  | 2023-01 | Ampere | Samsung 8nm | 25 W |
| AGX Thor 128GB | 2025-09 | Blackwell | TSMC 4NP | 30 W |

**Workload**: \`Linear(2048, 2048) + bias + atan\` at batch=1. 4M weights = 4 MB at INT8, the spec's "medium-sized linear operator" target. At batch=1 this is solidly memory-bandwidth bound on every Jetson — the matrix has to stream from LPDDR; on-chip L2 ranges 2-8 MB and isn't modeled as a coherent weight pool for GPUs (per-launch L2 set-aside on Hopper+ isn't covered yet).

**Metrics** (both derived from \`UnifiedAnalyzer\`'s roofline + energy model):
- **Sustained throughput** (inferences / sec) = 1 / latency
- **Intelligence per Watt** (inferences / joule) = 1 / energy_per_inference

**Output formats**: \`--output roadmap.png\` for the chart, \`--output roadmap.csv\` for the raw numbers.

## Smoke results (INT8, batch=1)

| Product | Latency | Energy | Throughput | Intelligence/W |
|---|---:|---:|---:|---:|
| AGX Orin 64GB | 0.187 ms | 1.75 mJ | **5,340 inf/s** | **571 inf/J** |
| Orin NX 16GB  | 0.168 ms | 1.34 mJ | **5,939 inf/s** | **746 inf/J** |
| AGX Thor 128GB | 0.119 ms | 1.12 mJ | **8,403 inf/s** | **891 inf/J** |

Story:
- Throughput grows from AGX Orin → Orin NX → Thor; Orin NX edges out AGX Orin at small-batch (lower-TDP binning + better narrow-fabric utilization), then Thor's process+architecture jump puts it ~40% above NX.
- **Intelligence/W trends monotonically up: 571 → 746 → 891 inf/J**, ~56% improvement from Ampere/8nm to Blackwell/4nm. This is the headline story for the slide.

## Notes

- Default precision is INT8 because Thor's resource model in the current \`graphs/\` catalog is INT8-only — a known modeling gap for Blackwell's FP4/FP6/FP8/FP16 support that lands in the eventual Thor catalog refresh. The script raises a clear error on Thor if you pass \`--precision fp16\` or \`fp32\`.
- Each chip uses its mapper's default thermal profile (closest thing to "stock"). Per-chip TDP appears in the legend.
- Built on top of PR #172 (CPU weight-stationarity fix) so the future ARM-multi-core + KPU overlays compare honestly against the Jetson streaming model — those overlays will show the cache-resident regime where the whole 4 MB matrix lives in L3 or KPU scratchpad.

## Sample output

PNG: 11x8.5", 120 DPI, 2-panel layout. Top panel: throughput. Bottom panel: intelligence/W. Both panels share the X-axis (release date) with a connecting trajectory line.

## Test plan

- [x] CSV output: 3 rows, fields populated, values match sanity bounds for the workload + bandwidth math
- [x] PNG output: renders cleanly, both panels populated, legend + per-product TDP visible
- [x] FP16 / FP32 raise on Thor (precision-not-supported error path is clear)
- [ ] PR CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI tool for analyzing industrial-grade Jetson device roadmap with performance and efficiency metrics
  * Calculates latency-derived throughput and energy-derived intelligence metrics across device generations
  * Supports multiple output formats: CSV, JSON, Markdown, text tables, and visualization plots
  * Configurable precision levels (fp32, fp16, int8) and custom workload width parameters

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/173)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->