### PR TITLE
feat(hardware): add HardwareType.NPU to the graphs enum

### DIFF
--- a/src/graphs/hardware/mappers/accelerators/hailo.py
+++ b/src/graphs/hardware/mappers/accelerators/hailo.py
@@ -55,9 +55,16 @@ class HailoMapper(HardwareMapper):
     def __init__(self, resource_model: HardwareResourceModel):
         super().__init__(resource_model)
 
-        # Validate this is a KPU (Hailo) model
-        if resource_model.hardware_type != HardwareType.KPU:
-            raise ValueError(f"HailoMapper requires KPU resource model, got {resource_model.hardware_type}")
+        # Validate this is a Hailo dataflow model. Hailo-8 now reports
+        # HardwareType.NPU after issue #191 added the enum value; the
+        # remaining Hailo-10H still reports HardwareType.KPU until its
+        # YAML migration lands (tracked in graphs#192). Accept both
+        # during the transition.
+        if resource_model.hardware_type not in (HardwareType.NPU, HardwareType.KPU):
+            raise ValueError(
+                f"HailoMapper requires NPU or KPU resource model, got "
+                f"{resource_model.hardware_type}"
+            )
 
         # Hailo-specific parameters
         self.dataflow_cores = resource_model.compute_units  # Number of dataflow processing elements

--- a/src/graphs/hardware/models/edge/hailo8.py
+++ b/src/graphs/hardware/models/edge/hailo8.py
@@ -24,16 +24,16 @@ NPUs have no external DRAM in the common case (Hailo-8 is SRAM-only)
 and run at a single fixed frequency, so per-profile memory_clock_mhz
 isn't an NPU concern.
 
-Two known shape quirks documented in PR #189's loader docstring,
-both v5 reconciliation items:
-  - ``HardwareType.KPU`` (sic!) -- the graphs ``HardwareType`` enum
-    has no NPU value; loader preserves the hand-coded choice for
-    parity. Adding ``HardwareType.NPU`` is a separate graphs-side
-    followup.
+One known shape quirk documented in PR #189's loader docstring
+(remaining v5 reconciliation item):
   - ``energy_per_flop_fp32`` synthesis -- NPUs don't ship FP32; the
     loader synthesizes it as ``energy_per_op_int8 * 8`` per the
     standard-cell rule of thumb. Within tolerance of the prior
     hand-coded ``get_base_alu_energy(16, 'standard_cell')`` value.
+
+(Issue #191 retired the second quirk: the loader now sets
+``HardwareType.NPU`` directly, no longer falling back to
+``HardwareType.KPU``.)
 
 The legacy resource-model ``name`` ("Hailo-8") is preserved.
 """

--- a/src/graphs/hardware/models/edge/npu_yaml_loader.py
+++ b/src/graphs/hardware/models/edge/npu_yaml_loader.py
@@ -30,20 +30,17 @@ unless noted):
                                   -> thermal_operating_points
   Roll-up performance             -> precision_profiles
 
-Two known shape quirks (documented; no parity gap):
+One known shape quirk (documented; no parity gap):
 
-  1. ``HardwareType.NPU`` doesn't exist on the graphs side. The
-     existing hand-coded Hailo-8 model uses ``HardwareType.KPU``
-     because dataflow architectures were lumped with KPU when the
-     enum was first defined. The loader preserves that choice for
-     parity; adding ``HardwareType.NPU`` is a separate followup
-     (graphs-side enum change, no schema impact).
+  NPUs don't ship FP32; the ``energy_per_flop_fp32`` legacy field
+  is synthesized from ``energy_per_op_int8_pj * 8`` (FP32 is roughly
+  8x the energy of INT8 in standard cells -- the rule of thumb the
+  existing models use). Downstream consumers that read
+  ``energy_per_flop_fp32`` get a sensible proxy.
 
-  2. NPUs don't ship FP32; the ``energy_per_flop_fp32`` legacy field
-     is synthesized from ``energy_per_op_int8_pj * 8`` (FP32 is
-     roughly 8x the energy of INT8 in standard cells -- the rule of
-     thumb the existing models use). Downstream consumers that read
-     ``energy_per_flop_fp32`` get a sensible proxy.
+(Previously this section also listed ``HardwareType.NPU`` as a quirk
+because the graphs enum had no NPU value -- issue #191 added it; the
+loader now sets ``hardware_type=HardwareType.NPU`` directly.)
 
 Out of scope for v4 (deferred to v5):
   - BOMCostProfile (YAML doesn't carry; v5 Market.bom)
@@ -456,13 +453,8 @@ def load_npu_resource_model_from_yaml(
         energy_scaling.update(fabric.energy_scaling)
 
     model = HardwareResourceModel(
-        # NOTE: HardwareType.NPU doesn't exist in the graphs enum yet;
-        # use KPU to match the hand-coded Hailo-8 factory's choice
-        # (dataflow architectures got lumped with KPU when the enum
-        # was first defined). Adding HardwareType.NPU is a separate
-        # graphs-side followup.
         name=name_override or cp.name,
-        hardware_type=HardwareType.KPU,
+        hardware_type=HardwareType.NPU,
 
         compute_fabrics=compute_fabrics,
 

--- a/src/graphs/hardware/resource_model.py
+++ b/src/graphs/hardware/resource_model.py
@@ -49,6 +49,7 @@ class HardwareType(Enum):
     DPU = "dpu"  # Xilinx Vitis AI (FPGA-based accelerator)
     CGRA = "cgra"  # Stanford Plasticine (spatial dataflow accelerator)
     DSP = "dsp"  # Digital Signal Processors (Qualcomm Hexagon, TI C7x, etc.)
+    NPU = "npu"  # Neural Processing Units (Hailo, Coral, etc. -- dedicated inference accelerators)
 
 
 class Precision(Enum):

--- a/src/graphs/reporting/layer_panels/layer2_register.py
+++ b/src/graphs/reporting/layer_panels/layer2_register.py
@@ -125,7 +125,10 @@ def _kpu_fill_drain_overhead(
 
     Returns (fill_cycles, drain_cycles) for the first tile
     specialization, or None when the model doesn't carry one
-    (non-KPU SKUs).
+    (non-KPU SKUs -- GPU / CPU / NPU / etc.). Hailo dataflow NPUs
+    are architecturally similar to KPUs but don't populate
+    tile_specializations on their thermal_operating_points, so this
+    KPU-gated branch correctly excludes them.
     """
     if model.hardware_type is not HardwareType.KPU:
         return None

