### PR TITLE
refactor(hardware): retire hand-coded hailo8 factory (#187 sprint PR 5/5)

### DIFF
--- a/src/graphs/hardware/models/edge/hailo8.py
+++ b/src/graphs/hardware/models/edge/hailo8.py
@@ -1,360 +1,86 @@
+"""Hailo-8 resource model.
+
+PR 5 of the NPU sprint scoped at #187. As of this PR, the chip's
+architectural and thermal-profile data lives in the canonical YAML
+at ``embodied-schemas:data/compute_products/hailo/hailo_8.yaml``
+(landed in embodied-schemas#26) and is loaded via ``npu_yaml_loader``.
+The previous ~360-LOC hand-coded ``HardwareResourceModel``
+constructor was retired here; its parity with the YAML-loaded model
+was established in PR #189's
+``test_npu_yaml_loader_hailo8_parity.py``.
+
+The public function name and signature are preserved so existing
+callers (``create_hailo8_mapper``, layer1 reporting, validation
+scripts, ``cli/compare_*.py``) continue to work unchanged.
+
+One overlay remains in the factory after loading -- BoM cost --
+which is data the v4 ComputeProduct schema doesn't yet carry:
+
+  - ``BOMCostProfile`` -- die / package / memory / PCB / thermal /
+    margin / retail; v5 ``Market.bom`` will absorb it.
+
+No memory_clock overlay needed (unlike Jetson AGX Orin / Thor):
+NPUs have no external DRAM in the common case (Hailo-8 is SRAM-only)
+and run at a single fixed frequency, so per-profile memory_clock_mhz
+isn't an NPU concern.
+
+Two known shape quirks documented in PR #189's loader docstring,
+both v5 reconciliation items:
+  - ``HardwareType.KPU`` (sic!) -- the graphs ``HardwareType`` enum
+    has no NPU value; loader preserves the hand-coded choice for
+    parity. Adding ``HardwareType.NPU`` is a separate graphs-side
+    followup.
+  - ``energy_per_flop_fp32`` synthesis -- NPUs don't ship FP32; the
+    loader synthesizes it as ``energy_per_op_int8 * 8`` per the
+    standard-cell rule of thumb. Within tolerance of the prior
+    hand-coded ``get_base_alu_energy(16, 'standard_cell')`` value.
+
+The legacy resource-model ``name`` ("Hailo-8") is preserved.
 """
-Hailo-8 Resource Model - Computer Vision AI Accelerator
 
-Dataflow architecture optimized for convolutional neural networks.
-Target: Edge AI cameras, drones, robots, embedded vision systems.
-
-Configuration:
-- 26 TOPS INT8 (dense workloads, not sparse)
-- Dataflow architecture with distributed on-chip memory
-- All-on-chip design (no external DRAM)
-- 16nm process
-- 2.5W typical power consumption
-
-Competitor to: KPU-T64, Google Coral Edge TPU, Qualcomm QCS6490
-"""
-
-from ...fabric_model import SoCFabricModel, Topology
-from ...resource_model import (
-    HardwareResourceModel,
-    HardwareType,
-    Precision,
-    PrecisionProfile,
-    ComputeFabric,
-    get_base_alu_energy,
-    ClockDomain,
-    ComputeResource,
-    PerformanceCharacteristics,
-    ThermalOperatingPoint,
-    BOMCostProfile,
-)
+from ...resource_model import BOMCostProfile, HardwareResourceModel
+from .npu_yaml_loader import load_npu_resource_model_from_yaml
 
 
-def _get_hailo8_fabric() -> SoCFabricModel:
-    """M6 Layer 6 fabric for Hailo-8.
-
-    Hailo does not publish NoC details. Per the issue M6 constraint
-    we ship with ``low_confidence=True`` and document the assumption:
-    32 dataflow units laid out as an 8x4 mesh, hop coefficients
-    estimated from the 16nm process baseline.
-    """
-    return SoCFabricModel(
-        topology=Topology.MESH_2D,
-        hop_latency_ns=1.5,
-        pj_per_flit_per_hop=1.5,
-        bisection_bandwidth_gbps=64.0,
-        controller_count=32,
-        flit_size_bytes=16,
-        mesh_dimensions=(8, 4),
-        routing_distance_factor=1.1,
-        low_confidence=True,
-        provenance=("Hailo-8: no public NoC topology data; assumed "
-                    "8x4 mesh estimated from compute_units=32 layout"),
-    )
+_LEGACY_NAME = "Hailo-8"
+_YAML_BASE_ID = "hailo_hailo_8"
 
 
 def hailo8_resource_model() -> HardwareResourceModel:
+    """Hailo-8 Computer Vision AI Accelerator.
+
+    See the YAML for the canonical chip description (32 dataflow
+    units, structure-driven dataflow architecture, INT8/INT4 only,
+    24 MiB on-chip SRAM, no external DRAM, MESH_2D NoC, single
+    2.5W operating point) and the migration notes at
+    ``docs/designs/npu-compute-product-schema-extension.md``.
     """
-    Hailo-8 Computer Vision AI Accelerator.
-
-    ARCHITECTURE:
-    - Structure-driven graph mapping architecture 
-    - Distributed on-chip memory fabric (no Von Neumann bottleneck)
-    - Network-specific compilation (custom dataflow per model)
-    - All computations on-chip (minimizes external memory access)
-    - 16nm TSMC process
-
-    PERFORMANCE:
-    - 26 TOPS INT8 (marketed, achievable)
-    - Realistic: ~22 TOPS INT8 sustained (85% efficiency)
-    - Excellent efficiency due to dataflow architecture
-    - No DVFS throttling (low power, excellent thermal design)
-
-    POWER PROFILE:
-    - 2.5W typical (single operating point, no DVFS needed)
-    - Passive cooling sufficient
-    - Best power efficiency in class (10.4 TOPS/W)
-
-    USE CASES:
-    - Edge AI cameras (YOLOv5, YOLOv8 detection)
-    - Drones (real-time object tracking)
-    - Industrial inspection (defect detection)
-    - Automotive ADAS (parking assist, lane detection)
-
-    CALIBRATION STATUS: ✅ WELL-DOCUMENTED
-    - Hailo publishes detailed benchmarks
-    - 85% efficiency typical for CNNs
-    - Real-world deployments confirm performance
-    """
-    # Physical hardware
-    num_dataflow_units = 32  # Estimated dataflow processing elements
-    int8_ops_per_unit_per_clock = 500  # High ops/clock for dataflow
-    sustained_clock_hz = 1.6e9  # 1.6 GHz sustained (no throttling)
-
-    # ========================================================================
-    # Dataflow Fabric Architecture (All-on-chip spatial dataflow)
-    # ========================================================================
-    dataflow_fabric = ComputeFabric(
-        fabric_type="dataflow_architecture",
-        circuit_type="standard_cell",   # Custom ASIC with standard cells
-        num_units=num_dataflow_units,   # 32 dataflow processing elements
-        ops_per_unit_per_clock={
-            Precision.INT8: 500,         # 500 INT8 ops/cycle per unit
-            Precision.INT4: 1000,        # 2× for INT4
-        },
-        core_frequency_hz=sustained_clock_hz,  # 1.6 GHz sustained
-        process_node_nm=16,              # 16nm TSMC
-        energy_per_flop_fp32=get_base_alu_energy(16, 'standard_cell'),  # 2.7 pJ
-        energy_scaling={
-            Precision.INT8: 0.125,       # INT8 is very efficient
-            Precision.INT4: 0.0625,      # INT4 even more efficient
-        }
+    model = load_npu_resource_model_from_yaml(
+        _YAML_BASE_ID,
+        name_override=_LEGACY_NAME,
     )
 
-    # Total INT8: 32 units × 500 ops/cycle × 1.6 GHz = 25.6 TOPS ≈ 26 TOPS ✓
-
-    # ========================================================================
-    # 2.5W MODE: Single operating point (no DVFS, well-designed thermal)
-    # ========================================================================
-    clock_2_5w = ClockDomain(
-        base_clock_hz=1.6e9,        # 1.6 GHz (estimated)
-        max_boost_clock_hz=1.6e9,   # No boost, constant frequency
-        sustained_clock_hz=1.6e9,   # No throttling
-        dvfs_enabled=False,          # Fixed frequency, excellent thermal
-    )
-
-    compute_resource_2_5w = ComputeResource(
-        resource_type="Hailo-Dataflow-Architecture",
-        num_units=num_dataflow_units,
-        ops_per_unit_per_clock={
-            Precision.INT8: 500,  # 32 units × 500 ops/clock × 1.6 GHz ≈ 25.6 TOPS
-            Precision.INT4: 1000,  # 2× for INT4 (not primary use case)
-        },
-        clock_domain=clock_2_5w,
-    )
-
-    # Sustained INT8: 32 × 500 × 1.6 GHz = 25.6 TOPS ≈ 26 TOPS ✓
-
-    thermal_2_5w = ThermalOperatingPoint(
-        name="2.5W-passive",
-        tdp_watts=2.5,
-        cooling_solution="passive-heatsink-small",
-        performance_specs={
-            Precision.INT8: PerformanceCharacteristics(
-                precision=Precision.INT8,
-                compute_resource=compute_resource_2_5w,
-                instruction_efficiency=0.95,  # Dataflow is very efficient
-                memory_bottleneck_factor=0.90,  # On-chip memory minimizes bottleneck
-                efficiency_factor=0.85,  # 85% → ~22 TOPS effective (excellent!)
-                native_acceleration=True,
-            ),
-            Precision.INT4: PerformanceCharacteristics(
-                precision=Precision.INT4,
-                compute_resource=compute_resource_2_5w,
-                efficiency_factor=0.80,  # Slightly lower for INT4
-                native_acceleration=True,
-            ),
-        }
-    )
-
-    # ========================================================================
-    # BOM COST PROFILE (Estimated @ 10K units)
-    # ========================================================================
-    bom_cost = BOMCostProfile(
-        silicon_die_cost=25.0,       # 16nm die (small, efficient)
-        package_cost=8.0,             # Standard BGA package
-        memory_cost=0.0,              # All on-chip SRAM (no external DRAM)
-        pcb_assembly_cost=4.0,        # Minimal external components
-        thermal_solution_cost=1.0,    # Tiny heatsink (2.5W)
-        other_costs=2.0,              # Testing, connectors
-        total_bom_cost=0,             # Auto-calculated: $40
-        margin_multiplier=4.0,        # High margin for specialized product
-        retail_price=160.0,           # Known retail: $150-180 for M.2 module
+    # BoM cost overlay -- not yet carried by the v4 ComputeProduct schema.
+    # Numbers from teardowns + Hailo public pricing (M.2 module retails
+    # at ~$160 with $40 BOM).
+    model.bom_cost_profile = BOMCostProfile(
+        silicon_die_cost=25.0,
+        package_cost=8.0,
+        memory_cost=0.0,           # all on-chip SRAM
+        pcb_assembly_cost=4.0,
+        thermal_solution_cost=1.0,
+        other_costs=2.0,
+        total_bom_cost=0,          # auto-calculated: $40
+        margin_multiplier=4.0,
+        retail_price=160.0,
         volume_tier="10K+",
         process_node="16nm",
         year=2025,
-        notes="Ultra-efficient edge AI accelerator. Low BOM due to all-on-chip design. "
-              "Highest TOPS/$ and TOPS/W in entry-level segment. M.2 module retails at $160."
-    )
-
-    # BOM: $25 + $8 + $0 + $4 + $1 + $2 = $40
-    # Retail: $160 (actual market pricing)
-    # Cost structure: $40 BOM, $120 margin (75% gross margin)
-
-    # ========================================================================
-    # Hardware Resource Model
-    # ========================================================================
-    model = HardwareResourceModel(
-        name="Hailo-8",
-        hardware_type=HardwareType.KPU,  # Dataflow architecture (similar to KPU)
-
-        # NEW: Compute fabric (single dataflow fabric)
-        compute_fabrics=[dataflow_fabric],
-
-        compute_units=num_dataflow_units,
-        threads_per_unit=128,  # Dataflow "threads" per unit
-        warps_per_unit=1,
-        warp_size=1,
-
-        # Thermal operating points (single profile, no DVFS needed)
-        thermal_operating_points={
-            "2.5W": thermal_2_5w,
-        },
-        default_thermal_profile="2.5W",
-
-        # Legacy precision profiles
-        precision_profiles={
-            Precision.INT8: PrecisionProfile(
-                precision=Precision.INT8,
-                peak_ops_per_sec=26e12,  # 26 TOPS INT8 (marketed, achievable)
-                tensor_core_supported=True,  # Dataflow acts like specialized hardware
-                relative_speedup=1.0,
-                bytes_per_element=1,
-            ),
-            Precision.INT4: PrecisionProfile(
-                precision=Precision.INT4,
-                peak_ops_per_sec=52e12,  # 52 TOPS INT4 (theoretical)
-                tensor_core_supported=True,
-                relative_speedup=2.0,
-                bytes_per_element=0.5,
-            ),
-        },
-        default_precision=Precision.INT8,
-
-        # Memory hierarchy (all on-chip)
-        peak_bandwidth=200e9,  # ~200 GB/s on-chip bandwidth (estimated)
-        l1_cache_per_unit=512 * 1024,  # 512 KB per unit (on-chip SRAM)
-        l2_cache_total=8 * 1024 * 1024,  # 8 MB total on-chip (estimated)
-        main_memory=0,  # No external DRAM (uses host memory for I/O only)
-
-        # Energy (use dataflow fabric energy)
-        energy_per_flop_fp32=dataflow_fabric.energy_per_flop_fp32,  # 2.7 pJ (16nm, standard cell)
-        energy_per_byte=2e-12,          # 2 pJ/byte (on-chip SRAM)
-
-        # Scheduling
-        min_occupancy=0.8,  # Dataflow compiler ensures high occupancy
-        max_concurrent_kernels=1,  # Single model execution
-        wave_quantization=1,
-
-        # BOM cost
-        bom_cost_profile=bom_cost,
-
-        # M3 Layer 3: software-managed on-chip SRAM partitioned per
-        # dataflow unit. Hailo's compiler statically allocates the
-        # working set; no hardware cache.
-        l1_storage_kind="scratchpad",
-
-        # M4 Layer 4: Hailo-8's inter-unit shared SRAM acts as the
-        # L2 layer above per-unit L1 partitions. 8 MB shared / 32
-        # units = 256 KiB per-unit share.
-        l2_cache_per_unit=(8 * 1024 * 1024) // 32,  # 256 KiB per unit
-        l2_topology="shared-llc",
-
-        # M5 Layer 5: Hailo dataflow has no inter-cluster cache.
-        l3_present=False,
-        l3_cache_total=0,
-        coherence_protocol="none",
-
-        # M7 Layer 7: Hailo-8 deployments load model weights once at
-        # initialization, then run inference entirely from on-chip
-        # SRAM. The legacy energy_per_byte=2 pJ/B reflects on-chip
-        # SRAM access, not DRAM. Model the host-side DRAM here as
-        # LPDDR4 for the cold-start / weight-load path.
-        memory_technology="LPDDR4 (host) + on-chip SRAM (steady-state)",
-        memory_read_energy_per_byte_pj=22.0,
-        memory_write_energy_per_byte_pj=27.0,
-
-        # M6 Layer 6: dataflow mesh between 32 PE units. Hailo does
-        # NOT publish per-hop NoC details, so this entry ships with
-        # low_confidence=True per issue M6 constraint. Mesh
-        # dimensions are estimated as a near-square 8x4 layout of
-        # the 32 dataflow units.
-        soc_fabric=_get_hailo8_fabric(),
-    )
-
-    # M3 Layer 3 provenance
-    from graphs.core.confidence import EstimationConfidence
-    model.set_provenance(
-        "l1_cache_per_unit",
-        EstimationConfidence.theoretical(
-            score=0.75,
-            source=("Hailo-8 Architecture Brief: ~16 MB total on-chip "
-                    "SRAM partitioned across 32 dataflow units (~512 KB/unit)"),
+        notes=(
+            "Ultra-efficient edge AI accelerator. Low BOM due to "
+            "all-on-chip design. Highest TOPS/$ and TOPS/W in "
+            "entry-level segment. M.2 module retails at $160."
         ),
     )
-    model.set_provenance(
-        "l1_storage_kind",
-        EstimationConfidence.theoretical(
-            score=0.95,
-            source="Hailo dataflow architecture: software-managed, no L1 cache",
-        ),
-    )
-
-    # M4 Layer 4 provenance for the shared L2 SRAM layer
-    model.set_provenance(
-        "l2_cache_per_unit",
-        EstimationConfidence.theoretical(
-            score=0.70,
-            source=("Hailo-8 architecture brief: ~8 MB inter-unit "
-                    "shared SRAM (256 KiB per-unit share). LLC by "
-                    "design; no DRAM-side cache."),
-        ),
-    )
-    model.set_provenance(
-        "l2_topology",
-        EstimationConfidence.theoretical(
-            score=0.90,
-            source="Hailo dataflow architecture: shared LLC over per-unit L1",
-        ),
-    )
-
-    # M5 Layer 5 provenance
-    model.set_provenance(
-        "l3_present",
-        EstimationConfidence.theoretical(
-            score=0.95,
-            source="Hailo dataflow: no inter-cluster cache layer",
-        ),
-    )
-    model.set_provenance(
-        "l3_cache_total",
-        EstimationConfidence.theoretical(
-            score=0.95,
-            source=("Hailo dataflow: Layer 5 cache absent by design, "
-                    "capacity fixed at 0 bytes"),
-        ),
-    )
-    model.set_provenance(
-        "coherence_protocol",
-        EstimationConfidence.theoretical(
-            score=0.95,
-            source="Hailo dataflow: no inter-unit coherence (compiler-routed)",
-        ),
-    )
-
-    # M6 Layer 6 provenance (low confidence - thin datasheet)
-    model.set_provenance(
-        "soc_fabric",
-        EstimationConfidence.theoretical(
-            score=0.40,
-            source=("Hailo-8 NoC topology not publicly documented; "
-                    "panel ships with low_confidence=True flag"),
-        ),
-    )
-
-    # M7 Layer 7 provenance: Hailo deploys with weights resident
-    # in on-chip SRAM; DRAM only on the cold-start path.
-    for key in ("memory_technology",
-                "memory_read_energy_per_byte_pj",
-                "memory_write_energy_per_byte_pj"):
-        model.set_provenance(
-            key,
-            EstimationConfidence.theoretical(
-                score=0.55,
-                source=("Hailo-8 host-side LPDDR4 for weight load; "
-                        "steady-state inference is on-chip SRAM "
-                        "(legacy 2 pJ/B value reflects SRAM, not DRAM)"),
-            ),
-        )
 
     return model

--- a/tests/hardware/test_npu_yaml_loader_hailo8_parity.py
+++ b/tests/hardware/test_npu_yaml_loader_hailo8_parity.py
@@ -1,30 +1,31 @@
-"""Parity test: YAML-loaded Hailo-8 matches hand-coded factory.
+"""Contract test: Hailo-8 factory produces the expected model.
 
-NPU sprint #187 PR 4. The hand-coded factory at
-``src/graphs/hardware/models/edge/hailo8.py`` is the ground truth that
-the YAML-loaded model needs to reproduce. This test compares the two
-field-by-field across every axis the downstream consumers (HailoMapper,
-roofline, energy estimator) read.
+Originally PR 4's parity test, comparing YAML-loaded against the
+hand-coded factory. PR 5 retired the 360-LOC hand-coded body of
+``hailo8_resource_model()`` and made it a thin wrapper over
+``load_npu_resource_model_from_yaml``, so today both ``hand_coded``
+and ``yaml_loaded`` fixtures resolve through the same loader.
 
-Once this test passes, PR 5 (cleanup) can replace the hand-coded
-factory with a thin ``load_npu_resource_model_from_yaml`` call
-without changing chip-level numerical output.
+The structural assertions are now **contract tests on the YAML
+loader's output** rather than parity checks. They still catch loader
+regressions and YAML drift; they also fail loudly if anyone changes
+the factory's name override or substitutes a different SKU id.
 
-**Documented gaps** -- both v5 reconciliation items, not v4 blockers:
+One factory overlay exists for Hailo-8 (the BoM cost; the v4 schema
+doesn't carry BoM data yet). No memory_clock overlay needed -- NPUs
+don't gate memory clock on thermal profile (single fixed clock,
+SRAM-only memory in the common case). The BoM-overlay tests below
+are specific to PR 5 and pin both that the factory adds it AND that
+the loader alone does NOT (so when v5 absorbs Market.bom the
+overlay-presence test fires as a deliberate-cleanup signal).
 
-  1. ``HardwareType.KPU`` (sic!) -- both the hand-coded factory and the
-     loader produce ``HardwareType.KPU`` because the graphs ``HardwareType``
-     enum doesn't have a NPU value yet. Adding ``HardwareType.NPU`` is
-     a separate followup; this test pins the current shared behavior
-     so the v5 enum addition fires it as a deliberate-update reminder.
-
-  2. ``energy_per_flop_fp32`` baseline -- NPUs don't ship FP32; the
-     loader synthesizes it as ``energy_per_op_int8 * 8`` per the
-     standard-cell rule of thumb. The hand-coded model uses
-     ``get_base_alu_energy(16, 'standard_cell')`` (=2.7 pJ). Real
-     Hailo-8 INT8 energy is ~0.34 pJ * 8 = 2.72 pJ FP32-equivalent --
-     close enough that the test passes within tolerance. Future
-     SIMD-packed energy work could narrow the gap further.
+Two documented shape quirks remain (both v5 reconciliation items):
+  - ``HardwareType.KPU`` (sic!) -- the graphs ``HardwareType`` enum
+    has no NPU value; loader preserves the hand-coded choice for
+    parity. Adding ``HardwareType.NPU`` is a separate followup.
+  - ``energy_per_flop_fp32`` synthesis -- NPUs don't ship FP32; the
+    loader synthesizes it as ``energy_per_op_int8 * 8`` per the
+    standard-cell rule of thumb.
 """
 
 import pytest
@@ -282,3 +283,39 @@ def test_loader_raises_on_gpu_sku():
 def test_loader_raises_on_cpu_sku():
     with pytest.raises(NPUYamlLoaderError, match="no NPUBlock"):
         load_npu_resource_model_from_yaml("intel_core_i7_12700k")
+
+
+# ---------------------------------------------------------------------------
+# PR 5 specifics: factory's BoM overlay (the only thing the factory adds
+# on top of the YAML loader's output)
+# ---------------------------------------------------------------------------
+
+def test_factory_attaches_bom_cost_profile(hand_coded):
+    """The thin factory layers a BOMCostProfile onto the YAML-loaded
+    model because the v4 ComputeProduct schema doesn't carry BoM data.
+    Validation scripts that read ``hardware.bom_cost_profile`` would
+    fall through to None without this overlay -- gracefully degrading
+    but losing the cost data.
+
+    Numbers should match the pre-PR-5 hand-coded BoM:
+    $25 die + $8 package + $0 memory + $4 PCB + $1 thermal + $2 other
+    = $40 BOM, $160 retail (Hailo-8 M.2 module market pricing)."""
+    bom = hand_coded.bom_cost_profile
+    assert bom is not None, "factory must attach BOMCostProfile (PR 5 overlay)"
+    assert bom.retail_price == pytest.approx(160.0)
+    assert bom.process_node == "16nm"
+    # Hailo-8 is all on-chip SRAM -- no external memory cost
+    assert bom.memory_cost == 0.0
+
+
+def test_loader_alone_does_not_attach_bom_cost(yaml_loaded):
+    """Confirms BoM is the FACTORY's contribution, not the loader's.
+    When v5 schema adds Market.bom and the loader starts populating
+    it, this test will fail and force a deliberate update -- delete
+    the factory's overlay and this guard."""
+    assert yaml_loaded.bom_cost_profile is None, (
+        "loader is not expected to attach BOMCostProfile; the v4 "
+        "ComputeProduct schema doesn't carry BoM data. If this fails, "
+        "the schema gained a Market.bom field; update the factory to "
+        "drop its BoM overlay accordingly."
+    )


### PR DESCRIPTION
## Summary

Final PR of the NPU sprint scoped at #187. Replaces the **360-LOC** hand-coded ``hailo8_resource_model()`` with a **90-LOC** thin wrapper over ``load_npu_resource_model_from_yaml()`` from #189. Net **-237 LOC**.

The public function name and signature are preserved so existing callers (``create_hailo8_mapper`` in HailoMapper factory, ``reporting/layer1_alu.py``, ``validation/hardware/test_phase2_edge_energy.py``, ``cli/compare_edge_ai_platforms.py``) continue to work unchanged.

## One overlay: BoM cost (no memory_clock needed for NPUs)

Unlike Jetson AGX Orin (#181) and Thor (#183) which layer both ``BOMCostProfile`` AND per-profile ``memory_clock_mhz`` after loading, the Hailo-8 factory needs only the BoM overlay:
- **BoM**: $25 die + $8 package + $0 memory (SRAM-only) + $4 PCB + $1 thermal + $2 other = $40 BOM, $160 retail. The v4 ComputeProduct schema doesn't have a ``Market.bom`` field yet.
- **No memory_clock overlay** -- NPUs don't gate memory clock on thermal profile (single fixed clock; SRAM-only memory in the common case).

This matches the simplicity pattern of the CPU PR 5 (#186) which had no overlays at all.

## Parity → contract test reframe

``tests/hardware/test_npu_yaml_loader_hailo8_parity.py``:
- Docstring updated from "Parity test" to "Contract test" since both fixtures now resolve through the loader
- 2 new BoM-overlay guards added (factory attaches it, loader alone does NOT) -- same pattern as #181 / #183 / #186
- All 32 pre-existing parity assertions still pass (loader-output contract is unchanged by the substitution)

## Test results: 2827 passing (was 2825 on graphs#189; +2 new BoM tests)

Pure substitution + 2 new tests; no behavior change for any consumer.

## Test plan

- [x] Local pytest passes (2827/13/4)
- [x] Smoke-tested ``create_hailo8_mapper().resource_model`` through the HailoMapper factory: 32 dataflow units, 25.6 TOPS INT8, BoM retail $160 preserved, MESH_2D NoC, single 2.5W profile
- [x] All 34 contract tests pass (32 original parity + 2 new BoM overlay guards)
- [ ] Reviewer: confirm BoM is the right overlay choice (vs leaving it as a v5 schema followup with the field None)

## Sprint complete (5 PRs across 2 repos)

- PR 1: #188 (paper exercise / design doc)
- PR 2: branes-ai/embodied-schemas#25 (``NPUBlock`` schema)
- PR 3: branes-ai/embodied-schemas#26 (Hailo-8 YAML + new ``hailo/`` vendor directory)
- PR 4: #189 (``npu_yaml_loader`` + 32 parity tests)
- PR 5: **this PR** (factory swap + BoM overlay + 2 contract tests)

## Path established for the next NPU SKU

- **Hailo-10H**: ~2 hours of YAML work + the ``KVCacheSpec`` schema extension when transformer support lands
- **Coral Edge TPU**: ~3 hours (YAML + new GF 28nm process node YAML)

## Catalog post-sprint

**12 KPU + 2 GPU + 1 CPU + 1 NPU = 16 ComputeProducts** across 4 architectures, 5 vendors (Stillwater, NVIDIA, Intel, Hailo + the foundries), and 6 process nodes (TSMC N16, N7, N4P, GF 12FDX, Samsung 8LPP, Intel 7).

## Two v5 reconciliation items documented in PR #189 remain open

1. ``HardwareType.NPU`` enum value on the graphs side (loader and hand-coded both use ``HardwareType.KPU`` today; adding the NPU value is a graphs-side enum addition).
2. ``energy_per_flop_fp32`` synthesis quality (loader uses ``int8 * 8`` standard-cell rule of thumb; landing real SIMD-packed energies in process-node YAML would tighten this).

Neither blocks the next NPU SKU; both are cross-cutting schema improvements.

## Related

- Sprint tracker: #187 (closed by this PR)
- Predecessor: #189 (loader)
- Siblings: #181 (GPU AGX Orin), #183 (GPU Thor), #186 (CPU i7-12700K) -- same shape