### PR TITLE
feat(hardware): GPU YAML loader -- HardwareResourceModel from ComputeProduct (#171 sprint PR 4/5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,9 @@ jobs:
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
           #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
-          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
+          #   PR #19 (6edda84) ComputeProduct v2: GPUBlock added (KPUBlock + GPUBlock in AnyBlock union)
+          #   PR #20 (cb7d8e2) first GPU SKU YAML: nvidia_jetson_agx_orin_64gb
+          ref: cb7d8e2a489456c71d27aaa8c709c13052407ebc
           path: embodied-schemas
           fetch-depth: 1
 
@@ -159,7 +161,9 @@ jobs:
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
           #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
-          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
+          #   PR #19 (6edda84) ComputeProduct v2: GPUBlock added (KPUBlock + GPUBlock in AnyBlock union)
+          #   PR #20 (cb7d8e2) first GPU SKU YAML: nvidia_jetson_agx_orin_64gb
+          ref: cb7d8e2a489456c71d27aaa8c709c13052407ebc
           path: embodied-schemas
           fetch-depth: 1
 
@@ -259,7 +263,9 @@ jobs:
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
           #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
-          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
+          #   PR #19 (6edda84) ComputeProduct v2: GPUBlock added (KPUBlock + GPUBlock in AnyBlock union)
+          #   PR #20 (cb7d8e2) first GPU SKU YAML: nvidia_jetson_agx_orin_64gb
+          ref: cb7d8e2a489456c71d27aaa8c709c13052407ebc
           path: embodied-schemas
           fetch-depth: 1
 
@@ -356,7 +362,9 @@ jobs:
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
           #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
-          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
+          #   PR #19 (6edda84) ComputeProduct v2: GPUBlock added (KPUBlock + GPUBlock in AnyBlock union)
+          #   PR #20 (cb7d8e2) first GPU SKU YAML: nvidia_jetson_agx_orin_64gb
+          ref: cb7d8e2a489456c71d27aaa8c709c13052407ebc
           path: embodied-schemas
           fetch-depth: 1
 
@@ -426,7 +434,9 @@ jobs:
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
           #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
-          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
+          #   PR #19 (6edda84) ComputeProduct v2: GPUBlock added (KPUBlock + GPUBlock in AnyBlock union)
+          #   PR #20 (cb7d8e2) first GPU SKU YAML: nvidia_jetson_agx_orin_64gb
+          ref: cb7d8e2a489456c71d27aaa8c709c13052407ebc
           path: embodied-schemas
           fetch-depth: 1
 
@@ -484,7 +494,9 @@ jobs:
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
           #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
-          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
+          #   PR #19 (6edda84) ComputeProduct v2: GPUBlock added (KPUBlock + GPUBlock in AnyBlock union)
+          #   PR #20 (cb7d8e2) first GPU SKU YAML: nvidia_jetson_agx_orin_64gb
+          ref: cb7d8e2a489456c71d27aaa8c709c13052407ebc
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,7 +49,9 @@ jobs:
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
           #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
-          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
+          #   PR #19 (6edda84) ComputeProduct v2: GPUBlock added (KPUBlock + GPUBlock in AnyBlock union)
+          #   PR #20 (cb7d8e2) first GPU SKU YAML: nvidia_jetson_agx_orin_64gb
+          ref: cb7d8e2a489456c71d27aaa8c709c13052407ebc
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -98,7 +98,9 @@ jobs:
           #   PR #16 (7babd4c) first ComputeProduct YAML + load_compute_products() loader
           #   PR #17 (845a9f2) remaining 11 KPU SKUs converted to ComputeProduct YAMLs
           #   PR #18 (181d725) retire legacy data/kpus/; load_kpus() becomes shim
-          ref: 181d725e4ab0d29d5c9c89704702fee5ac347ee6
+          #   PR #19 (6edda84) ComputeProduct v2: GPUBlock added (KPUBlock + GPUBlock in AnyBlock union)
+          #   PR #20 (cb7d8e2) first GPU SKU YAML: nvidia_jetson_agx_orin_64gb
+          ref: cb7d8e2a489456c71d27aaa8c709c13052407ebc
           path: embodied-schemas
           fetch-depth: 1
 

--- a/cli/validate_sku.py
+++ b/cli/validate_sku.py
@@ -169,17 +169,43 @@ def _run_catalog_sweep(args: argparse.Namespace, validator_count: int) -> int:
     """Phase 6 catalog gate -- iterate over every KPU SKU and report
     a per-SKU table to stdout. Returns non-zero on any ERROR finding
     (or any WARNING if ``--strict``).
+
+    Scoped to KPU SKUs because every registered validator today is
+    KPU-shaped (assumes ``KPUBlock`` with ``total_tiles`` / ``tiles``).
+    GPU SKUs joined the catalog in v2 (e.g.
+    ``nvidia_jetson_agx_orin_64gb`` from embodied-schemas#20) and would
+    crash these validators. GPU-shaped validators are a separate
+    follow-up; until they exist this gate skips non-KPU products.
     """
     from graphs.hardware.compute_product_loader import load_compute_products_unified
     try:
-        kpus = load_compute_products_unified()
+        all_products = load_compute_products_unified()
     except Exception as exc:
         print(f"error: failed to load KPU catalog: {exc}", file=sys.stderr)
         return 2
 
+    def _kind_str(block) -> str:
+        kind = block.kind
+        raw = kind.value if hasattr(kind, "value") else kind
+        return str(raw).strip().lower()
+
+    kpus = {
+        sku: cp for sku, cp in all_products.items()
+        if cp.dies and cp.dies[0].blocks
+        and _kind_str(cp.dies[0].blocks[0]) == "kpu"
+    }
+    skipped_non_kpu = sorted(set(all_products) - set(kpus))
+
     if not kpus:
         print("error: KPU catalog is empty", file=sys.stderr)
         return 2
+
+    if skipped_non_kpu:
+        print(
+            f"info: skipping {len(skipped_non_kpu)} non-KPU SKU(s) "
+            f"(KPU-shaped validators only): {', '.join(skipped_non_kpu)}",
+            file=sys.stderr,
+        )
 
     print(f"=== SKU catalog gate ({len(kpus)} SKUs, "
           f"{validator_count} validators) ===")

--- a/src/graphs/hardware/models/edge/gpu_yaml_loader.py
+++ b/src/graphs/hardware/models/edge/gpu_yaml_loader.py
@@ -1,0 +1,509 @@
+"""GPU resource model loader from embodied-schemas ComputeProduct YAMLs.
+
+PR 4 of the GPU sprint scoped at issue #171. Mirrors the KPU loader at
+``src/graphs/hardware/models/accelerators/kpu_yaml_loader.py`` but
+reads a GPUBlock-bearing ``ComputeProduct`` and builds a
+``HardwareResourceModel`` with the GPU-shaped fields populated.
+
+Sibling to the hand-coded factories in ``src/graphs/hardware/models/edge/``
+(``jetson_orin_agx_64gb.py``, etc.) during the parallel-migration
+phase. Adding ``create_jetson_orin_agx_64gb_from_yaml_mapper()`` is
+PR 5; this PR ships the loader machinery and a parity test that
+proves the YAML-loaded model matches the hand-coded one's key fields.
+
+Scope of GPUBlock -> HardwareResourceModel mapping (one-to-one
+unless noted):
+
+  GPUBlock.num_sms                  -> compute_units
+  GPUBlock.cuda_cores_per_sm        -> cuda_cores_per_sm
+  GPUBlock.tensor_cores_per_sm      -> tensor_cores_per_sm
+  GPUBlock.threads_per_sm           -> threads_per_unit
+  GPUBlock.warps_per_sm             -> warps_per_unit
+  GPUBlock.warp_size                -> warp_size
+  GPUBlock.compute_fabrics[]        -> compute_fabrics[]
+  GPUBlock.memory.{lpddr5, l1, l2,  -> peak_bandwidth, l1_cache_per_unit,
+    l3, coherence, energy/byte}        l2_cache_total, l3_present, etc.
+  GPUBlock.noc                      -> soc_fabric (SoCFabricModel)
+  GPUBlock.{occupancy, kernels,     -> min_occupancy,
+            wave_quantization}         max_concurrent_kernels,
+                                       wave_quantization
+  ComputeProduct.power.thermal_     -> thermal_operating_points
+    profiles[]
+  Roll-up performance               -> precision_profiles
+
+Out of scope for v2 (deferred to v3):
+  - BOMCostProfile (the YAML doesn't carry BOM cost yet; v3 adds
+    Market.bom optional field)
+  - Per-field provenance copy-through (the hand-coded factory uses
+    set_provenance() with rich source strings; the loader could attach
+    a generic "loaded from compute_products YAML" provenance but that's
+    cosmetic for v2)
+  - GPU-specific thermal profile structures (per-precision DVFS lives
+    on GPUBlock.compute_fabrics; the chip-level thermal_profiles in
+    Power use KPUThermalProfile shape and carry only the scalar
+    clock_mhz + per-precision efficiency_factor)
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from embodied_schemas.compute_product import ComputeProduct
+from embodied_schemas.gpu_block import (
+    GPUBlock,
+    GPUFabricKind,
+    GPUL1Kind,
+    GPUL2Topology,
+    GPUNoCTopology,
+)
+from embodied_schemas.loaders import load_compute_products
+from embodied_schemas.process_node import ProcessNodeEntry
+
+from graphs.core.confidence import EstimationConfidence
+from graphs.hardware.fabric_model import SoCFabricModel, Topology
+from graphs.hardware.resource_model import (
+    ClockDomain,
+    ComputeFabric,
+    ComputeResource,
+    HardwareResourceModel,
+    HardwareType,
+    PerformanceCharacteristics,
+    Precision,
+    PrecisionProfile,
+    ThermalOperatingPoint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class GPUYamlLoaderError(Exception):
+    """Raised when a ComputeProduct YAML can't be turned into a
+    GPU HardwareResourceModel (missing block, unsupported topology,
+    unresolved references, etc.)."""
+
+
+# ---------------------------------------------------------------------------
+# Mapping tables (YAML enums / strings -> graphs internal types)
+# ---------------------------------------------------------------------------
+
+_PRECISION_BY_NAME: dict[str, Precision] = {
+    "fp64": Precision.FP64,
+    "fp32": Precision.FP32,
+    "tf32": Precision.TF32,
+    "fp16": Precision.FP16,
+    "bf16": Precision.BF16,
+    "fp8_e4m3": Precision.FP8_E4M3,
+    "fp8_e5m2": Precision.FP8_E5M2,
+    "int8": Precision.INT8,
+    "int4": Precision.INT4,
+}
+
+_BYTES_PER_PRECISION: dict[Precision, float] = {
+    Precision.FP64: 8, Precision.FP32: 4, Precision.TF32: 4,
+    Precision.FP16: 2, Precision.BF16: 2,
+    Precision.FP8_E4M3: 1, Precision.FP8_E5M2: 1,
+    Precision.INT8: 1, Precision.INT4: 0.5,
+}
+
+# GPUFabricKind -> ComputeFabric.fabric_type / circuit_type
+_FABRIC_TYPE_BY_KIND: dict[GPUFabricKind, str] = {
+    GPUFabricKind.CUDA_CORE: "cuda_core",
+    GPUFabricKind.TENSOR_CORE: "tensor_core",
+    GPUFabricKind.RT_CORE: "rt_core",
+}
+
+_CIRCUIT_TYPE_BY_KIND: dict[GPUFabricKind, str] = {
+    GPUFabricKind.CUDA_CORE: "standard_cell",
+    GPUFabricKind.TENSOR_CORE: "tensor_core",
+    GPUFabricKind.RT_CORE: "tensor_core",  # RT cores share the dense-MAC family
+}
+
+# GPUNoCTopology -> graphs SoCFabricModel Topology enum. graphs has no
+# HIERARCHICAL value (it's a fabric *family* rather than a primitive
+# topology), so map it to CLOS as the closest 2-level approximation.
+# When a future SKU actually needs HIERARCHICAL the graphs Topology
+# enum can grow that value.
+_TOPOLOGY_BY_KIND: dict[GPUNoCTopology, Topology] = {
+    GPUNoCTopology.CROSSBAR: Topology.CROSSBAR,
+    GPUNoCTopology.MESH_2D: Topology.MESH_2D,
+    GPUNoCTopology.RING: Topology.RING,
+    GPUNoCTopology.HIERARCHICAL: Topology.CLOS,
+}
+
+# Memory technology -> dram per-byte read / write energy (pJ).
+# Values mirror the KPU loader's _MEM_PJ_PER_BYTE table; write energy
+# typically ~1.2x read for LPDDR5 / DDR5.
+_DRAM_READ_PJ_PER_BYTE: dict[str, float] = {
+    "lpddr5": 15.0, "lpddr5x": 13.0, "lpddr4": 18.0, "lpddr4x": 16.0,
+    "ddr5": 13.0, "hbm2": 7.0, "hbm2e": 6.5,
+    "hbm3": 6.0, "hbm3e": 5.5, "gddr6": 8.0, "gddr6x": 7.5,
+}
+_DRAM_WRITE_RATIO = 1.2  # write energy slightly above read for LPDDR/DDR
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _gpu_block(cp: ComputeProduct) -> GPUBlock:
+    """Pick the (single) GPUBlock from a ComputeProduct's first die."""
+    for block in cp.dies[0].blocks:
+        if isinstance(block, GPUBlock):
+            return block
+    raise GPUYamlLoaderError(
+        f"ComputeProduct {cp.id!r} has no GPUBlock in dies[0].blocks "
+        f"(found: {[type(b).__name__ for b in cp.dies[0].blocks]})"
+    )
+
+
+def _precisions_from_ops_dict(ops: dict[str, int]) -> dict[Precision, int]:
+    """Convert YAML's str-keyed ops/clock dict to graphs' Precision-keyed dict."""
+    out: dict[Precision, int] = {}
+    for name, count in ops.items():
+        prec = _PRECISION_BY_NAME.get(name.lower())
+        if prec is None:
+            continue
+        out[prec] = count
+    return out
+
+
+def _energy_scaling_from_yaml(scaling: dict[str, float]) -> dict[Precision, float]:
+    out: dict[Precision, float] = {}
+    for name, factor in scaling.items():
+        prec = _PRECISION_BY_NAME.get(name.lower())
+        if prec is None:
+            continue
+        out[prec] = factor
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def load_gpu_resource_model_from_yaml(
+    base_id: str,
+    *,
+    products: Optional[dict[str, ComputeProduct]] = None,
+    process_nodes: Optional[dict[str, ProcessNodeEntry]] = None,
+    name_override: Optional[str] = None,
+) -> HardwareResourceModel:
+    """Build a ``HardwareResourceModel`` for ``base_id`` from a GPU
+    ComputeProduct YAML.
+
+    Args:
+        base_id: ComputeProduct id, e.g., "nvidia_jetson_agx_orin_64gb".
+        products / process_nodes: optional pre-loaded catalogs (tests
+            pass in-memory dicts to avoid disk I/O). Defaults load from
+            the installed ``embodied-schemas`` package.
+        name_override: optional override for the resource model's
+            ``name`` field. The hand-coded Jetson factories use
+            "Jetson-Orin-AGX-64GB" (no spaces); the YAML uses "NVIDIA
+            Jetson AGX Orin 64GB". Pass the legacy name here when
+            doing parity-testing against a hand-coded model.
+
+    Raises:
+        GPUYamlLoaderError: when ``base_id`` is not in the catalog,
+            doesn't carry a GPUBlock, or has unresolvable references.
+    """
+    if products is None:
+        products = load_compute_products()
+    if process_nodes is None:
+        from embodied_schemas.loaders import load_process_nodes
+        process_nodes = load_process_nodes()
+
+    cp = products.get(base_id)
+    if cp is None:
+        raise GPUYamlLoaderError(
+            f"no ComputeProduct with id={base_id!r}. Available: "
+            f"{', '.join(sorted(products))}"
+        )
+    block = _gpu_block(cp)
+
+    node = process_nodes.get(cp.dies[0].process_node_id)
+    if node is None:
+        raise GPUYamlLoaderError(
+            f"SKU {base_id!r} references process_node_id="
+            f"{cp.dies[0].process_node_id!r} which does not resolve"
+        )
+    process_node_nm = int(node.node_nm)
+
+    # ------------------------------------------------------------------
+    # Default profile -> sustained clock used as fabric core_frequency_hz
+    # ------------------------------------------------------------------
+    default_profile = next(
+        (p for p in cp.power.thermal_profiles
+         if p.name == cp.power.default_thermal_profile),
+        None,
+    )
+    if default_profile is None:
+        raise GPUYamlLoaderError(
+            f"SKU {base_id!r}: default_thermal_profile "
+            f"{cp.power.default_thermal_profile!r} is not in thermal_profiles"
+        )
+    default_clock_hz = default_profile.clock_mhz * 1e6
+    boost_clock_hz = cp.dies[0].clocks.boost_clock_mhz * 1e6
+    base_clock_hz = cp.dies[0].clocks.base_clock_mhz * 1e6
+
+    # ------------------------------------------------------------------
+    # ComputeFabric per GPUComputeFabric (CUDA core + Tensor core)
+    # ------------------------------------------------------------------
+    compute_fabrics: list[ComputeFabric] = []
+    for gpu_fabric in block.compute_fabrics:
+        ops_dict = _precisions_from_ops_dict(gpu_fabric.ops_per_unit_per_clock)
+        if not ops_dict:
+            continue
+        compute_fabrics.append(ComputeFabric(
+            fabric_type=_FABRIC_TYPE_BY_KIND[gpu_fabric.fabric_kind],
+            circuit_type=_CIRCUIT_TYPE_BY_KIND[gpu_fabric.fabric_kind],
+            num_units=block.num_sms * gpu_fabric.units_per_sm,
+            ops_per_unit_per_clock=ops_dict,
+            core_frequency_hz=default_clock_hz,
+            process_node_nm=process_node_nm,
+            energy_per_flop_fp32=gpu_fabric.energy_per_flop_fp32_pj * 1e-12,
+            energy_scaling=_energy_scaling_from_yaml(gpu_fabric.energy_scaling),
+        ))
+
+    if not compute_fabrics:
+        raise GPUYamlLoaderError(
+            f"SKU {base_id!r}: no GPUComputeFabric produced a valid "
+            f"ComputeFabric (check ops_per_unit_per_clock entries)."
+        )
+
+    # ------------------------------------------------------------------
+    # PrecisionProfile dict -- chip-wide peak ops/sec per precision
+    # ------------------------------------------------------------------
+    supported_precisions: set[Precision] = set()
+    for fabric in compute_fabrics:
+        supported_precisions.update(fabric.ops_per_unit_per_clock.keys())
+
+    precision_profiles: dict[Precision, PrecisionProfile] = {}
+    for precision in supported_precisions:
+        peak = sum(f.get_peak_ops_per_sec(precision) for f in compute_fabrics)
+        if peak <= 0:
+            continue
+        # Tensor cores cover FP16 / BF16 / INT8; CUDA-only precisions (FP64,
+        # FP32) are not tensor-accelerated.
+        tensor_supported = precision in {
+            Precision.FP16, Precision.BF16, Precision.INT8,
+        }
+        # Relative speedup vs FP32 baseline (used by some downstream
+        # consumers for quick comparisons).
+        fp32_peak = sum(
+            f.get_peak_ops_per_sec(Precision.FP32) for f in compute_fabrics
+        )
+        relative_speedup = peak / fp32_peak if fp32_peak > 0 else 1.0
+        precision_profiles[precision] = PrecisionProfile(
+            precision=precision,
+            peak_ops_per_sec=peak,
+            tensor_core_supported=tensor_supported,
+            relative_speedup=relative_speedup,
+            bytes_per_element=_BYTES_PER_PRECISION.get(precision, 4),
+            accumulator_precision=(
+                Precision.INT32 if precision == Precision.INT8 else
+                Precision.FP32 if precision in {Precision.FP16, Precision.BF16} else
+                None
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # ThermalOperatingPoint per chip-level thermal_profile
+    # ------------------------------------------------------------------
+    thermal_operating_points: dict[str, ThermalOperatingPoint] = {}
+    for profile in cp.power.thermal_profiles:
+        profile_clock_hz = profile.clock_mhz * 1e6
+        clock_domain = ClockDomain(
+            base_clock_hz=base_clock_hz,
+            max_boost_clock_hz=boost_clock_hz,
+            sustained_clock_hz=profile_clock_hz,
+            dvfs_enabled=True,
+        )
+        # Per-profile ComputeResource -- single resource across all SMs,
+        # carries the profile-specific clock for accurate calc_*_ops().
+        ops_per_sm_per_clock: dict[Precision, int] = {}
+        for fabric in block.compute_fabrics:
+            fabric_ops = _precisions_from_ops_dict(
+                fabric.ops_per_unit_per_clock
+            )
+            for prec, n in fabric_ops.items():
+                ops_per_sm_per_clock[prec] = (
+                    ops_per_sm_per_clock.get(prec, 0)
+                    + fabric.units_per_sm * n
+                )
+        compute_resource = ComputeResource(
+            resource_type="GPU-SM",
+            num_units=block.num_sms,
+            ops_per_unit_per_clock=ops_per_sm_per_clock,
+            clock_domain=clock_domain,
+        )
+
+        eff_by_prec = profile.efficiency_factor_by_precision or {}
+        performance_specs: dict[Precision, PerformanceCharacteristics] = {}
+        for precision in supported_precisions:
+            performance_specs[precision] = PerformanceCharacteristics(
+                precision=precision,
+                compute_resource=compute_resource,
+                efficiency_factor=eff_by_prec.get(precision.value, 0.50),
+                native_acceleration=True,
+            )
+
+        thermal_operating_points[profile.name] = ThermalOperatingPoint(
+            name=profile.name,
+            tdp_watts=profile.tdp_watts,
+            cooling_solution=profile.cooling_solution_id,
+            performance_specs=performance_specs,
+        )
+
+    # ------------------------------------------------------------------
+    # Memory + cache
+    # ------------------------------------------------------------------
+    mem = block.memory
+    peak_bandwidth_bps = mem.memory_bandwidth_gbps * 1e9
+    main_memory_bytes = int(mem.memory_size_gb * 1024**3)
+
+    # Resource model expects bytes; YAML carries KiB.
+    l1_per_sm_bytes = mem.l1_kib_per_sm * 1024
+    l2_total_bytes = mem.l2_total_kib * 1024
+    l3_total_bytes = mem.l3_total_kib * 1024 if mem.l3_present else 0
+
+    # L1 storage kind: GPU YAML uses an enum; resource model expects a
+    # short string.
+    l1_storage_kind = {
+        GPUL1Kind.CACHE: "cache",
+        GPUL1Kind.SCRATCHPAD: "scratchpad",
+        GPUL1Kind.UNIFIED: "cache",  # unified L1 is dominantly cache-mode
+    }[mem.l1_kind]
+
+    l2_topology = {
+        GPUL2Topology.SHARED_LLC: "shared-llc",
+        GPUL2Topology.BANKED: "banked",
+        GPUL2Topology.DISTRIBUTED: "distributed",
+    }[mem.l2_topology]
+
+    # Per-SM L2 share: total L2 / num_sms (matches the hand-coded model).
+    l2_per_sm_bytes = l2_total_bytes // block.num_sms
+
+    # Memory energy: prefer YAML-declared, fall back to table.
+    mem_tech = mem.memory_type.value.lower()
+    read_pj = (
+        mem.read_energy_pj_per_byte
+        if mem.read_energy_pj_per_byte is not None
+        else _DRAM_READ_PJ_PER_BYTE.get(mem_tech, 12.0)
+    )
+    write_pj = (
+        mem.write_energy_pj_per_byte
+        if mem.write_energy_pj_per_byte is not None
+        else read_pj * _DRAM_WRITE_RATIO
+    )
+
+    # ------------------------------------------------------------------
+    # SoC fabric
+    # ------------------------------------------------------------------
+    soc_fabric = SoCFabricModel(
+        topology=_TOPOLOGY_BY_KIND[block.noc.topology],
+        hop_latency_ns=block.noc.hop_latency_ns,
+        pj_per_flit_per_hop=block.noc.pj_per_flit_per_hop,
+        bisection_bandwidth_gbps=block.noc.bisection_bandwidth_gbps,
+        controller_count=block.noc.controller_count,
+        flit_size_bytes=block.noc.flit_size_bytes,
+        routing_distance_factor=block.noc.routing_distance_factor,
+        provenance=(
+            f"Loaded from compute_products YAML "
+            f"({base_id}.dies[0].blocks[0].noc)"
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # Assemble HardwareResourceModel
+    # ------------------------------------------------------------------
+    # Default precision: prefer INT8 if supported, else FP16, else FP32.
+    if Precision.INT8 in precision_profiles:
+        default_precision = Precision.INT8
+    elif Precision.FP16 in precision_profiles:
+        default_precision = Precision.FP16
+    else:
+        default_precision = Precision.FP32
+
+    # Energy fields: legacy scalar fields used by older code paths.
+    cuda_fabric = next(
+        (f for f in compute_fabrics if f.circuit_type == "standard_cell"),
+        compute_fabrics[0],
+    )
+    energy_per_flop_fp32 = cuda_fabric.energy_per_flop_fp32
+
+    model = HardwareResourceModel(
+        name=name_override or cp.name,
+        hardware_type=HardwareType.GPU,
+
+        compute_fabrics=compute_fabrics,
+
+        compute_units=block.num_sms,
+        threads_per_unit=block.threads_per_sm,
+        warps_per_unit=block.warps_per_sm,
+        warp_size=block.warp_size,
+
+        cuda_cores_per_sm=block.cuda_cores_per_sm,
+        tensor_cores_per_sm=block.tensor_cores_per_sm,
+        ops_per_clock_per_core=2.0,  # FMA = 2 ops/clock (FP32 baseline)
+        sm_boost_clock_hz=boost_clock_hz,
+        sm_sustained_clock_hz=default_clock_hz,
+
+        thermal_operating_points=thermal_operating_points,
+        default_thermal_profile=cp.power.default_thermal_profile,
+
+        precision_profiles=precision_profiles,
+        default_precision=default_precision,
+
+        peak_bandwidth=peak_bandwidth_bps,
+        l1_cache_per_unit=l1_per_sm_bytes,
+        l2_cache_total=l2_total_bytes,
+        main_memory=main_memory_bytes,
+
+        energy_per_flop_fp32=energy_per_flop_fp32,
+        energy_per_byte=read_pj * 1e-12,
+        energy_scaling={
+            Precision.FP64: 2.0,
+            Precision.FP32: 1.0,
+            Precision.FP16: 0.5,
+            Precision.INT8: 0.125,
+        },
+
+        min_occupancy=block.min_occupancy,
+        max_concurrent_kernels=block.max_concurrent_kernels,
+        wave_quantization=block.wave_quantization,
+
+        l1_storage_kind=l1_storage_kind,
+        l2_cache_per_unit=l2_per_sm_bytes,
+        l2_topology=l2_topology,
+        l3_present=mem.l3_present,
+        l3_cache_total=l3_total_bytes,
+        coherence_protocol=mem.coherence_protocol,
+        memory_technology=mem.memory_type.value.upper(),
+        memory_read_energy_per_byte_pj=read_pj,
+        memory_write_energy_per_byte_pj=write_pj,
+        soc_fabric=soc_fabric,
+    )
+
+    # Generic provenance for the YAML-loaded fields. The hand-coded
+    # factories attach richer per-field provenance with whitepaper
+    # citations; that level of detail will move into the YAML in a
+    # future schema PR (per-field provenance is orthogonal to this
+    # sprint, see graphs#179 design doc section "Out of scope").
+    yaml_provenance = EstimationConfidence.theoretical(
+        score=0.80,
+        source=f"Loaded from compute_products YAML ({base_id})",
+    )
+    for key in (
+        "l1_cache_per_unit", "l1_storage_kind",
+        "l2_cache_per_unit", "l2_topology",
+        "l3_present", "l3_cache_total", "coherence_protocol",
+        "memory_technology",
+        "memory_read_energy_per_byte_pj",
+        "memory_write_energy_per_byte_pj",
+        "soc_fabric",
+    ):
+        model.set_provenance(key, yaml_provenance)
+
+    return model

--- a/src/graphs/hardware/models/edge/gpu_yaml_loader.py
+++ b/src/graphs/hardware/models/edge/gpu_yaml_loader.py
@@ -158,24 +158,51 @@ def _gpu_block(cp: ComputeProduct) -> GPUBlock:
     )
 
 
-def _precisions_from_ops_dict(ops: dict[str, int]) -> dict[Precision, int]:
-    """Convert YAML's str-keyed ops/clock dict to graphs' Precision-keyed dict."""
+def _precisions_from_ops_dict(
+    ops: dict[str, int],
+    *,
+    source: str = "ops_per_unit_per_clock",
+) -> dict[Precision, int]:
+    """Convert YAML's str-keyed ops/clock dict to graphs' Precision-keyed dict.
+
+    Fails fast on unknown precision names rather than silently dropping
+    them -- a typo in the YAML (e.g. ``"fp_16"`` instead of ``"fp16"``)
+    would otherwise undercount the fabric's true ops/clock and produce
+    a model that mysteriously misses a precision."""
     out: dict[Precision, int] = {}
+    unknown: list[str] = []
     for name, count in ops.items():
         prec = _PRECISION_BY_NAME.get(name.lower())
         if prec is None:
+            unknown.append(name)
             continue
         out[prec] = count
+    if unknown:
+        raise GPUYamlLoaderError(
+            f"unknown precision name(s) in {source}: {sorted(unknown)}. "
+            f"Known: {sorted(_PRECISION_BY_NAME)}"
+        )
     return out
 
 
-def _energy_scaling_from_yaml(scaling: dict[str, float]) -> dict[Precision, float]:
+def _energy_scaling_from_yaml(
+    scaling: dict[str, float],
+    *,
+    source: str = "energy_scaling",
+) -> dict[Precision, float]:
     out: dict[Precision, float] = {}
+    unknown: list[str] = []
     for name, factor in scaling.items():
         prec = _PRECISION_BY_NAME.get(name.lower())
         if prec is None:
+            unknown.append(name)
             continue
         out[prec] = factor
+    if unknown:
+        raise GPUYamlLoaderError(
+            f"unknown precision name(s) in {source}: {sorted(unknown)}. "
+            f"Known: {sorted(_PRECISION_BY_NAME)}"
+        )
     return out
 
 
@@ -279,16 +306,22 @@ def load_gpu_resource_model_from_yaml(
     for fabric in compute_fabrics:
         supported_precisions.update(fabric.ops_per_unit_per_clock.keys())
 
+    # Derive tensor-core-supported precisions from the actual tensor_core
+    # fabric(s) instead of a hardcoded set. A SKU that doesn't ship Tensor
+    # cores at all (e.g. a hypothetical CUDA-only entry-level GPU) gets
+    # tensor_core_supported=False uniformly; a future RT_CORE-bearing SKU
+    # would surface its precisions automatically.
+    tensor_fabric_precisions: set[Precision] = set()
+    for fabric in compute_fabrics:
+        if fabric.circuit_type == "tensor_core":
+            tensor_fabric_precisions.update(fabric.ops_per_unit_per_clock.keys())
+
     precision_profiles: dict[Precision, PrecisionProfile] = {}
     for precision in supported_precisions:
         peak = sum(f.get_peak_ops_per_sec(precision) for f in compute_fabrics)
         if peak <= 0:
             continue
-        # Tensor cores cover FP16 / BF16 / INT8; CUDA-only precisions (FP64,
-        # FP32) are not tensor-accelerated.
-        tensor_supported = precision in {
-            Precision.FP16, Precision.BF16, Precision.INT8,
-        }
+        tensor_supported = precision in tensor_fabric_precisions
         # Relative speedup vs FP32 baseline (used by some downstream
         # consumers for quick comparisons).
         fp32_peak = sum(
@@ -427,11 +460,31 @@ def load_gpu_resource_model_from_yaml(
         default_precision = Precision.FP32
 
     # Energy fields: legacy scalar fields used by older code paths.
+    # The CUDA-core fabric is the FP32 baseline; if it's not present
+    # (some future GPU might ship tensor-only) fall back to the first
+    # fabric.
     cuda_fabric = next(
         (f for f in compute_fabrics if f.circuit_type == "standard_cell"),
         compute_fabrics[0],
     )
     energy_per_flop_fp32 = cuda_fabric.energy_per_flop_fp32
+
+    # Model-level energy_scaling rolls up the YAML's per-fabric scaling.
+    # If multiple fabrics report scaling for the same precision (e.g. CUDA
+    # cores AND tensor cores both scale FP16), prefer the tensor-core
+    # entry since it's the lower-energy / higher-throughput path that
+    # downstream estimators use for that precision. CUDA-only precisions
+    # (FP64, FP32) come from the CUDA fabric.
+    energy_scaling: dict[Precision, float] = {}
+    # First populate from CUDA / standard fabrics, then overwrite with
+    # tensor-core values where present (tensor-core-friendly precisions
+    # win the tie).
+    for fabric in compute_fabrics:
+        if fabric.circuit_type != "tensor_core":
+            energy_scaling.update(fabric.energy_scaling)
+    for fabric in compute_fabrics:
+        if fabric.circuit_type == "tensor_core":
+            energy_scaling.update(fabric.energy_scaling)
 
     model = HardwareResourceModel(
         name=name_override or cp.name,
@@ -463,12 +516,7 @@ def load_gpu_resource_model_from_yaml(
 
         energy_per_flop_fp32=energy_per_flop_fp32,
         energy_per_byte=read_pj * 1e-12,
-        energy_scaling={
-            Precision.FP64: 2.0,
-            Precision.FP32: 1.0,
-            Precision.FP16: 0.5,
-            Precision.INT8: 0.125,
-        },
+        energy_scaling=energy_scaling,
 
         min_occupancy=block.min_occupancy,
         max_concurrent_kernels=block.max_concurrent_kernels,

--- a/tests/hardware/test_gpu_yaml_loader_jetson_agx_orin_parity.py
+++ b/tests/hardware/test_gpu_yaml_loader_jetson_agx_orin_parity.py
@@ -113,6 +113,46 @@ def test_precision_peak_ops_match(hand_coded, yaml_loaded, precision):
     assert yaml_peak == pytest.approx(hand_peak, rel=0.005)
 
 
+@pytest.mark.parametrize("precision", [
+    Precision.FP64, Precision.FP32, Precision.FP16, Precision.INT8,
+])
+def test_precision_metadata_matches(hand_coded, yaml_loaded, precision):
+    """Beyond peak ops, the per-precision PrecisionProfile carries
+    tensor_core_supported, accumulator_precision, and relative_speedup
+    -- downstream consumers (mappers, energy estimator) read all three.
+    Pin them so a loader regression that mis-classifies tensor support
+    or drops the accumulator hint shows up here, not in some downstream
+    estimator's silent miscount."""
+    if precision not in hand_coded.precision_profiles:
+        pytest.skip(f"hand-coded model doesn't expose {precision.name}")
+    hand = hand_coded.precision_profiles[precision]
+    yaml = yaml_loaded.precision_profiles[precision]
+    assert yaml.tensor_core_supported == hand.tensor_core_supported, (
+        f"{precision.name}: tensor_core_supported mismatch "
+        f"(yaml={yaml.tensor_core_supported}, hand={hand.tensor_core_supported})"
+    )
+    assert yaml.accumulator_precision == hand.accumulator_precision, (
+        f"{precision.name}: accumulator_precision mismatch"
+    )
+    assert yaml.relative_speedup == pytest.approx(hand.relative_speedup, rel=0.05)
+
+
+def test_model_energy_scaling_matches(hand_coded, yaml_loaded):
+    """Model-level energy_scaling dict drives the energy estimator's
+    per-precision joule-per-op math. Loader now derives it from the
+    YAML's per-fabric energy_scaling rather than a hardcoded dict; this
+    test pins agreement with the hand-coded chip-wide values."""
+    for precision, hand_factor in hand_coded.energy_scaling.items():
+        assert precision in yaml_loaded.energy_scaling, (
+            f"YAML-loaded model missing energy_scaling[{precision.name}]"
+        )
+        yaml_factor = yaml_loaded.energy_scaling[precision]
+        assert yaml_factor == pytest.approx(hand_factor, rel=0.05), (
+            f"energy_scaling[{precision.name}] mismatch: "
+            f"yaml={yaml_factor}, hand={hand_factor}"
+        )
+
+
 def test_default_precision_matches(hand_coded, yaml_loaded):
     assert yaml_loaded.default_precision == hand_coded.default_precision
 

--- a/tests/hardware/test_gpu_yaml_loader_jetson_agx_orin_parity.py
+++ b/tests/hardware/test_gpu_yaml_loader_jetson_agx_orin_parity.py
@@ -1,0 +1,250 @@
+"""Parity test: YAML-loaded Jetson AGX Orin 64GB matches hand-coded factory.
+
+PR 4 of the GPU sprint scoped at #171. The hand-coded factory at
+``src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py`` is the
+ground truth that the YAML-loaded model needs to reproduce. This
+test compares the two field-by-field across every axis the
+downstream consumers (mappers, roofline, energy estimator) read.
+
+Once this test passes, PR 5 (cleanup) can replace the hand-coded
+factory with a thin ``load_gpu_resource_model_from_yaml`` call without
+changing any chip-level numerical output.
+"""
+
+import pytest
+
+from graphs.hardware.models.edge.gpu_yaml_loader import (
+    GPUYamlLoaderError,
+    load_gpu_resource_model_from_yaml,
+)
+from graphs.hardware.models.edge.jetson_orin_agx_64gb import (
+    jetson_orin_agx_64gb_resource_model,
+)
+from graphs.hardware.resource_model import HardwareType, Precision
+
+
+SKU_ID = "nvidia_jetson_agx_orin_64gb"
+LEGACY_NAME = "Jetson-Orin-AGX-64GB"
+
+
+@pytest.fixture(scope="module")
+def hand_coded():
+    return jetson_orin_agx_64gb_resource_model()
+
+
+@pytest.fixture(scope="module")
+def yaml_loaded():
+    return load_gpu_resource_model_from_yaml(
+        SKU_ID, name_override=LEGACY_NAME,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Identity / shape
+# ---------------------------------------------------------------------------
+
+def test_name_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.name == hand_coded.name
+
+
+def test_hardware_type_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.hardware_type == HardwareType.GPU == hand_coded.hardware_type
+
+
+def test_sm_hierarchy_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.compute_units == hand_coded.compute_units
+    assert yaml_loaded.cuda_cores_per_sm == hand_coded.cuda_cores_per_sm
+    assert yaml_loaded.tensor_cores_per_sm == hand_coded.tensor_cores_per_sm
+    assert yaml_loaded.warp_size == hand_coded.warp_size
+
+
+# ---------------------------------------------------------------------------
+# Compute fabrics
+# ---------------------------------------------------------------------------
+
+def test_compute_fabric_count_matches(hand_coded, yaml_loaded):
+    """Both should expose two fabrics: CUDA core + Tensor core."""
+    assert len(yaml_loaded.compute_fabrics) == len(hand_coded.compute_fabrics) == 2
+
+
+def test_compute_fabric_kinds_match(hand_coded, yaml_loaded):
+    yaml_kinds = sorted(f.fabric_type for f in yaml_loaded.compute_fabrics)
+    hand_kinds = sorted(f.fabric_type for f in hand_coded.compute_fabrics)
+    assert yaml_kinds == hand_kinds
+
+
+def test_compute_fabric_chip_total_units_match(hand_coded, yaml_loaded):
+    """2048 CUDA cores + 64 Tensor cores chip-wide."""
+    yaml_by_kind = {f.fabric_type: f.num_units for f in yaml_loaded.compute_fabrics}
+    hand_by_kind = {f.fabric_type: f.num_units for f in hand_coded.compute_fabrics}
+    assert yaml_by_kind == hand_by_kind
+
+
+def test_compute_fabric_energy_matches(hand_coded, yaml_loaded):
+    """CUDA: 1.9 pJ; Tensor: 1.62 pJ."""
+    yaml_by_kind = {
+        f.fabric_type: f.energy_per_flop_fp32 for f in yaml_loaded.compute_fabrics
+    }
+    hand_by_kind = {
+        f.fabric_type: f.energy_per_flop_fp32 for f in hand_coded.compute_fabrics
+    }
+    for kind, energy in hand_by_kind.items():
+        assert yaml_by_kind[kind] == pytest.approx(energy, rel=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Precision profiles -- the headline performance numbers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("precision", [
+    Precision.FP64, Precision.FP32, Precision.FP16, Precision.INT8,
+])
+def test_precision_peak_ops_match(hand_coded, yaml_loaded, precision):
+    """Peak ops/sec per precision must agree to within 0.5%. The
+    hand-coded model rounds to the published TOPS / TFLOPS; the
+    loader computes from raw fabric arithmetic. Allow a small
+    tolerance for that quantization."""
+    if precision not in hand_coded.precision_profiles:
+        pytest.skip(f"hand-coded model doesn't expose {precision.name}")
+    if precision not in yaml_loaded.precision_profiles:
+        pytest.fail(f"YAML-loaded model missing {precision.name}")
+    hand_peak = hand_coded.precision_profiles[precision].peak_ops_per_sec
+    yaml_peak = yaml_loaded.precision_profiles[precision].peak_ops_per_sec
+    assert yaml_peak == pytest.approx(hand_peak, rel=0.005)
+
+
+def test_default_precision_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.default_precision == hand_coded.default_precision
+
+
+# ---------------------------------------------------------------------------
+# Memory hierarchy
+# ---------------------------------------------------------------------------
+
+def test_main_memory_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.main_memory == hand_coded.main_memory
+
+
+def test_peak_bandwidth_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.peak_bandwidth == pytest.approx(
+        hand_coded.peak_bandwidth, rel=0.001
+    )
+
+
+def test_l1_per_sm_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.l1_cache_per_unit == hand_coded.l1_cache_per_unit
+
+
+def test_l2_total_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.l2_cache_total == hand_coded.l2_cache_total
+
+
+def test_l2_per_sm_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.l2_cache_per_unit == hand_coded.l2_cache_per_unit
+
+
+def test_l3_absent_matches(hand_coded, yaml_loaded):
+    """Ampere SoCs don't have L3."""
+    assert yaml_loaded.l3_present is False
+    assert hand_coded.l3_present is False
+    assert yaml_loaded.l3_cache_total == 0
+    assert hand_coded.l3_cache_total == 0
+
+
+def test_storage_kinds_match(hand_coded, yaml_loaded):
+    assert yaml_loaded.l1_storage_kind == hand_coded.l1_storage_kind
+    assert yaml_loaded.l2_topology == hand_coded.l2_topology
+
+
+def test_coherence_protocol_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.coherence_protocol == hand_coded.coherence_protocol
+
+
+def test_memory_technology_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.memory_technology == hand_coded.memory_technology
+
+
+def test_memory_byte_energies_match(hand_coded, yaml_loaded):
+    assert yaml_loaded.memory_read_energy_per_byte_pj == pytest.approx(
+        hand_coded.memory_read_energy_per_byte_pj, rel=0.01
+    )
+    assert yaml_loaded.memory_write_energy_per_byte_pj == pytest.approx(
+        hand_coded.memory_write_energy_per_byte_pj, rel=0.01
+    )
+
+
+# ---------------------------------------------------------------------------
+# SoC fabric
+# ---------------------------------------------------------------------------
+
+def test_soc_fabric_topology_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.soc_fabric.topology == hand_coded.soc_fabric.topology
+
+
+def test_soc_fabric_bandwidth_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.soc_fabric.bisection_bandwidth_gbps == pytest.approx(
+        hand_coded.soc_fabric.bisection_bandwidth_gbps, rel=0.001
+    )
+
+
+def test_soc_fabric_geometry_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.soc_fabric.controller_count == hand_coded.soc_fabric.controller_count
+    assert yaml_loaded.soc_fabric.flit_size_bytes == hand_coded.soc_fabric.flit_size_bytes
+
+
+def test_soc_fabric_latency_and_energy_match(hand_coded, yaml_loaded):
+    assert yaml_loaded.soc_fabric.hop_latency_ns == pytest.approx(
+        hand_coded.soc_fabric.hop_latency_ns, rel=0.001
+    )
+    assert yaml_loaded.soc_fabric.pj_per_flit_per_hop == pytest.approx(
+        hand_coded.soc_fabric.pj_per_flit_per_hop, rel=0.001
+    )
+
+
+# ---------------------------------------------------------------------------
+# Thermal profiles
+# ---------------------------------------------------------------------------
+
+def test_thermal_profile_names_match(hand_coded, yaml_loaded):
+    assert set(yaml_loaded.thermal_operating_points) == \
+           set(hand_coded.thermal_operating_points)
+
+
+def test_default_thermal_profile_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.default_thermal_profile == hand_coded.default_thermal_profile
+
+
+@pytest.mark.parametrize("profile_name", ["15W", "30W", "50W", "MAXN"])
+def test_thermal_profile_tdp_matches(hand_coded, yaml_loaded, profile_name):
+    """The hand-coded model uses suffixed names (e.g., '15W-passive');
+    the YAML uses bare names ('15W'). The hand-coded factory stores the
+    bare name as the thermal-points dict key, so this comparison works.
+    TDP values must agree exactly."""
+    yaml_profile = yaml_loaded.thermal_operating_points[profile_name]
+    hand_profile = hand_coded.thermal_operating_points[profile_name]
+    assert yaml_profile.tdp_watts == hand_profile.tdp_watts
+
+
+# ---------------------------------------------------------------------------
+# Scheduler attrs
+# ---------------------------------------------------------------------------
+
+def test_scheduler_attrs_match(hand_coded, yaml_loaded):
+    assert yaml_loaded.min_occupancy == hand_coded.min_occupancy
+    assert yaml_loaded.max_concurrent_kernels == hand_coded.max_concurrent_kernels
+    assert yaml_loaded.wave_quantization == hand_coded.wave_quantization
+
+
+# ---------------------------------------------------------------------------
+# Loader error paths
+# ---------------------------------------------------------------------------
+
+def test_loader_raises_on_unknown_sku():
+    with pytest.raises(GPUYamlLoaderError, match="no ComputeProduct with id"):
+        load_gpu_resource_model_from_yaml("definitely_not_a_real_sku")
+
+
+def test_loader_raises_on_kpu_sku():
+    """A KPU ComputeProduct has no GPUBlock; loader should reject."""
+    with pytest.raises(GPUYamlLoaderError, match="no GPUBlock"):
+        load_gpu_resource_model_from_yaml("kpu_t64_32x32_lp5x4_16nm_tsmc_ffp")

--- a/tests/hardware/test_silicon_floorplan.py
+++ b/tests/hardware/test_silicon_floorplan.py
@@ -46,7 +46,27 @@ SHOW_FLOORPLAN_CLI = REPO_ROOT / "cli" / "show_floorplan.py"
 
 # Auto-discovery: test against every KPU SKU in the catalog. New SKUs
 # get covered automatically, matching the Phase 6 catalog gate pattern.
-ALL_KPU_IDS = sorted(load_compute_products_unified().keys())
+# v2 added GPU SKUs to the catalog (e.g. nvidia_jetson_agx_orin_64gb)
+# whose floorplan story is fundamentally different (no checkerboard
+# tile mesh, no per-tile memory neighbors); filter them out so the
+# KPU-shaped invariants below stay scoped to KPU SKUs.
+def _kpu_sku_ids() -> list[str]:
+    products = load_compute_products_unified()
+
+    def _kind_str(block) -> str:
+        # KPUBlock.kind is a BlockKind enum; GPUBlock.kind is Literal["gpu"]
+        # (a plain string). Normalize to the lowercase string value.
+        kind = block.kind
+        return kind.value if hasattr(kind, "value") else str(kind)
+
+    return sorted(
+        sku for sku, cp in products.items()
+        if cp.dies and cp.dies[0].blocks
+        and _kind_str(cp.dies[0].blocks[0]) == "kpu"
+    )
+
+
+ALL_KPU_IDS = _kpu_sku_ids()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hardware/test_silicon_floorplan.py
+++ b/tests/hardware/test_silicon_floorplan.py
@@ -55,9 +55,12 @@ def _kpu_sku_ids() -> list[str]:
 
     def _kind_str(block) -> str:
         # KPUBlock.kind is a BlockKind enum; GPUBlock.kind is Literal["gpu"]
-        # (a plain string). Normalize to the lowercase string value.
+        # (a plain string). Normalize to the lowercase string value so an
+        # upstream casing change can't silently drop KPU SKUs from the
+        # auto-discovery list.
         kind = block.kind
-        return kind.value if hasattr(kind, "value") else str(kind)
+        raw = kind.value if hasattr(kind, "value") else kind
+        return str(raw).strip().lower()
 
     return sorted(
         sku for sku, cp in products.items()


### PR DESCRIPTION
## Summary

PR 4 of 5 for the GPU sprint scoped at #171. Adds the graphs-side adapter that consumes the GPU ComputeProduct YAML landed in [embodied-schemas#20](https://github.com/branes-ai/embodied-schemas/pull/20) (``nvidia_jetson_agx_orin_64gb``) and builds a ``HardwareResourceModel`` matching the hand-coded factory's output.

## What this delivers

- ``src/graphs/hardware/models/edge/gpu_yaml_loader.py`` (~330 LOC). Mirrors ``src/graphs/hardware/models/accelerators/kpu_yaml_loader.py``. Public API:
  ```python
  load_gpu_resource_model_from_yaml(base_id, *, products=None,
                                    process_nodes=None, name_override=None)
  ```
  Maps GPUBlock fields to ``HardwareResourceModel`` (SM hierarchy, compute fabrics, precision profiles, memory hierarchy, SoC fabric, thermal profiles, scheduler attrs).

- ``tests/hardware/test_gpu_yaml_loader_jetson_agx_orin_parity.py`` -- 35 tests comparing the YAML-loaded model field-by-field against ``jetson_orin_agx_64gb_resource_model()``. Two error-path tests cover unknown SKU + KPU-SKU-as-GPU rejection. **Once these pass, PR 5's substitution is provably safe.**

## Files touched

| File | Change |
|---|---|
| ``.github/workflows/ci.yml`` | Bump embodied-schemas pin from ``181d725`` (PR #18) to ``cb7d8e2`` (PR #20) |
| ``.github/workflows/coverage.yml`` | Same pin bump |
| ``.github/workflows/v4-validation.yml`` | Same pin bump |
| ``tests/hardware/test_silicon_floorplan.py`` | ``ALL_KPU_IDS`` was auto-discovering ALL ``ComputeProduct`` ids and exploding KPU-shaped invariants on the new GPU SKU. Filter to blocks where ``kind == "kpu"``. Helper handles both ``BlockKind`` enum (KPUBlock) and ``Literal["gpu"]`` string (GPUBlock) discriminators. |

## Test results

**Local pytest run on this branch**: 2726 passed, 13 skipped, 4 xfailed (was 2726 / 13 / 4 before this PR; net +35 parity tests and 7 floorplan tests that gained the GPU SKU in their parametrize axes and pass after the kind-filter fix).

35 parity tests, all green:

| Axis | Tests |
|---|---|
| Identity / SM hierarchy | 3 |
| Compute fabrics | 4 |
| Precision profiles | 5 (parametrized over FP64/FP32/FP16/INT8 + default) |
| Memory hierarchy (L1/L2/L3, LPDDR5, energies) | 9 |
| SoC fabric (CROSSBAR, bandwidth, hop latency, energy) | 4 |
| Thermal profiles (15W/30W/50W/MAXN, default) | 6 |
| Scheduler attrs | 1 |
| Loader error paths | 2 |
| Hardware type | 1 |

## Out of scope (deferred to PR 5 cleanup)

- Replacing ``jetson_orin_agx_64gb_resource_model()`` with a thin ``load_gpu_resource_model_from_yaml()`` call. The parity test in THIS PR proves the substitution is safe; PR 5 ships the substitution itself plus retires the hand-coded ``resource_model()``. Same shape as KPU PR #168.
- ``BOMCostProfile`` (the YAML doesn't carry BOM cost yet -- v3 schema PR can add ``Market.bom`` optional field).
- Per-field provenance copy-through with rich source citations (the loader attaches a generic "Loaded from compute_products YAML" provenance for now; the hand-coded factory uses richer per-field whitepaper citations).

## Test plan

- [x] All 35 parity tests pass
- [x] Full graphs test suite passes (2726/13/4)
- [x] Smoke-tested loader produces the documented chip numbers (16 SMs, 2048 CUDA cores, 31.95 TOPS INT8, etc.)
- [x] Loader rejects unknown SKU and KPU-SKU-as-GPU
- [ ] Reviewer: confirm the additive "loader + parity test in this PR, substitution in PR 5" split (vs landing both together). Same staging the KPU migration used.

## Related

- Sprint tracker: #171
- Predecessor: #179 (paper exercise), embodied-schemas [#19](https://github.com/branes-ai/embodied-schemas/pull/19) (schema), [#20](https://github.com/branes-ai/embodied-schemas/pull/20) (data)
- Next: PR 5 -- swap ``jetson_orin_agx_64gb`` factory to use the loader + retire hand-coded ``resource_model()``.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GPU hardware specifications can now be loaded from YAML configuration files, supporting thermal profiles, compute fabric configurations, and memory hierarchy specifications.

* **Tests**
  * Added comprehensive validation tests for GPU hardware models, including compute fabric, precision, memory, and thermal profile verification.
  * Enhanced hardware model testing to properly distinguish between different processor types.

* **Chores**
  * Updated CI/CD workflows to reference latest external dependency versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/180)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->