--- a/tests/hardware/test_npu_yaml_loader_hailo8_parity.py
+++ b/tests/hardware/test_npu_yaml_loader_hailo8_parity.py
@@ -19,13 +19,16 @@ are specific to PR 5 and pin both that the factory adds it AND that
 the loader alone does NOT (so when v5 absorbs Market.bom the
 overlay-presence test fires as a deliberate-cleanup signal).
 
-Two documented shape quirks remain (both v5 reconciliation items):
-  - ``HardwareType.KPU`` (sic!) -- the graphs ``HardwareType`` enum
-    has no NPU value; loader preserves the hand-coded choice for
-    parity. Adding ``HardwareType.NPU`` is a separate followup.
+One documented shape quirk remains (v5 reconciliation item):
   - ``energy_per_flop_fp32`` synthesis -- NPUs don't ship FP32; the
     loader synthesizes it as ``energy_per_op_int8 * 8`` per the
     standard-cell rule of thumb.
+
+(Previously this section also flagged ``HardwareType.KPU`` as a
+quirk because the graphs enum had no NPU value -- issue #191 added
+it; the loader now sets ``HardwareType.NPU`` directly. The hand-
+coded factory at ``hailo8.py`` is a thin wrapper over the loader so
+both sides report ``HardwareType.NPU``.)
 """
 
 import pytest
@@ -63,10 +66,11 @@ def test_name_matches(hand_coded, yaml_loaded):
 
 
 def test_hardware_type_matches(hand_coded, yaml_loaded):
-    """Both produce HardwareType.KPU (the graphs enum has no NPU value).
-    Adding HardwareType.NPU is a separate followup -- this test fires
-    when that lands so the substitution can happen deliberately."""
-    assert yaml_loaded.hardware_type == hand_coded.hardware_type == HardwareType.KPU
+    """Both produce HardwareType.NPU. Issue #191 added the NPU enum
+    value; before that, both produced HardwareType.KPU because
+    dataflow architectures were lumped with KPU when the enum was
+    first defined."""
+    assert yaml_loaded.hardware_type == hand_coded.hardware_type == HardwareType.NPU
 
 
 def test_compute_units_matches(hand_coded, yaml_loaded):


### PR DESCRIPTION
## Summary

Resolves the v5 reconciliation item the NPU sprint (#187) carried forward: the graphs ``HardwareType`` enum lacked an ``NPU`` value, so ``npu_yaml_loader`` was forced to set ``HardwareType.KPU`` on loaded models for parity with the hand-coded Hailo-8 factory. This worked but labeled dataflow NPU SKUs as KPUs in downstream reporting.

## Changes

| File | Change |
|---|---|
| ``src/graphs/hardware/resource_model.py`` | ``HardwareType`` enum gains ``NPU = "npu"`` |
| ``src/graphs/hardware/models/edge/npu_yaml_loader.py`` | Switches ``hardware_type`` from KPU to NPU; module docstring retires the "HardwareType.KPU quirk" note |
| ``src/graphs/hardware/models/edge/hailo8.py`` | Docstring updated to mark the quirk as retired (factory swap behavior unchanged) |
| ``src/graphs/hardware/mappers/accelerators/hailo.py`` | ``HailoMapper`` guard now accepts both NPU (Hailo-8) AND KPU (Hailo-10H still on KPU until #192) |
| ``src/graphs/reporting/layer_panels/layer2_register.py`` | Comment-only clarification on the KPU-tile branch (functionally safe -- Hailo doesn't populate tile_specs) |
| ``tests/hardware/test_npu_yaml_loader_hailo8_parity.py`` | Parity test assertion flipped from KPU to NPU |

## Audit of HardwareType.KPU branches

Two consumers branch on ``HardwareType.KPU``; both audited:

1. **``HailoMapper.__init__`` guard** -- updated to accept both NPU + KPU. Once #192 migrates Hailo-10H, the KPU acceptance can be dropped.
2. **``layer2_register._read_kpu_tile_cycles``** -- functionally safe. Returns ``None`` for non-KPU SKUs; Hailo dataflow NPUs don't populate ``tile_specializations`` even when treated as KPU, so the inner loops returned ``None`` anyway. Comment-only change to clarify the intent.

No other consumers branch on the missing NPU value.

## Test plan

- [x] All 2827 tests pass locally (matches PR #190 baseline -- no regressions)
- [x] Smoke verified: ``HardwareType.NPU.value == "npu"``, Hailo-8 reports NPU, Hailo-10H still reports KPU
- [x] Parity test now asserts ``HardwareType.NPU``
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied: ``gh pr ready``

## Followups

When [#192](https://github.com/branes-ai/graphs/issues/192) migrates Hailo-10H to the YAML loader, drop the KPU acceptance from the HailoMapper guard.

Resolves #191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected hardware type detection for Hailo-8 and Hailo-10H device models.

* **Improvements**
  * Extended hardware compatibility framework to support NPU-based accelerators alongside existing KPU devices.
  * Updated device model validation to properly recognize both NPU and KPU hardware types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->