### PR TITLE
refactor(hardware): retire hand-coded jetson_orin_agx_64gb factory (#171 sprint PR 5/5)

### DIFF
--- a/src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py
+++ b/src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py
@@ -1,392 +1,68 @@
+"""Jetson Orin AGX 64GB resource model.
+
+PR 5 of the GPU sprint scoped at #171. As of this PR, the chip's
+architectural and thermal-profile data lives in the canonical YAML
+at ``embodied-schemas:data/compute_products/nvidia/jetson_agx_orin_64gb.yaml``
+and is loaded via ``gpu_yaml_loader``. The previous ~630-LOC
+hand-coded ``HardwareResourceModel`` constructor was retired here;
+its parity with the YAML-loaded model was established field-by-field
+in PR #180's ``test_gpu_yaml_loader_jetson_agx_orin_parity.py``.
+
+The public function name and signature are preserved so existing
+callers (``create_jetson_orin_agx_64gb_mapper``, layer1 reporting,
+validation scripts, ``cli/compare_*.py``) continue to work unchanged.
+
+Three pieces of data don't yet live in the YAML and are therefore
+attached here after loading:
+  - ``BOMCostProfile`` -- die / package / memory / PCB / thermal /
+    margin / retail BOM. The v2 ComputeProduct schema doesn't carry
+    BoM cost; v3 schema PR will add ``Market.bom`` and this
+    overlay can move into the YAML.
+  - ``ThermalOperatingPoint.memory_clock_mhz`` -- LPDDR5-6400 runs at
+    3200 MHz internal across all four nvpmodel profiles on Orin AGX
+    (NVIDIA datasheet). The chip-level ``thermal_profiles`` use the
+    ``KPUThermalProfile`` shape which doesn't carry a
+    ``memory_clock_mhz`` field; the v3 schema generalization
+    (``ThermalProfile`` with optional memory clock) covered in the
+    design doc will eliminate this overlay.
+  - The legacy resource-model ``name`` ("Jetson-Orin-AGX-64GB", no
+    spaces) is preserved for backward compatibility with existing
+    test fixtures and chart legends. The YAML's ``name`` field is
+    "NVIDIA Jetson AGX Orin 64GB" -- that's the human-readable form
+    that future schema-aware consumers should prefer.
 """
-Jetson Orin AGX 64GB Resource Model hardware resource model.
 
-MEMORY: 64 GB LPDDR5
+from ...resource_model import BOMCostProfile, HardwareResourceModel
+from .gpu_yaml_loader import load_gpu_resource_model_from_yaml
 
-Extracted from resource_model.py during refactoring.
-"""
 
-from ...resource_model import (
-    HardwareResourceModel,
-    HardwareType,
-    Precision,
-    PrecisionProfile,
-    ComputeFabric,
-    get_base_alu_energy,
-    ClockDomain,
-    ComputeResource,
-    TileSpecialization,
-    KPUComputeResource,
-    PerformanceCharacteristics,
-    ThermalOperatingPoint,
-    BOMCostProfile,
-)
-from ...fabric_model import SoCFabricModel, Topology
+_LEGACY_NAME = "Jetson-Orin-AGX-64GB"
+_YAML_BASE_ID = "nvidia_jetson_agx_orin_64gb"
 
 
 def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
+    """NVIDIA Jetson Orin AGX 64GB with realistic DVFS-aware multi-power-profile modeling.
+
+    See the YAML for the canonical chip description (Ampere SMs,
+    Tensor cores, LPDDR5, four nvpmodel profiles) and the migration
+    notes at ``docs/designs/gpu-compute-product-schema-extension.md``.
     """
-    NVIDIA Jetson Orin AGX 64GB with realistic DVFS-aware multi-power-profile modeling.
-
-    MEMORY: 64 GB LPDDR5
-
-    Configuration: AGX variant (2048 CUDA cores, 16 Ampere SMs, 64 Tensor Cores)
-
-    CRITICAL REALITY CHECK - Performance Specifications:
-    - Marketing claim: 275 TOPS INT8 (sparse networks, all engines: GPU+DLA+PVA)
-    - Dense networks total: 138 TOPS INT8 (GPU + 2×DLA)
-      - GPU only (dense): 5.3 TOPS INT8 @ 1.3 GHz ← Relevant for PyTorch workloads
-        (64 Tensor Cores × 64 MACs/TC/clock × 1.3 GHz = 5.3 TOPS)
-      - 2×DLA (dense): 52.5 TOPS INT8
-    - GPU sparse: 10.6 TOPS INT8 (2:4 structured sparsity gives 2× speedup)
-    - Customer empirical data: 2-4% of peak at typical power budgets
-    - Root cause: Severe DVFS thermal throttling + memory bottlenecks
-
-    Power Profiles with Realistic DVFS Behavior:
-    ============================================
-
-    15W Mode (Passive Cooling - What Customers Actually Deploy):
-    - Base clock: 306 MHz (guaranteed minimum)
-    - Boost clock: 1.02 GHz (datasheet spec, rarely sustained)
-    - Sustained clock: 400 MHz (empirical under thermal load)
-    - Thermal throttle factor: 39% (severe throttling!)
-    - Peak INT8: 1.6 TOPS (4,096 MACs/clock × 400 MHz)
-    - Effective INT8: ~0.3 TOPS (20% of peak due to memory bottlenecks)
-    - Use case: Battery-powered robots, drones (must avoid thermal shutdown)
-
-    30W Mode (Active Cooling - Better but Still Throttles):
-    - Sustained clock: 650 MHz (64% of boost)
-    - Peak INT8: 2.7 TOPS (4,096 MACs/clock × 650 MHz)
-    - Effective INT8: ~1.1 TOPS (40% of peak)
-    - Use case: Tethered robots with active cooling
-
-    50W Mode (High Performance - Active Cooling Required):
-    - Sustained clock: 900 MHz (87% of boost)
-    - Peak INT8: 3.7 TOPS (4,096 MACs/clock × 900 MHz)
-    - Effective INT8: ~2.2 TOPS (60% of peak)
-    - Use case: Tethered systems with robust cooling
-
-    MAXN Mode (Unconstrained - Experimental):
-    - Maximum clocks, no power cap (can exceed 60W)
-    - WARNING: Hardware throttling engaged when power exceeds TDP
-    - Not recommended for prolonged heavy workloads
-    - Use case: Benchmarking and short bursts only
-
-    References:
-    - Jetson Orin AGX Datasheet: NVIDIA Technical Brief
-    - Empirical measurements: Customer lab data (2-4% of peak @ 15W)
-    - DVFS behavior: Observed clock throttling under sustained load
-    """
-    # ========================================================================
-    # CUDA Core Fabric (Standard Cell FP32 ALUs)
-    # ========================================================================
-    # Physical hardware specs (constant across power modes)
-    # Official specs: 2048 CUDA cores total, Ampere architecture
-    num_sms = 16                     # 2048 CUDA cores ÷ 128 cores/SM = 16 SMs
-    cuda_cores_per_sm = 128          # Ampere architecture standard
-    tensor_cores_per_sm = 4          # 64 Tensor cores total ÷ 16 SMs = 4 per SM
-    total_tensor_cores = 64          # Total tensor cores across all SMs
-
-    # Use 30W mode as baseline for fabric specs (most realistic deployment)
-    baseline_freq_hz = 650e6  # 650 MHz sustained (30W mode)
-
-    cuda_fabric = ComputeFabric(
-        fabric_type="cuda_core",
-        circuit_type="standard_cell",
-        num_units=num_sms * cuda_cores_per_sm,  # 16 SMs × 128 CUDA cores/SM = 2,048 cores
-        ops_per_unit_per_clock={
-            Precision.FP64: 2,         # FMA: 2 ops/clock
-            Precision.FP32: 2,         # FMA: 2 ops/clock
-        },
-        core_frequency_hz=baseline_freq_hz,  # 650 MHz sustained (30W)
-        process_node_nm=8,             # Samsung 8nm
-        energy_per_flop_fp32=get_base_alu_energy(8, 'standard_cell'),  # 1.9 pJ
-        energy_scaling={
-            Precision.FP64: 2.0,       # Double precision = 2× energy
-            Precision.FP32: 1.0,       # Baseline
-            Precision.FP16: 0.5,       # Half precision (emulated on CUDA cores)
-            Precision.INT8: 0.125,     # INT8 (emulated on CUDA cores)
-        }
+    model = load_gpu_resource_model_from_yaml(
+        _YAML_BASE_ID,
+        name_override=_LEGACY_NAME,
     )
 
-    # ========================================================================
-    # Tensor Core Fabric (15% more efficient for fused MAC+accumulate)
-    # ========================================================================
-    # Ampere Tensor Cores (2nd gen): 256 FP16 ops/TC/clock, 512 INT8 ops/TC/clock
-    # This is for 4x4x4 matrix operations with 4-way throughput
-    tensor_fabric = ComputeFabric(
-        fabric_type="tensor_core",
-        circuit_type="tensor_core",
-        num_units=num_sms * tensor_cores_per_sm,  # 16 SMs × 4 Tensor Cores/SM = 64 TCs
-        ops_per_unit_per_clock={
-            Precision.FP16: 256,       # 256 FP16 ops/clock/TC (Ampere 2nd gen)
-            Precision.INT8: 512,       # 512 INT8 ops/clock/TC (Ampere 2nd gen)
-        },
-        core_frequency_hz=baseline_freq_hz,  # 650 MHz sustained (30W)
-        process_node_nm=8,
-        energy_per_flop_fp32=get_base_alu_energy(8, 'tensor_core'),  # 1.62 pJ (15% better)
-        energy_scaling={
-            Precision.FP16: 0.5,       # Half precision
-            Precision.INT8: 0.125,     # INT8
-        }
-    )
+    # Memory-clock overlay -- LPDDR5-6400 internal clock is 3200 MHz on
+    # Orin AGX, identical across all four nvpmodel profiles. The
+    # KPUThermalProfile shape used by chip-level Power.thermal_profiles
+    # doesn't carry memory_clock_mhz; a v3 ThermalProfile generalization
+    # will absorb this overlay.
+    for profile in model.thermal_operating_points.values():
+        profile.memory_clock_mhz = 3200.0
 
-    # ========================================================================
-    # Combined Peak Calculations (CUDA cores + Tensor cores)
-    # ========================================================================
-    # FP16/INT8 can use BOTH CUDA cores (at 2x/4x rate) AND Tensor cores
-    # This matches auto_detect.py calculations for consistency with calibration
-    #
-    # FP32: CUDA cores only = 2048 cores × 2 ops (FMA) = 4096 ops/clock
-    # FP16: CUDA cores (2x) + Tensor cores = 2048×4 + 64×256 = 24576 ops/clock
-    # INT8: CUDA cores (4x) + Tensor cores = 2048×8 + 64×512 = 49152 ops/clock
-    #
-    # At 650 MHz (30W baseline):
-    #   FP32: 4096 × 650e6 = 2.66 TFLOPS
-    #   FP16: 24576 × 650e6 = 15.97 TFLOPS (6x FP32)
-    #   INT8: 49152 × 650e6 = 31.95 TOPS (12x FP32)
-
-    fp32_ops_per_clock = num_sms * cuda_cores_per_sm * 2  # 2048 × 2 = 4096
-    fp16_ops_per_clock = (num_sms * cuda_cores_per_sm * 4 +
-                          total_tensor_cores * 256)  # 8192 + 16384 = 24576
-    int8_ops_per_clock = (num_sms * cuda_cores_per_sm * 8 +
-                          total_tensor_cores * 512)  # 16384 + 32768 = 49152
-
-    # Legacy per-SM values (still used by some thermal profiles)
-    int8_ops_per_sm_per_clock = 256  # 4 TCs/SM × 64 MACs/TC = 256 MACs/SM/clock
-    fp32_ops_per_sm_per_clock = 256  # CUDA core capability: 128 cores × 2 ops (FMA)
-    fp16_ops_per_sm_per_clock = 256  # Tensor Core FP16: 4 TCs/SM × 64 MACs/TC
-
-    # ========================================================================
-    # 15W MODE: Realistic deployment configuration (passive cooling)
-    # ========================================================================
-    clock_15w = ClockDomain(
-        base_clock_hz=306e6,         # 306 MHz guaranteed minimum
-        max_boost_clock_hz=1.02e9,   # 1.02 GHz datasheet boost
-        sustained_clock_hz=400e6,    # 400 MHz empirical (39% throttle!)
-        dvfs_enabled=True,
-    )
-
-    compute_resource_15w_int8 = ComputeResource(
-        resource_type="Ampere-SM-TensorCore",
-        num_units=num_sms,
-        ops_per_unit_per_clock={
-            Precision.INT8: int8_ops_per_sm_per_clock,
-            Precision.FP16: fp16_ops_per_sm_per_clock,
-            Precision.FP32: fp32_ops_per_sm_per_clock,
-        },
-        clock_domain=clock_15w,
-    )
-
-    # Peak INT8: 64 TCs × 64 MACs/TC/clock × 1.02 GHz = 4.2 TOPS (boost clock)
-    # Sustained INT8: 64 TCs × 64 MACs/TC × 400 MHz = 1.6 TOPS (throttled)
-    # Effective INT8: 1.6 TOPS × 0.20 empirical derate = 0.3 TOPS (memory-bound)
-
-    thermal_15w = ThermalOperatingPoint(
-        name="15W-passive",
-        tdp_watts=15.0,
-        cooling_solution="passive-heatsink",
-        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
-        performance_specs={
-            Precision.INT8: PerformanceCharacteristics(
-                precision=Precision.INT8,
-                compute_resource=compute_resource_15w_int8,
-                instruction_efficiency=0.85,
-                memory_bottleneck_factor=0.60,
-                efficiency_factor=0.47,  # 47% of sustained (3% of peak!)
-                native_acceleration=True,
-            ),
-            Precision.FP16: PerformanceCharacteristics(
-                precision=Precision.FP16,
-                compute_resource=compute_resource_15w_int8,
-                efficiency_factor=0.40,  # Worse (more memory bound)
-                native_acceleration=True,
-            ),
-            Precision.FP32: PerformanceCharacteristics(
-                precision=Precision.FP32,
-                compute_resource=compute_resource_15w_int8,
-                efficiency_factor=0.25,  # Much worse
-                native_acceleration=True,
-            ),
-        }
-    )
-
-    # ========================================================================
-    # 30W MODE: Balanced configuration (active fan cooling)
-    # ========================================================================
-    clock_30w = ClockDomain(
-        base_clock_hz=612e6,
-        max_boost_clock_hz=1.15e9,
-        sustained_clock_hz=650e6,    # 650 MHz sustained (57% throttle)
-        dvfs_enabled=True,
-    )
-
-    compute_resource_30w = ComputeResource(
-        resource_type="Ampere-SM-TensorCore",
-        num_units=num_sms,
-        ops_per_unit_per_clock={
-            Precision.INT8: int8_ops_per_sm_per_clock,
-            Precision.FP16: fp16_ops_per_sm_per_clock,
-            Precision.FP32: fp32_ops_per_sm_per_clock,
-        },
-        clock_domain=clock_30w,
-    )
-
-    # Sustained INT8: 64 TCs × 64 MACs/TC × 650 MHz = 2.7 TOPS
-    # Effective: 2.7 × 0.40 = 1.1 TOPS (40% efficiency, memory-bound)
-
-    thermal_30w = ThermalOperatingPoint(
-        name="30W-active",
-        tdp_watts=30.0,
-        cooling_solution="active-fan",
-        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
-        performance_specs={
-            Precision.INT8: PerformanceCharacteristics(
-                precision=Precision.INT8,
-                compute_resource=compute_resource_30w,
-                efficiency_factor=0.60,  # Better (10% of peak)
-                native_acceleration=True,
-            ),
-            Precision.FP16: PerformanceCharacteristics(
-                precision=Precision.FP16,
-                compute_resource=compute_resource_30w,
-                efficiency_factor=0.50,
-                native_acceleration=True,
-            ),
-            Precision.FP32: PerformanceCharacteristics(
-                precision=Precision.FP32,
-                compute_resource=compute_resource_30w,
-                efficiency_factor=0.35,
-                native_acceleration=True,
-            ),
-        }
-    )
-
-    # ========================================================================
-    # 50W MODE: High performance (active cooling required)
-    # ========================================================================
-    # CALIBRATED 2026-02-03: Measured via Conv2D microbenchmarks on Orin AGX
-    # GPU clock observed at 306-816 MHz range during benchmarks
-    clock_50w = ClockDomain(
-        base_clock_hz=828e6,
-        max_boost_clock_hz=1.2e9,
-        sustained_clock_hz=900e6,    # 900 MHz sustained (75% of boost)
-        dvfs_enabled=True,
-    )
-
-    compute_resource_50w = ComputeResource(
-        resource_type="Ampere-SM-TensorCore",
-        num_units=num_sms,
-        ops_per_unit_per_clock={
-            Precision.INT8: int8_ops_per_sm_per_clock,
-            Precision.FP16: fp16_ops_per_sm_per_clock,
-            Precision.FP32: fp32_ops_per_sm_per_clock,
-        },
-        clock_domain=clock_50w,
-    )
-
-    # CALIBRATION DATA (2026-02-03, Conv2D microbenchmarks):
-    # - FP32 Conv2D average: 968 GFLOPS (26% of theoretical peak)
-    # - FP16 Conv2D average: 1012 GFLOPS (27% of theoretical peak)
-    # - BF16 Conv2D average: 1057 GFLOPS (29% of theoretical peak)
-    # - Depthwise convs: 3-80 GFLOPS (severely memory-bound)
-    # - Standard 3x3 convs: 400-4000 GFLOPS (size-dependent)
-    # - GEMM: 1592 GFLOPS FP32, 3406 GFLOPS FP16 (higher than Conv2D)
-    # Note: INT8 requires TensorRT for native support, not available in PyTorch
-
-    thermal_50w = ThermalOperatingPoint(
-        name="50W-performance",
-        tdp_watts=50.0,
-        cooling_solution="active-fan-high",
-        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
-        performance_specs={
-            Precision.INT8: PerformanceCharacteristics(
-                precision=Precision.INT8,
-                compute_resource=compute_resource_50w,
-                # INT8 estimated from FP16 scaling (TensorRT typically 1.5-2x FP16)
-                efficiency_factor=0.40,  # Conservative estimate without TensorRT calibration
-                native_acceleration=True,
-            ),
-            Precision.FP16: PerformanceCharacteristics(
-                precision=Precision.FP16,
-                compute_resource=compute_resource_50w,
-                # CALIBRATED: 1012 GFLOPS / 3686 GFLOPS theoretical = 27%
-                efficiency_factor=0.27,
-                native_acceleration=True,
-            ),
-            Precision.FP32: PerformanceCharacteristics(
-                precision=Precision.FP32,
-                compute_resource=compute_resource_50w,
-                # CALIBRATED: 968 GFLOPS / 3686 GFLOPS theoretical = 26%
-                efficiency_factor=0.26,
-                native_acceleration=True,
-            ),
-            Precision.BF16: PerformanceCharacteristics(
-                precision=Precision.BF16,
-                compute_resource=compute_resource_50w,
-                # CALIBRATED: 1057 GFLOPS / 3686 GFLOPS theoretical = 29%
-                efficiency_factor=0.29,
-                native_acceleration=True,
-            ),
-        }
-    )
-
-    # ========================================================================
-    # MAXN MODE: Unconstrained (experimental - hardware throttling engaged)
-    # ========================================================================
-    clock_maxn = ClockDomain(
-        base_clock_hz=918e6,
-        max_boost_clock_hz=1.3e9,
-        sustained_clock_hz=1.0e9,    # 1.0 GHz sustained (77% of boost)
-        dvfs_enabled=True,
-    )
-
-    compute_resource_maxn = ComputeResource(
-        resource_type="Ampere-SM-TensorCore",
-        num_units=num_sms,
-        ops_per_unit_per_clock={
-            Precision.INT8: int8_ops_per_sm_per_clock,
-            Precision.FP16: fp16_ops_per_sm_per_clock,
-            Precision.FP32: fp32_ops_per_sm_per_clock,
-        },
-        clock_domain=clock_maxn,
-    )
-
-    # MAXN is unconstrained but throttles under sustained load
-    # Peak INT8: 64 TCs × 64 MACs/TC × 1.0 GHz = 4.1 TOPS
-    # Effective: varies due to thermal throttling
-
-    thermal_maxn = ThermalOperatingPoint(
-        name="MAXN-unconstrained",
-        tdp_watts=60.0,  # Can exceed this, triggering throttling
-        cooling_solution="active-fan-max",
-        memory_clock_mhz=3200.0,  # LPDDR5-6400 (Orin GA10B silicon spec)
-        performance_specs={
-            Precision.INT8: PerformanceCharacteristics(
-                precision=Precision.INT8,
-                compute_resource=compute_resource_maxn,
-                efficiency_factor=0.75,  # Best case before throttling
-                native_acceleration=True,
-            ),
-            Precision.FP16: PerformanceCharacteristics(
-                precision=Precision.FP16,
-                compute_resource=compute_resource_maxn,
-                efficiency_factor=0.65,
-                native_acceleration=True,
-            ),
-            Precision.FP32: PerformanceCharacteristics(
-                precision=Precision.FP32,
-                compute_resource=compute_resource_maxn,
-                efficiency_factor=0.50,
-                native_acceleration=True,
-            ),
-        }
-    )
-
-    # ========================================================================
-    # BOM Cost Profile
-    # ========================================================================
-    bom_cost = BOMCostProfile(
+    # BoM cost overlay -- not yet carried by the v2 ComputeProduct schema.
+    # Numbers from NVIDIA pricing / industry teardowns (2025).
+    model.bom_cost_profile = BOMCostProfile(
         silicon_die_cost=380.0,
         package_cost=60.0,
         memory_cost=160.0,
@@ -399,232 +75,11 @@ def jetson_orin_agx_64gb_resource_model() -> HardwareResourceModel:
         volume_tier="10K+",
         process_node="8nm",
         year=2025,
-        notes="High-end edge AI module. 64GB LPDDR5. NVIDIA pricing: competitive margin for robotics/automotive. Competes with datacenter inference cards.",
-    )
-
-    # ========================================================================
-    # Legacy Precision Profiles (calculated from combined CUDA + Tensor cores)
-    # ========================================================================
-    # Calculate peak ops at 30W sustained baseline (650 MHz)
-    # FP64/FP32: CUDA cores only
-    # FP16/INT8: Combined CUDA cores (at higher rate) + Tensor cores
-    cuda_fp64_peak = cuda_fabric.get_peak_ops_per_sec(Precision.FP64)
-    cuda_fp32_peak = cuda_fabric.get_peak_ops_per_sec(Precision.FP32)
-    # FP16/INT8: Use combined peaks (CUDA + Tensor cores)
-    combined_fp16_peak = fp16_ops_per_clock * baseline_freq_hz  # 24576 × 650e6 = 15.97 TFLOPS
-    combined_int8_peak = int8_ops_per_clock * baseline_freq_hz  # 49152 × 650e6 = 31.95 TOPS
-
-    # ========================================================================
-    # Hardware Resource Model (uses NEW thermal operating points + compute fabrics)
-    # ========================================================================
-    model = HardwareResourceModel(
-        name="Jetson-Orin-AGX-64GB",
-        hardware_type=HardwareType.GPU,
-
-        # NEW: Compute fabrics
-        compute_fabrics=[cuda_fabric, tensor_fabric],
-
-        # Legacy fields (for backward compatibility)
-        compute_units=num_sms,
-        threads_per_unit=64,
-        warps_per_unit=2,
-        warp_size=32,
-
-        # GPU Microarchitecture (Ampere)
-        cuda_cores_per_sm=cuda_cores_per_sm,
-        tensor_cores_per_sm=tensor_cores_per_sm,
-        ops_per_clock_per_core=2.0,  # FMA: 2 ops/clock for FP32
-        sm_boost_clock_hz=1.3e9,     # 1.3 GHz boost (MAXN mode)
-        sm_sustained_clock_hz=650e6,  # 650 MHz sustained (30W mode typical)
-
-        # NEW: Thermal operating points with DVFS modeling
-        # Power modes per NVIDIA nvpmodel: 15W, 30W, 50W, MAXN
-        thermal_operating_points={
-            "15W": thermal_15w,   # Battery-powered deployment (passive cooling)
-            "30W": thermal_30w,   # Balanced (active cooling, typical deployment)
-            "50W": thermal_50w,   # High performance (robust active cooling)
-            "MAXN": thermal_maxn, # Unconstrained (experimental, throttles under load)
-        },
-        default_thermal_profile="30W",  # Balanced default for edge AI with active cooling
-
-        # Legacy precision profiles (calculated from fabrics)
-        precision_profiles={
-            Precision.FP64: PrecisionProfile(
-                precision=Precision.FP64,
-                peak_ops_per_sec=cuda_fp64_peak,  # ~2.7 TFLOPS @ 650 MHz
-                tensor_core_supported=False,
-                relative_speedup=1.0,
-                bytes_per_element=8,
-            ),
-            Precision.FP32: PrecisionProfile(
-                precision=Precision.FP32,
-                peak_ops_per_sec=cuda_fp32_peak,  # ~2.7 TFLOPS @ 650 MHz (CUDA cores)
-                tensor_core_supported=False,
-                relative_speedup=1.0,
-                bytes_per_element=4,
-            ),
-            Precision.FP16: PrecisionProfile(
-                precision=Precision.FP16,
-                peak_ops_per_sec=combined_fp16_peak,  # ~16 TFLOPS @ 650 MHz (CUDA + Tensor)
-                tensor_core_supported=True,
-                relative_speedup=6.0,  # ~6x FP32 theoretical
-                bytes_per_element=2,
-                accumulator_precision=Precision.FP32,
-            ),
-            Precision.INT8: PrecisionProfile(
-                precision=Precision.INT8,
-                peak_ops_per_sec=combined_int8_peak,  # ~32 TOPS @ 650 MHz (CUDA + Tensor)
-                tensor_core_supported=True,
-                relative_speedup=12.0,  # ~12x FP32 theoretical
-                bytes_per_element=1,
-                accumulator_precision=Precision.INT32,
-            ),
-        },
-        default_precision=Precision.INT8,
-
-        peak_bandwidth=204.8e9,       # 204.8 GB/s LPDDR5
-        l1_cache_per_unit=128 * 1024,  # 128 KB per SM
-        l2_cache_total=4 * 1024 * 1024,  # 4 MB
-        main_memory=64 * 1024**3,     # 64 GB LPDDR5
-
-        # Legacy energy (use CUDA fabric as baseline)
-        energy_per_flop_fp32=cuda_fabric.energy_per_flop_fp32,  # 1.9 pJ
-        energy_per_byte=15e-12,       # 15 pJ/byte (LPDDR5)
-        energy_scaling={
-            Precision.FP64: 2.0,
-            Precision.FP32: 1.0,
-            Precision.FP16: 0.5,
-            Precision.INT8: 0.125,
-        },
-
-        min_occupancy=0.3,
-        max_concurrent_kernels=8,
-        wave_quantization=4,
-        bom_cost_profile=bom_cost,
-
-        # M3 Layer 3: Ampere SM L1 / shared-memory unified store.
-        # Hardware-managed when used as L1, software-managed when
-        # configured as shared memory; classified as cache because
-        # the dominant deployment uses unified L1 cache mode.
-        l1_storage_kind="cache",
-
-        # M4 Layer 4: Orin's L2 is a single 4 MB shared structure.
-        # Ampere SoCs do not have a distinct L3 -- L2 is the LLC.
-        # ``l2_cache_per_unit`` reports the per-SM share (4 MB / 16 SMs).
-        l2_cache_per_unit=(4 * 1024 * 1024) // 16,  # 256 KiB per SM
-        l2_topology="shared-llc",
-
-        # M5 Layer 5: Ampere SoC has no distinct L3 layer.
-        l3_present=False,
-        l3_cache_total=0,
-        coherence_protocol="none",  # SIMT memory model, not snoopy
-
-        # M7 Layer 7: 256-bit LPDDR5 (204.8 GB/s).
-        memory_technology="LPDDR5",
-        memory_read_energy_per_byte_pj=15.0,
-        memory_write_energy_per_byte_pj=18.0,
-
-        # M6 Layer 6: SM-to-L2 crossbar interconnect. 16 SMs * 4 L2
-        # slices = 64-port crossbar; effectively single-hop access
-        # across the full L2.
-        soc_fabric=SoCFabricModel(
-            topology=Topology.CROSSBAR,
-            hop_latency_ns=2.0,
-            pj_per_flit_per_hop=8.0,
-            bisection_bandwidth_gbps=2048.0,  # ~256 GB/s SM<->L2
-            controller_count=16,              # 16 SMs as crossbar ports
-            flit_size_bytes=32,
-            routing_distance_factor=1.0,
-            provenance=("Jetson Orin AGX Ampere SoC: SM-to-L2 crossbar "
-                        "interconnect (NVIDIA architectural fact)"),
+        notes=(
+            "High-end edge AI module. 64GB LPDDR5. NVIDIA pricing: "
+            "competitive margin for robotics/automotive. Competes with "
+            "datacenter inference cards."
         ),
     )
-
-    # M3 Layer 3 provenance for L1 cache fields
-    from graphs.core.confidence import EstimationConfidence
-    model.set_provenance(
-        "l1_cache_per_unit",
-        EstimationConfidence.theoretical(
-            score=0.85,
-            source=("Ampere SM Architecture Whitepaper: 192 KB unified "
-                    "L1 / shared, of which 128 KB configurable as L1"),
-        ),
-    )
-    model.set_provenance(
-        "l1_storage_kind",
-        EstimationConfidence.theoretical(
-            score=0.80,
-            source=("Ampere unified L1: hardware-managed when used as "
-                    "L1, software-managed when configured as shared mem"),
-        ),
-    )
-
-    # M4 Layer 4 provenance for L2 (== LLC on Orin AGX)
-    model.set_provenance(
-        "l2_cache_per_unit",
-        EstimationConfidence.theoretical(
-            score=0.85,
-            source=("Jetson Orin AGX datasheet: 4 MB shared L2 across "
-                    "16 Ampere SMs (256 KiB per-SM share)"),
-        ),
-    )
-    model.set_provenance(
-        "l2_topology",
-        EstimationConfidence.theoretical(
-            score=0.90,
-            source=("Ampere SoC architectural fact: L2 is the LLC "
-                    "(no distinct L3 layer)"),
-        ),
-    )
-
-    # M5 Layer 5 provenance: Orin has no distinct L3
-    model.set_provenance(
-        "l3_present",
-        EstimationConfidence.theoretical(
-            score=0.95,
-            source="Ampere SoC architectural fact: no distinct L3 layer",
-        ),
-    )
-    model.set_provenance(
-        "l3_cache_total",
-        EstimationConfidence.theoretical(
-            score=0.95,
-            source=("Ampere SoC: Layer 5 cache absent by design "
-                    "(L2 is the LLC), capacity fixed at 0 bytes"),
-        ),
-    )
-    model.set_provenance(
-        "coherence_protocol",
-        EstimationConfidence.theoretical(
-            score=0.90,
-            source=("SIMT shared-memory model: not snoopy / coherent in "
-                    "the CPU sense (warp-level memory ordering only)"),
-        ),
-    )
-
-    # M6 Layer 6 provenance: SM-to-L2 crossbar
-    model.set_provenance(
-        "soc_fabric",
-        EstimationConfidence.theoretical(
-            score=0.75,
-            source=("Ampere SM-to-L2 crossbar topology is documented; "
-                    "per-flit energy estimated from 8nm process baseline"),
-        ),
-    )
-
-    # M7 Layer 7 provenance
-    for key in ("memory_technology",
-                "memory_read_energy_per_byte_pj",
-                "memory_write_energy_per_byte_pj"):
-        model.set_provenance(
-            key,
-            EstimationConfidence.theoretical(
-                score=0.85,
-                source=("Jetson Orin AGX: 256-bit LPDDR5 @ 204.8 GB/s "
-                        "(NVIDIA datasheet); JEDEC LPDDR5 energy"),
-            ),
-        )
 
     return model
-
-

--- a/tests/hardware/test_gpu_yaml_loader_jetson_agx_orin_parity.py
+++ b/tests/hardware/test_gpu_yaml_loader_jetson_agx_orin_parity.py
@@ -1,14 +1,23 @@
-"""Parity test: YAML-loaded Jetson AGX Orin 64GB matches hand-coded factory.
+"""Contract test: Jetson AGX Orin 64GB factory produces the expected model.
 
-PR 4 of the GPU sprint scoped at #171. The hand-coded factory at
-``src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py`` is the
-ground truth that the YAML-loaded model needs to reproduce. This
-test compares the two field-by-field across every axis the
-downstream consumers (mappers, roofline, energy estimator) read.
+Originally PR 4's parity test, comparing the YAML-loaded model
+against the hand-coded factory. PR 5 retired the hand-coded body
+and made the factory a thin wrapper over
+``load_gpu_resource_model_from_yaml``, so today both ``hand_coded``
+and ``yaml_loaded`` fixtures resolve through the same loader.
 
-Once this test passes, PR 5 (cleanup) can replace the hand-coded
-factory with a thin ``load_gpu_resource_model_from_yaml`` call without
-changing any chip-level numerical output.
+The structural assertions (SM hierarchy, compute fabrics, memory
+hierarchy, SoC fabric, thermal profiles, scheduler attrs) are now
+**contract tests on the YAML loader's output** rather than parity
+checks. They still catch loader regressions and YAML drift; they
+also fail loudly if anyone changes the factory's name override or
+substitutes a different SKU id.
+
+The BOM cost preservation test below is specific to PR 5: the BoM
+overlay is the only piece of data the factory adds on top of the
+loader output (the v2 ComputeProduct schema doesn't carry BoM cost
+yet). Removing the overlay would break validation scripts that read
+``hardware.bom_cost_profile``.
 """
 
 import pytest
@@ -288,3 +297,60 @@ def test_loader_raises_on_kpu_sku():
     """A KPU ComputeProduct has no GPUBlock; loader should reject."""
     with pytest.raises(GPUYamlLoaderError, match="no GPUBlock"):
         load_gpu_resource_model_from_yaml("kpu_t64_32x32_lp5x4_16nm_tsmc_ffp")
+
+
+# ---------------------------------------------------------------------------
+# PR 5 specifics: factory's BoM overlay (the only thing the factory adds
+# on top of the YAML loader's output)
+# ---------------------------------------------------------------------------
+
+def test_factory_attaches_bom_cost_profile(hand_coded):
+    """The thin factory layers a BOMCostProfile onto the YAML-loaded
+    model because the v2 ComputeProduct schema doesn't carry BoM data.
+    Removing this overlay would break validation scripts that read
+    ``hardware.bom_cost_profile``."""
+    bom = hand_coded.bom_cost_profile
+    assert bom is not None, "factory must attach BOMCostProfile (PR 5 overlay)"
+    # Spot-check the headline numbers; full BOMCostProfile content is
+    # AGX Orin specific and cited in the factory module.
+    assert bom.retail_price == pytest.approx(899.0)
+    assert bom.process_node == "8nm"
+
+
+def test_factory_attaches_memory_clock_to_thermal_profiles(hand_coded):
+    """Orin AGX runs LPDDR5-6400 at 3200 MHz internal across all four
+    nvpmodel profiles. The chip-level KPUThermalProfile shape doesn't
+    carry memory_clock_mhz; the factory layers it on after loading.
+    Without this overlay the cli/list_hardware_resources Phase 4
+    tests fail."""
+    for name, profile in hand_coded.thermal_operating_points.items():
+        assert profile.memory_clock_mhz == 3200.0, (
+            f"profile {name!r} missing memory_clock_mhz overlay "
+            f"(got {profile.memory_clock_mhz})"
+        )
+
+
+def test_loader_alone_does_not_attach_memory_clock(yaml_loaded):
+    """Confirms memory_clock_mhz is the FACTORY's contribution. The
+    v3 schema generalization (ThermalProfile w/ optional memory clock)
+    will move it into the YAML; this assertion will fire then and force
+    a deliberate update -- delete the overlay and this guard."""
+    for name, profile in yaml_loaded.thermal_operating_points.items():
+        assert profile.memory_clock_mhz is None, (
+            f"loader populated memory_clock_mhz on profile {name!r} "
+            f"(expected None until v3 schema). The factory's overlay "
+            f"can now be deleted."
+        )
+
+
+def test_loader_alone_does_not_attach_bom_cost(yaml_loaded):
+    """Confirms the BoM is the FACTORY's contribution, not the loader's.
+    If the v3 schema PR adds Market.bom and the loader starts populating
+    it, this test will fail and force a deliberate update -- at which
+    point the factory's overlay can be deleted."""
+    assert yaml_loaded.bom_cost_profile is None, (
+        "loader is not expected to attach BOMCostProfile; the v2 "
+        "ComputeProduct schema doesn't carry BoM data. If this assertion "
+        "fails, the YAML schema gained a Market.bom field; update the "
+        "factory to drop its BoM overlay accordingly."
+    )


### PR DESCRIPTION
## Summary

Final PR of the GPU sprint scoped at #171. Replaces the 630-LOC hand-coded ``jetson_orin_agx_64gb_resource_model()`` with a 73-LOC thin wrapper over ``load_gpu_resource_model_from_yaml()`` from PR #180. Net -479 LOC.

The wrapper preserves the public function signature so existing callers (``create_jetson_orin_agx_64gb_mapper``, layer1 reporting, validation scripts, ``cli/compare_*.py``) continue to work unchanged.

## What the YAML loader covers

SM hierarchy, compute fabrics (CUDA + Tensor cores with per-precision ops and energy), memory hierarchy (L1/L2/L3, LPDDR5), SoC fabric (crossbar), all four nvpmodel thermal profiles, precision profiles, scheduler attrs.

PR #180's 42 parity tests proved these match the hand-coded factory's output before this swap; they still serve as the loader-output contract test.

## Two overlays remain in the factory

Both are data the v2 ComputeProduct schema doesn't yet carry:

1. **``BOMCostProfile``** (silicon / package / memory / PCB / thermal / margin / retail) -- v3 schema PR will add ``Market.bom`` and this overlay can move into the YAML.

2. **``ThermalOperatingPoint.memory_clock_mhz``** -- LPDDR5-6400 runs at 3200 MHz internal across all four nvpmodel profiles on Orin AGX (NVIDIA datasheet). The chip-level ``Power.thermal_profiles`` uses ``KPUThermalProfile`` shape which doesn't carry ``memory_clock_mhz``; the v3 ``ThermalProfile`` generalization will absorb this overlay.

Both overlays are guarded by tests that assert the factory adds them AND that the loader alone does NOT (so the v3 absorption fires a deliberate-cleanup signal when the schema gains those fields).

## Test results

2735 passing (was 2731 before PR 5, net +4 overlay tests). Catalog gate clean. CI re-runs against this branch.

The original parity test from PR #180 has been re-framed as a contract test on the YAML loader's output (since both fixtures now resolve through the same loader). The structural assertions (SM hierarchy, fabrics, memory, SoC fabric, thermal profiles, scheduler attrs) still catch loader regressions and YAML drift; they also fail loudly if anyone changes the factory's name override or substitutes a different SKU id.

## Files touched

| File | Change |
|---|---|
| ``src/graphs/hardware/models/edge/jetson_orin_agx_64gb.py`` | 630 LOC -> 73 LOC (-557 net) |
| ``tests/hardware/test_gpu_yaml_loader_jetson_agx_orin_parity.py`` | Docstring updated to reflect new contract-test role; +4 new tests covering both overlays |

## Test plan

- [x] Local pytest suite passes (2735/13/4)
- [x] ``create_jetson_orin_agx_64gb_mapper()`` smoke-tests pass (factory wraps the loader)
- [x] BOMCostProfile preserved (smoke + parity test)
- [x] ``memory_clock_mhz=3200`` populated on all four thermal profiles
- [x] ``test_v4_validation`` and ``test_thermal_profiles`` pass (consumers of the factory's ThermalOperatingPoint shape)

## Sprint complete

- PR 1: #179 (paper exercise / design doc)
- PR 2: branes-ai/embodied-schemas#19 (GPUBlock schema)
- PR 3: branes-ai/embodied-schemas#20 (Jetson AGX Orin YAML)
- PR 4: #180 (gpu_yaml_loader + 42 parity tests)
- PR 5: **this PR** (factory swap + overlay tests)

## Related

- Sprint tracker: #171
- Loader PR: #180
- Design doc: ``docs/designs/gpu-compute-product-schema-extension.md``

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Jetson Orin AGX 64GB hardware resource model now includes memory clock frequency specifications and bill-of-materials cost profile information, providing enhanced data for system capacity planning and cost estimation.

* **Tests**
  * Test coverage expanded to validate correct loading and configuration of hardware model specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/181)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->