### PR TITLE
feat(hardware): CGRA YAML loader (#196 sprint PR 4/5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
           #   PR #31 (e4d1835) second NPU SKU YAML: hailo_hailo_10h (first KVCacheSpec user)
           #   PR #32 (f5035fb) GF 28nm process node YAML (Coral Edge TPU precursor)
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
-          ref: 6e3aadb7e5bef0ed322e1f1f1172489a30da66d0
+          #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
+          #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
+          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
           path: embodied-schemas
           fetch-depth: 1
 
@@ -181,7 +183,9 @@ jobs:
           #   PR #31 (e4d1835) second NPU SKU YAML: hailo_hailo_10h (first KVCacheSpec user)
           #   PR #32 (f5035fb) GF 28nm process node YAML (Coral Edge TPU precursor)
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
-          ref: 6e3aadb7e5bef0ed322e1f1f1172489a30da66d0
+          #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
+          #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
+          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
           path: embodied-schemas
           fetch-depth: 1
 
@@ -292,7 +296,9 @@ jobs:
           #   PR #31 (e4d1835) second NPU SKU YAML: hailo_hailo_10h (first KVCacheSpec user)
           #   PR #32 (f5035fb) GF 28nm process node YAML (Coral Edge TPU precursor)
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
-          ref: 6e3aadb7e5bef0ed322e1f1f1172489a30da66d0
+          #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
+          #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
+          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
           path: embodied-schemas
           fetch-depth: 1
 
@@ -400,7 +406,9 @@ jobs:
           #   PR #31 (e4d1835) second NPU SKU YAML: hailo_hailo_10h (first KVCacheSpec user)
           #   PR #32 (f5035fb) GF 28nm process node YAML (Coral Edge TPU precursor)
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
-          ref: 6e3aadb7e5bef0ed322e1f1f1172489a30da66d0
+          #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
+          #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
+          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
           path: embodied-schemas
           fetch-depth: 1
 
@@ -481,7 +489,9 @@ jobs:
           #   PR #31 (e4d1835) second NPU SKU YAML: hailo_hailo_10h (first KVCacheSpec user)
           #   PR #32 (f5035fb) GF 28nm process node YAML (Coral Edge TPU precursor)
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
-          ref: 6e3aadb7e5bef0ed322e1f1f1172489a30da66d0
+          #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
+          #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
+          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
           path: embodied-schemas
           fetch-depth: 1
 
@@ -550,7 +560,9 @@ jobs:
           #   PR #31 (e4d1835) second NPU SKU YAML: hailo_hailo_10h (first KVCacheSpec user)
           #   PR #32 (f5035fb) GF 28nm process node YAML (Coral Edge TPU precursor)
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
-          ref: 6e3aadb7e5bef0ed322e1f1f1172489a30da66d0
+          #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
+          #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
+          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,7 +60,9 @@ jobs:
           #   PR #31 (e4d1835) second NPU SKU YAML: hailo_hailo_10h (first KVCacheSpec user)
           #   PR #32 (f5035fb) GF 28nm process node YAML (Coral Edge TPU precursor)
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
-          ref: 6e3aadb7e5bef0ed322e1f1f1172489a30da66d0
+          #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
+          #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
+          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -109,7 +109,9 @@ jobs:
           #   PR #31 (e4d1835) second NPU SKU YAML: hailo_hailo_10h (first KVCacheSpec user)
           #   PR #32 (f5035fb) GF 28nm process node YAML (Coral Edge TPU precursor)
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
-          ref: 6e3aadb7e5bef0ed322e1f1f1172489a30da66d0
+          #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
+          #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
+          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
           path: embodied-schemas
           fetch-depth: 1
 

--- a/src/graphs/hardware/models/accelerators/cgra_yaml_loader.py
+++ b/src/graphs/hardware/models/accelerators/cgra_yaml_loader.py
@@ -1,0 +1,547 @@
+"""CGRA resource model loader from embodied-schemas ComputeProduct YAMLs.
+
+PR 4 of the CGRA mini-sprint scoped at issue #196. Mirrors
+``src/graphs/hardware/models/edge/npu_yaml_loader.py`` (NPU sprint
+#189) but reads a CGRABlock-bearing ``ComputeProduct`` and builds a
+``HardwareResourceModel`` with the CGRA-shaped fields populated.
+
+Sibling to the hand-coded factory at
+``src/graphs/hardware/models/accelerators/stanford_plasticine_cgra.py``
+during the parallel-migration phase. Adding the factory swap is PR 5;
+this PR ships the loader machinery and a parity test that proves the
+YAML-loaded model matches the hand-coded one's key fields.
+
+Scope of CGRABlock -> HardwareResourceModel mapping (one-to-one
+unless noted):
+
+  CGRABlock.num_pcus              -> compute_units
+  CGRABlock.macs_per_pcu          -> threads_per_unit
+  CGRABlock.compute_fabrics[*]    -> compute_fabrics[] (num_units =
+                                     num_pcus per fabric)
+  CGRABlock.memory.{pmu, shared,  -> peak_bandwidth, l1/l2_cache_*,
+    host_dram}                       main_memory, memory_technology,
+                                     memory_*_energy_per_byte_pj
+  CGRABlock.noc                   -> soc_fabric (SoCFabricModel)
+  CGRABlock.{min_occupancy,       -> matching HardwareResourceModel fields
+    max_concurrent_models,
+    wave_quantization}
+  ComputeProduct.power.thermal_profiles[]
+                                  -> thermal_operating_points
+  Roll-up performance             -> precision_profiles
+
+CGRA-specific design decisions:
+
+1. **peak_bandwidth picks on_chip_bandwidth_gbps** (PCU mesh
+   bisection), NOT host_dram_bandwidth_gbps. CGRA workloads are
+   compiled to fit in on-chip SRAM (PMU + shared L2); host DRAM is
+   only used for bitstream load + spills. Plasticine's hand-coded
+   factory uses 40 GB/s (the PCU mesh), not the host DDR4 bandwidth.
+   This contrasts with NPU's "DRAM tier when present" convention --
+   CGRA's reconfig + dataflow pattern means on-chip is the
+   steady-state bottleneck.
+
+2. **energy_per_flop_fp32 uses fabric's FP32 scaling** when present.
+   Unlike NPUs (INT-only; FP32 synthesized as INT8 * 8), CGRAs ship
+   honest FP energy scaling in ``CGRAComputeFabric.energy_scaling``.
+   The loader uses the fabric's INT8-baseline * the FP32 scaling
+   multiplier when available, giving more accurate FP energy.
+
+3. **HardwareType.CGRA already exists** on the graphs side (unlike
+   NPU which needed #191). The loader sets it directly with no
+   transitional period.
+
+Out of scope for v5 (deferred to v6):
+
+  - BOMCostProfile (YAML doesn't carry; v6 Market.bom)
+  - Per-field provenance copy-through with rich source citations
+  - ``reconfig_overhead_cycles`` surfacing on HardwareResourceModel --
+    the v5 schema carries it on CGRABlock but the legacy graphs model
+    has no equivalent field. PR 5 cleanup or v6 will add it. Until
+    then, downstream estimators read it from the ComputeProduct
+    directly when they need it.
+  - ``supports_partial_reconfig`` -- same story.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from embodied_schemas.compute_product import ComputeProduct
+from embodied_schemas.cgra_block import (
+    CGRABlock,
+    CGRAFabricKind,
+    CGRANoCTopology,
+)
+from embodied_schemas.loaders import load_compute_products
+from embodied_schemas.process_node import ProcessNodeEntry
+
+from graphs.core.confidence import EstimationConfidence
+from graphs.hardware.fabric_model import SoCFabricModel, Topology
+from graphs.hardware.resource_model import (
+    ComputeFabric,
+    HardwareResourceModel,
+    HardwareType,
+    Precision,
+    PrecisionProfile,
+    ThermalOperatingPoint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class CGRAYamlLoaderError(Exception):
+    """Raised when a ComputeProduct YAML can't be turned into a CGRA
+    HardwareResourceModel (missing block, unsupported topology,
+    unresolved references, etc.)."""
+
+
+# ---------------------------------------------------------------------------
+# Mapping tables
+# ---------------------------------------------------------------------------
+
+_PRECISION_BY_NAME: dict[str, Precision] = {
+    "fp64": Precision.FP64,
+    "fp32": Precision.FP32,
+    "tf32": Precision.TF32,
+    "fp16": Precision.FP16,
+    "bf16": Precision.BF16,
+    "fp8_e4m3": Precision.FP8_E4M3,
+    "fp8_e5m2": Precision.FP8_E5M2,
+    "int8": Precision.INT8,
+    "int4": Precision.INT4,
+}
+
+_BYTES_PER_PRECISION: dict[Precision, float] = {
+    Precision.FP64: 8, Precision.FP32: 4, Precision.TF32: 4,
+    Precision.FP16: 2, Precision.BF16: 2,
+    Precision.FP8_E4M3: 1, Precision.FP8_E5M2: 1,
+    Precision.INT8: 1, Precision.INT4: 0.5,
+}
+
+# CGRAFabricKind -> ComputeFabric.fabric_type. The choice of name
+# matches the existing hand-coded factory's fabric_type string
+# ("pcu_spatial_dataflow") so parity tests can pin equality.
+_FABRIC_TYPE_BY_KIND: dict[CGRAFabricKind, str] = {
+    CGRAFabricKind.PCU_SPATIAL_DATAFLOW: "pcu_spatial_dataflow",
+    CGRAFabricKind.SYSTOLIC_PCU:         "systolic_pcu",
+    CGRAFabricKind.HETEROGENEOUS_PCU:    "heterogeneous_pcu",
+}
+
+# CGRAs use custom standard-cell designs across all fabric kinds.
+_CIRCUIT_TYPE_DEFAULT = "standard_cell"
+
+# CGRANoCTopology -> graphs SoCFabricModel Topology enum.
+_TOPOLOGY_BY_KIND: dict[CGRANoCTopology, Topology] = {
+    CGRANoCTopology.MESH_2D:  Topology.MESH_2D,
+    CGRANoCTopology.TORUS_2D: Topology.MESH_2D,   # torus = degenerate mesh w/ wrap-around
+    CGRANoCTopology.CROSSBAR: Topology.CROSSBAR,
+}
+
+# Memory technology -> per-byte energy table (DRAM only; on-chip SRAM
+# energy comes from the YAML's pmu_access_energy_pj_per_byte).
+_DRAM_READ_PJ_PER_BYTE: dict[str, float] = {
+    "ddr4": 28.0, "ddr5": 25.0,
+    "lpddr4": 18.0, "lpddr4x": 16.0,
+    "lpddr5": 15.0, "lpddr5x": 13.0,
+    "hbm2": 7.0, "hbm3": 6.0,
+}
+_DRAM_WRITE_RATIO = 1.2
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _cgra_block(cp: ComputeProduct) -> CGRABlock:
+    """Pick the (single) CGRABlock from a ComputeProduct's first die."""
+    for block in cp.dies[0].blocks:
+        if isinstance(block, CGRABlock):
+            return block
+    raise CGRAYamlLoaderError(
+        f"ComputeProduct {cp.id!r} has no CGRABlock in dies[0].blocks "
+        f"(found: {[type(b).__name__ for b in cp.dies[0].blocks]})"
+    )
+
+
+def _precisions_from_ops_dict(
+    ops: dict[str, int],
+    *,
+    source: str = "ops_per_unit_per_clock",
+) -> dict[Precision, int]:
+    """Convert YAML's str-keyed ops/clock dict to graphs' Precision-keyed
+    dict. Fails fast on unknown precision names."""
+    out: dict[Precision, int] = {}
+    unknown: list[str] = []
+    for name, count in ops.items():
+        prec = _PRECISION_BY_NAME.get(name.lower())
+        if prec is None:
+            unknown.append(name)
+            continue
+        out[prec] = count
+    if unknown:
+        raise CGRAYamlLoaderError(
+            f"unknown precision name(s) in {source}: {sorted(unknown)}. "
+            f"Known: {sorted(_PRECISION_BY_NAME)}"
+        )
+    return out
+
+
+def _energy_scaling_from_yaml(
+    scaling: dict[str, float],
+    *,
+    source: str = "energy_scaling",
+) -> dict[Precision, float]:
+    out: dict[Precision, float] = {}
+    unknown: list[str] = []
+    for name, factor in scaling.items():
+        prec = _PRECISION_BY_NAME.get(name.lower())
+        if prec is None:
+            unknown.append(name)
+            continue
+        out[prec] = factor
+    if unknown:
+        raise CGRAYamlLoaderError(
+            f"unknown precision name(s) in {source}: {sorted(unknown)}. "
+            f"Known: {sorted(_PRECISION_BY_NAME)}"
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def load_cgra_resource_model_from_yaml(
+    base_id: str,
+    *,
+    products: Optional[dict[str, ComputeProduct]] = None,
+    process_nodes: Optional[dict[str, ProcessNodeEntry]] = None,
+    name_override: Optional[str] = None,
+) -> HardwareResourceModel:
+    """Build a ``HardwareResourceModel`` for ``base_id`` from a CGRA
+    ComputeProduct YAML.
+
+    Args:
+        base_id: ComputeProduct id, e.g., "stanford_plasticine_v2".
+        products / process_nodes: optional pre-loaded catalogs.
+        name_override: optional override for the resource model's
+            ``name`` field. Plasticine v2 YAML name is
+            "Stanford Plasticine v2"; the hand-coded factory uses
+            "CGRA-Plasticine-v2" -- pass that to preserve compat.
+
+    Raises:
+        CGRAYamlLoaderError: when ``base_id`` is not in the catalog,
+            doesn't carry a CGRABlock, or has unresolvable references.
+    """
+    if products is None:
+        products = load_compute_products()
+    if process_nodes is None:
+        from embodied_schemas.loaders import load_process_nodes
+        process_nodes = load_process_nodes()
+
+    cp = products.get(base_id)
+    if cp is None:
+        raise CGRAYamlLoaderError(
+            f"no ComputeProduct with id={base_id!r}. Available: "
+            f"{', '.join(sorted(products))}"
+        )
+    block = _cgra_block(cp)
+
+    node = process_nodes.get(cp.dies[0].process_node_id)
+    if node is None:
+        raise CGRAYamlLoaderError(
+            f"SKU {base_id!r} references process_node_id="
+            f"{cp.dies[0].process_node_id!r} which does not resolve"
+        )
+    process_node_nm = int(node.node_nm)
+
+    # ------------------------------------------------------------------
+    # Default thermal profile -> clock used as fabric core_frequency_hz
+    # ------------------------------------------------------------------
+    default_profile = next(
+        (p for p in cp.power.thermal_profiles
+         if p.name == cp.power.default_thermal_profile),
+        None,
+    )
+    if default_profile is None:
+        raise CGRAYamlLoaderError(
+            f"SKU {base_id!r}: default_thermal_profile "
+            f"{cp.power.default_thermal_profile!r} is not in thermal_profiles"
+        )
+    default_clock_hz = default_profile.clock_mhz * 1e6
+
+    # ------------------------------------------------------------------
+    # ComputeFabric per CGRA fabric. CGRAs usually ship a single fabric
+    # (Plasticine: PCU spatial dataflow). num_units = num_pcus because
+    # the fabric "lives" on all PCUs.
+    # ------------------------------------------------------------------
+    compute_fabrics: list[ComputeFabric] = []
+    for cgra_fabric in block.compute_fabrics:
+        ops_dict = _precisions_from_ops_dict(
+            cgra_fabric.ops_per_unit_per_clock,
+            source=f"fabric.{cgra_fabric.fabric_kind.value}",
+        )
+        if not ops_dict:
+            continue
+        # CGRAs ship honest FP energy scaling (unlike NPUs which are
+        # INT-only). Use the fabric's FP32 scaling when present;
+        # fall back to INT8 * 8 (the NPU loader's convention).
+        energy_per_op_int8_j = cgra_fabric.energy_per_op_int8_pj * 1e-12
+        cgra_scaling = _energy_scaling_from_yaml(cgra_fabric.energy_scaling)
+        if Precision.FP32 in cgra_scaling:
+            energy_per_flop_fp32_j = energy_per_op_int8_j * cgra_scaling[Precision.FP32]
+        else:
+            energy_per_flop_fp32_j = energy_per_op_int8_j * 8.0
+        # ComputeFabric.energy_scaling expects FP32-baseline scaling
+        # (legacy convention). Translate: scaling_fp32 = scaling_int8 / fp32_scaling.
+        # INT8 itself gets 1.0 / fp32_scaling.
+        fp32_scaling: dict[Precision, float] = {}
+        fp32_baseline = cgra_scaling.get(Precision.FP32, 8.0)
+        fp32_scaling[Precision.INT8] = 1.0 / fp32_baseline
+        for prec, factor in cgra_scaling.items():
+            if prec == Precision.FP32:
+                continue   # FP32 is the baseline (1.0) after rescaling
+            fp32_scaling[prec] = factor / fp32_baseline
+        compute_fabrics.append(ComputeFabric(
+            fabric_type=_FABRIC_TYPE_BY_KIND[cgra_fabric.fabric_kind],
+            circuit_type=_CIRCUIT_TYPE_DEFAULT,
+            num_units=block.num_pcus,
+            ops_per_unit_per_clock=ops_dict,
+            core_frequency_hz=default_clock_hz,
+            process_node_nm=process_node_nm,
+            energy_per_flop_fp32=energy_per_flop_fp32_j,
+            energy_scaling=fp32_scaling,
+        ))
+
+    if not compute_fabrics:
+        raise CGRAYamlLoaderError(
+            f"SKU {base_id!r}: no CGRAComputeFabric produced a valid "
+            f"ComputeFabric (check ops_per_unit_per_clock entries)."
+        )
+
+    # ------------------------------------------------------------------
+    # PrecisionProfile dict -- chip-wide peak ops/sec per precision
+    # ------------------------------------------------------------------
+    supported_precisions: set[Precision] = set()
+    for fabric in compute_fabrics:
+        supported_precisions.update(fabric.ops_per_unit_per_clock.keys())
+
+    precision_profiles: dict[Precision, PrecisionProfile] = {}
+    for precision in supported_precisions:
+        peak = sum(f.get_peak_ops_per_sec(precision) for f in compute_fabrics)
+        if peak <= 0:
+            continue
+        # CGRA tensor-core analogue: PCUs are reconfigurable spatial
+        # fabric, not fixed tensor cores. tensor_core_supported=False.
+        tensor_supported = False
+        # Relative speedup vs INT8 (the CGRA baseline). FP16 = 1/4,
+        # FP32 = 1/8 for Plasticine-style emulation.
+        int8_peak = sum(
+            f.get_peak_ops_per_sec(Precision.INT8) for f in compute_fabrics
+        )
+        relative_speedup = peak / int8_peak if int8_peak > 0 else 1.0
+        precision_profiles[precision] = PrecisionProfile(
+            precision=precision,
+            peak_ops_per_sec=peak,
+            tensor_core_supported=tensor_supported,
+            relative_speedup=relative_speedup,
+            bytes_per_element=_BYTES_PER_PRECISION.get(precision, 4),
+            accumulator_precision=(
+                Precision.INT32 if precision == Precision.INT8 else
+                Precision.FP32 if precision == Precision.FP16 else
+                None
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # ThermalOperatingPoint per chip-level thermal_profile
+    # ------------------------------------------------------------------
+    thermal_operating_points: dict[str, ThermalOperatingPoint] = {}
+    for profile in cp.power.thermal_profiles:
+        thermal_operating_points[profile.name] = ThermalOperatingPoint(
+            name=profile.name,
+            tdp_watts=profile.tdp_watts,
+            cooling_solution=profile.cooling_solution_id,
+            performance_specs={},   # per-precision details live in precision_profiles
+        )
+
+    # ------------------------------------------------------------------
+    # Memory + cache (PMU + shared L2 + host DRAM)
+    # ------------------------------------------------------------------
+    mem = block.memory
+    # peak_bandwidth: PCU mesh bisection (on_chip), NOT host DRAM.
+    # CGRAs compile to fit on-chip; host DRAM is only for bitstream load
+    # + spills. Matches Plasticine's hand-coded 40 GB/s. See module
+    # docstring for the design decision.
+    peak_bandwidth_bps = mem.on_chip_bandwidth_gbps * 1e9
+
+    # Host DRAM -> main_memory (legacy field). When has_host_dram=False
+    # the chip uses no main memory (Cerebras-style).
+    if mem.has_host_dram and mem.host_dram_size_gb is not None:
+        main_memory_bytes = int(mem.host_dram_size_gb * 1024**3)
+    else:
+        main_memory_bytes = 0
+
+    # Per-PCU PMU is the "L1" of CGRA-land (software-managed scratchpad).
+    l1_per_unit_bytes = mem.pmu_kib_per_pcu * 1024
+
+    # Shared SRAM is the "L2/LLC" of CGRA-land.
+    l2_total_bytes = mem.shared_sram_kib * 1024
+    l2_per_unit_bytes = (
+        l2_total_bytes // block.num_pcus
+        if block.num_pcus > 0 else 0
+    )
+
+    # Memory technology label. When has_host_dram=False, name the
+    # primary memory (SRAM) so downstream consumers don't claim DRAM.
+    if mem.has_host_dram and mem.host_dram_type is not None:
+        memory_technology = mem.host_dram_type.value.upper()
+        dram_tech = mem.host_dram_type.value.lower()
+        read_pj = _DRAM_READ_PJ_PER_BYTE.get(dram_tech, 25.0)
+        write_pj = read_pj * _DRAM_WRITE_RATIO
+        # Honor the YAML's host_dram_access_energy_pj_per_byte when
+        # populated (more accurate than the lookup table)
+        if mem.host_dram_access_energy_pj_per_byte > 0:
+            read_pj = mem.host_dram_access_energy_pj_per_byte
+            write_pj = read_pj * _DRAM_WRITE_RATIO
+    else:
+        memory_technology = "on-chip SRAM (no host DRAM)"
+        read_pj = mem.pmu_access_energy_pj_per_byte
+        write_pj = read_pj
+
+    # ------------------------------------------------------------------
+    # SoC fabric
+    # ------------------------------------------------------------------
+    soc_fabric_kwargs = dict(
+        topology=_TOPOLOGY_BY_KIND[block.noc.topology],
+        hop_latency_ns=block.noc.hop_latency_ns,
+        pj_per_flit_per_hop=block.noc.pj_per_flit_per_hop,
+        bisection_bandwidth_gbps=block.noc.bisection_bandwidth_gbps,
+        controller_count=block.noc.unit_count,
+        flit_size_bytes=block.noc.flit_size_bytes,
+        routing_distance_factor=block.noc.routing_distance_factor,
+        provenance=(
+            f"Loaded from compute_products YAML "
+            f"({base_id}.dies[0].blocks[0].noc); CGRA NoC topology "
+            f"{block.noc.topology.value} mapped to graphs SoCFabric "
+            f"{_TOPOLOGY_BY_KIND[block.noc.topology].name}"
+        ),
+    )
+    # Mesh dimensions: pass through when MESH_2D or TORUS_2D
+    if (block.noc.topology in (CGRANoCTopology.MESH_2D, CGRANoCTopology.TORUS_2D)
+            and block.noc.mesh_rows is not None
+            and block.noc.mesh_cols is not None):
+        soc_fabric_kwargs["mesh_dimensions"] = (
+            block.noc.mesh_rows, block.noc.mesh_cols
+        )
+    # Confidence flag
+    from embodied_schemas.process_node import DataConfidence
+    if block.noc.confidence == DataConfidence.THEORETICAL:
+        soc_fabric_kwargs["low_confidence"] = True
+    soc_fabric = SoCFabricModel(**soc_fabric_kwargs)
+
+    # ------------------------------------------------------------------
+    # Assemble HardwareResourceModel
+    # ------------------------------------------------------------------
+    # Default precision: INT8 (the CGRA default; FP is emulated)
+    if Precision.INT8 in precision_profiles:
+        default_precision = Precision.INT8
+    elif Precision.INT4 in precision_profiles:
+        default_precision = Precision.INT4
+    else:
+        default_precision = next(iter(precision_profiles))
+
+    # Energy fields: use the first fabric (CGRAs typically have one)
+    first_fabric = compute_fabrics[0]
+    energy_per_flop_fp32 = first_fabric.energy_per_flop_fp32
+    # Model-level energy_scaling: roll up from all fabrics
+    energy_scaling: dict[Precision, float] = {}
+    for fabric in compute_fabrics:
+        energy_scaling.update(fabric.energy_scaling)
+
+    model = HardwareResourceModel(
+        name=name_override or cp.name,
+        hardware_type=HardwareType.CGRA,
+
+        compute_fabrics=compute_fabrics,
+
+        compute_units=block.num_pcus,
+        threads_per_unit=block.macs_per_pcu,
+        warps_per_unit=1,    # CGRAs don't have warps; legacy compat
+        warp_size=1,         # spatial dataflow
+
+        thermal_operating_points=thermal_operating_points,
+        default_thermal_profile=cp.power.default_thermal_profile,
+
+        precision_profiles=precision_profiles,
+        default_precision=default_precision,
+
+        peak_bandwidth=peak_bandwidth_bps,
+        l1_cache_per_unit=l1_per_unit_bytes,
+        l2_cache_total=l2_total_bytes,
+        main_memory=main_memory_bytes,
+
+        energy_per_flop_fp32=energy_per_flop_fp32,
+        energy_per_byte=read_pj * 1e-12,
+        energy_scaling=energy_scaling,
+
+        min_occupancy=block.min_occupancy,
+        max_concurrent_kernels=block.max_concurrent_models,
+        wave_quantization=block.wave_quantization,
+
+        # M3 Layer 3: software-managed PMU scratchpad (compiler-routed).
+        l1_storage_kind="scratchpad",
+
+        # M4 Layer 4: shared SRAM acts as LLC above per-PCU partitions
+        l2_cache_per_unit=l2_per_unit_bytes,
+        l2_topology="shared-llc",
+
+        # M5 Layer 5: CGRAs don't have L3 between PCUs.
+        l3_present=False,
+        l3_cache_total=0,
+
+        # Compiler-routed spatial dataflow has no coherence
+        coherence_protocol=mem.coherence_protocol,
+
+        # M7 Layer 7
+        memory_technology=memory_technology,
+        memory_read_energy_per_byte_pj=read_pj,
+        memory_write_energy_per_byte_pj=write_pj,
+
+        # M6 Layer 6
+        soc_fabric=soc_fabric,
+    )
+
+    # Generic provenance for the YAML-loaded fields
+    yaml_provenance = EstimationConfidence.theoretical(
+        score=0.80,
+        source=f"Loaded from compute_products YAML ({base_id})",
+    )
+    for key in (
+        "l1_cache_per_unit", "l1_storage_kind",
+        "l2_cache_per_unit", "l2_topology",
+        "l3_present", "l3_cache_total", "coherence_protocol",
+        "memory_technology",
+        "memory_read_energy_per_byte_pj",
+        "memory_write_energy_per_byte_pj",
+        "soc_fabric",
+    ):
+        model.set_provenance(key, yaml_provenance)
+
+    # Per-precision provenance on compute_fabric ops/clock
+    fabric_provenance = EstimationConfidence.theoretical(
+        score=0.55,
+        source=(
+            f"Loaded from compute_products YAML ({base_id}): per-fabric "
+            f"ops_per_unit_per_clock at the dominant PCU fabric"
+        ),
+    )
+    for precision in supported_precisions:
+        model.set_provenance(
+            f"compute_fabric.ops_per_clock.{precision.value}",
+            fabric_provenance,
+        )
+
+    return model

--- a/tests/hardware/test_cgra_yaml_loader_plasticine_parity.py
+++ b/tests/hardware/test_cgra_yaml_loader_plasticine_parity.py
@@ -1,0 +1,347 @@
+"""Contract test: Plasticine v2 YAML loader produces the expected model.
+
+PR 4 of the CGRA mini-sprint scoped at issue #196. Mirror of
+``tests/hardware/test_npu_yaml_loader_hailo8_parity.py``. Compares the
+YAML-loaded model against the hand-coded factory at
+``src/graphs/hardware/models/accelerators/stanford_plasticine_cgra.py``.
+
+PR 5 will retire the hand-coded body and make ``stanford_plasticine_cgra_resource_model()``
+a thin wrapper over the loader; at that point both ``hand_coded`` and
+``yaml_loaded`` fixtures will resolve through the same code path and
+these structural assertions become contract tests on the loader.
+
+Documented drifts (the loader CORRECTS legacy bugs; parity test pins
+the YAML values as the new contract):
+
+  - ``INT8 peak: 10.24 TOPS`` (yaml) vs ``0.307 TOPS`` (hand-coded).
+    The legacy factory's ``theoretical_tops`` formula uses
+    ``num_pcus * macs_per_pcu * ops_per_mac * clock`` = 32*8*2*1e9 =
+    0.512 TOPS, then * 0.60 efficiency = 0.307 TOPS. This ignores the
+    PCU's dual-issue / pipeline multiplier. The YAML's ComputeFabric
+    correctly reports 320 ops/PCU/clock = 10.24 TOPS chip-level
+    (which matches the Plasticine paper's marketed number).
+  - ``FP16 peak: 2.56 TOPS`` (yaml) vs ``0.077 TOPS`` (hand-coded).
+    Same root cause.
+  - ``memory_technology``: ``"DDR4"`` (yaml) vs ``None`` (hand-coded).
+    The legacy doesn't populate this field; the YAML loader does.
+  - ``soc_fabric``: populated (yaml) vs ``None`` (hand-coded). Same.
+  - ``energy_per_flop_fp32``: ~0.5% drift (4.02 pJ vs 4.0 pJ). The
+    YAML loader uses the CGRA fabric's FP32 scaling (6.7x INT8 =
+    4.02 pJ); the hand-coded uses ``get_base_alu_energy(28,
+    'standard_cell')`` = 4.0 pJ. Both are correct interpretations.
+
+Where the hand-coded and YAML-loaded agree (these are the actual
+parity assertions):
+
+  - compute_units, threads_per_unit
+  - peak_bandwidth (40 GB/s -- PCU mesh, on-chip)
+  - l1_cache_per_unit, l2_cache_total, main_memory
+  - default_precision (INT8)
+  - hardware_type (CGRA)
+  - thermal profile shape (single profile, 15W)
+  - scheduler attrs (min_occupancy, max_concurrent_kernels)
+"""
+
+import pytest
+
+from graphs.hardware.models.accelerators.cgra_yaml_loader import (
+    CGRAYamlLoaderError,
+    load_cgra_resource_model_from_yaml,
+)
+from graphs.hardware.models.accelerators.stanford_plasticine_cgra import (
+    stanford_plasticine_cgra_resource_model,
+)
+from graphs.hardware.resource_model import HardwareType, Precision
+
+
+SKU_ID = "stanford_plasticine_v2"
+LEGACY_NAME = "CGRA-Plasticine-v2"
+
+
+@pytest.fixture(scope="module")
+def hand_coded():
+    return stanford_plasticine_cgra_resource_model()
+
+
+@pytest.fixture(scope="module")
+def yaml_loaded():
+    return load_cgra_resource_model_from_yaml(
+        SKU_ID, name_override=LEGACY_NAME,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Identity / shape
+# ---------------------------------------------------------------------------
+
+def test_name_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.name == hand_coded.name == "CGRA-Plasticine-v2"
+
+
+def test_hardware_type_is_cgra(hand_coded, yaml_loaded):
+    """Both produce HardwareType.CGRA -- no transitional period needed
+    (unlike NPU's #191 enum gap)."""
+    assert yaml_loaded.hardware_type == hand_coded.hardware_type == HardwareType.CGRA
+
+
+def test_compute_units_matches(hand_coded, yaml_loaded):
+    """32 PCUs (Pattern Compute Units)."""
+    assert yaml_loaded.compute_units == hand_coded.compute_units == 32
+
+
+def test_threads_per_unit_matches(hand_coded, yaml_loaded):
+    """8 MACs per PCU."""
+    assert yaml_loaded.threads_per_unit == hand_coded.threads_per_unit == 8
+
+
+# ---------------------------------------------------------------------------
+# Compute fabrics
+# ---------------------------------------------------------------------------
+
+def test_single_compute_fabric(hand_coded, yaml_loaded):
+    """Plasticine has one fabric (PCU spatial dataflow)."""
+    assert len(yaml_loaded.compute_fabrics) == len(hand_coded.compute_fabrics) == 1
+
+
+def test_compute_fabric_is_pcu_spatial_dataflow(hand_coded, yaml_loaded):
+    """First SKU to exercise CGRAFabricKind.PCU_SPATIAL_DATAFLOW ->
+    fabric_type 'pcu_spatial_dataflow' via the loader's mapping table."""
+    assert yaml_loaded.compute_fabrics[0].fabric_type == "pcu_spatial_dataflow"
+    assert hand_coded.compute_fabrics[0].fabric_type == "pcu_spatial_dataflow"
+
+
+def test_compute_fabric_num_units(hand_coded, yaml_loaded):
+    """num_units = 32 PCUs."""
+    assert yaml_loaded.compute_fabrics[0].num_units == hand_coded.compute_fabrics[0].num_units == 32
+
+
+def test_compute_fabric_int8_ops_per_clock(hand_coded, yaml_loaded):
+    """320 INT8 ops/PCU/clock (the actual chip-level number; the
+    legacy hand-coded's PrecisionProfile uses a buggy formula but the
+    ComputeFabric is correct)."""
+    hand_int8 = hand_coded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.INT8)
+    yaml_int8 = yaml_loaded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.INT8)
+    assert yaml_int8 == hand_int8 == 320
+
+
+def test_compute_fabric_fp16_ops_per_clock(hand_coded, yaml_loaded):
+    """80 FP16 ops/PCU/clock (1/4 INT8 rate -- Plasticine emulates FP16)."""
+    hand_fp16 = hand_coded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.FP16)
+    yaml_fp16 = yaml_loaded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.FP16)
+    assert yaml_fp16 == hand_fp16 == 80
+
+
+def test_compute_fabric_energy_documented_drift(hand_coded, yaml_loaded):
+    """DOCUMENTED DRIFT: hand-coded uses ``get_base_alu_energy(28,
+    'standard_cell')`` ~= 4.0 pJ; loader uses CGRA fabric's
+    energy_per_op_int8 * energy_scaling[FP32] = 0.6 * 6.7 = 4.02 pJ.
+    ~0.5% drift; both are valid interpretations of 28nm SLP FP32 energy."""
+    for fab in (hand_coded.compute_fabrics[0], yaml_loaded.compute_fabrics[0]):
+        # Range sanity check: 28nm planar FP32 should be ~3-8 pJ
+        assert 1e-12 < fab.energy_per_flop_fp32 < 10e-12, (
+            f"fabric energy_per_flop_fp32={fab.energy_per_flop_fp32} "
+            f"outside [1, 10] pJ range for 28nm planar"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Precision profiles -- the YAML CORRECTS a legacy bug
+# ---------------------------------------------------------------------------
+
+def test_int8_peak_is_yaml_corrected_chip_level(yaml_loaded):
+    """YAML-loaded INT8 peak = 10.24 TOPS (= 32 PCUs * 320 ops/clk *
+    1 GHz). This is the actual Plasticine v2 marketed number. The
+    legacy hand-coded reports 0.307 TOPS (a buggy formula that
+    ignores the per-PCU ops/clock multiplier); the YAML loader
+    CORRECTS this. Parity test pins the YAML value as the new contract."""
+    assert yaml_loaded.precision_profiles[Precision.INT8].peak_ops_per_sec == pytest.approx(
+        10.24e12, rel=0.01
+    )
+
+
+def test_legacy_int8_peak_undershoots_chip_level(hand_coded):
+    """Pinned for visibility: legacy hand-coded reports 0.307 TOPS
+    (about 33x smaller than the actual chip-level peak). PR 5 cleanup
+    will retire the hand-coded path and this test becomes redundant
+    (loader becomes the only source). Until then, document the bug."""
+    legacy_peak = hand_coded.precision_profiles[Precision.INT8].peak_ops_per_sec
+    assert legacy_peak == pytest.approx(0.307e12, rel=0.05), (
+        f"unexpected legacy peak {legacy_peak/1e12:.3f} TOPS; if this "
+        f"changed the legacy was fixed -- update this drift annotation."
+    )
+
+
+def test_default_precision_matches(hand_coded, yaml_loaded):
+    """Both prefer INT8 as default."""
+    assert yaml_loaded.default_precision == hand_coded.default_precision == Precision.INT8
+
+
+def test_int4_not_in_precision_profiles(hand_coded, yaml_loaded):
+    """Plasticine targets INT8 minimum -- no INT4 (unlike Hailo SKUs)."""
+    assert Precision.INT4 not in hand_coded.precision_profiles
+    assert Precision.INT4 not in yaml_loaded.precision_profiles
+
+
+# ---------------------------------------------------------------------------
+# Memory hierarchy (PMU + L2 + host DDR4)
+# ---------------------------------------------------------------------------
+
+def test_peak_bandwidth_matches_on_chip_mesh(hand_coded, yaml_loaded):
+    """40 GB/s -- PCU mesh bisection. The loader picks on_chip not
+    host_dram (CGRA workloads stay on-chip; host bus is only for
+    bitstream load + spills). Matches Plasticine's hand-coded 40 GB/s."""
+    assert yaml_loaded.peak_bandwidth == pytest.approx(40e9, rel=0.01)
+    assert hand_coded.peak_bandwidth == pytest.approx(40e9, rel=0.01)
+
+
+def test_main_memory_matches(hand_coded, yaml_loaded):
+    """4 GiB host DDR4."""
+    assert yaml_loaded.main_memory == hand_coded.main_memory == 4 * 1024**3
+
+
+def test_l1_per_unit_matches(hand_coded, yaml_loaded):
+    """64 KiB PMU per PCU."""
+    assert yaml_loaded.l1_cache_per_unit == hand_coded.l1_cache_per_unit
+    assert yaml_loaded.l1_cache_per_unit == 64 * 1024
+
+
+def test_l2_cache_total_matches(hand_coded, yaml_loaded):
+    """2 MiB shared L2."""
+    assert yaml_loaded.l2_cache_total == hand_coded.l2_cache_total
+    assert yaml_loaded.l2_cache_total == 2 * 1024 * 1024
+
+
+def test_l2_per_unit_calculated_correctly(yaml_loaded):
+    """2 MiB / 32 PCUs = 64 KiB per-PCU share. Hand-coded doesn't
+    set l2_cache_per_unit; pin the YAML's value."""
+    assert yaml_loaded.l2_cache_per_unit == (2 * 1024 * 1024) // 32
+
+
+def test_l3_absent(yaml_loaded):
+    """CGRAs don't have L3 by construction."""
+    assert yaml_loaded.l3_present is False
+    assert yaml_loaded.l3_cache_total == 0
+
+
+def test_l1_storage_kind_is_scratchpad(yaml_loaded):
+    """PMU is software-managed scratchpad."""
+    assert yaml_loaded.l1_storage_kind == "scratchpad"
+
+
+def test_coherence_protocol_is_none(yaml_loaded):
+    """Spatial dataflow has no coherence (compiler-routed)."""
+    assert yaml_loaded.coherence_protocol == "none"
+
+
+def test_yaml_populates_memory_technology(yaml_loaded):
+    """DOCUMENTED DRIFT: hand-coded does NOT set memory_technology
+    (returns None); YAML loader populates it from host_dram_type.
+    The YAML's "DDR4" is structurally correct."""
+    assert yaml_loaded.memory_technology == "DDR4"
+
+
+# ---------------------------------------------------------------------------
+# SoC fabric (4x8 mesh -- DRIFT: hand-coded doesn't populate)
+# ---------------------------------------------------------------------------
+
+def test_yaml_populates_soc_fabric(yaml_loaded):
+    """DOCUMENTED DRIFT: hand-coded does NOT set soc_fabric (returns
+    None); YAML loader populates it from NoC schema. The YAML's
+    4x8 mesh structure is correct and unblocks downstream Layer 6
+    reporting that the hand-coded couldn't support."""
+    from graphs.hardware.fabric_model import Topology
+    assert yaml_loaded.soc_fabric is not None
+    assert yaml_loaded.soc_fabric.topology == Topology.MESH_2D
+    assert yaml_loaded.soc_fabric.mesh_dimensions == (4, 8)
+    assert yaml_loaded.soc_fabric.controller_count == 32
+    assert yaml_loaded.soc_fabric.bisection_bandwidth_gbps == pytest.approx(40.0)
+    assert yaml_loaded.soc_fabric.low_confidence is True
+
+
+def test_hand_coded_soc_fabric_is_none(hand_coded):
+    """Pinned for visibility: hand-coded didn't model the SoC fabric.
+    PR 5 cleanup makes the YAML loader the only source."""
+    assert hand_coded.soc_fabric is None
+
+
+# ---------------------------------------------------------------------------
+# Thermal profiles (single 15W operating point)
+# ---------------------------------------------------------------------------
+
+def test_thermal_profile_count_matches(hand_coded, yaml_loaded):
+    assert len(yaml_loaded.thermal_operating_points) == 1
+    assert len(hand_coded.thermal_operating_points) == 1
+
+
+def test_default_thermal_profile_tdp(hand_coded, yaml_loaded):
+    """Both default profiles report 15W."""
+    hand_default = hand_coded.thermal_operating_points[hand_coded.default_thermal_profile]
+    yaml_default = yaml_loaded.thermal_operating_points[yaml_loaded.default_thermal_profile]
+    assert yaml_default.tdp_watts == hand_default.tdp_watts == 15.0
+
+
+# ---------------------------------------------------------------------------
+# Scheduler attrs
+# ---------------------------------------------------------------------------
+
+def test_scheduler_attrs_match(hand_coded, yaml_loaded):
+    """0.3 occupancy (CGRA fabric overhead; lower than fixed-function
+    NPU), single concurrent program, wave_q=1."""
+    assert yaml_loaded.min_occupancy == pytest.approx(0.3, rel=0.05)
+    assert hand_coded.min_occupancy == pytest.approx(0.3, rel=0.05)
+    assert yaml_loaded.max_concurrent_kernels == hand_coded.max_concurrent_kernels == 1
+    assert yaml_loaded.wave_quantization == hand_coded.wave_quantization == 1
+
+
+# ---------------------------------------------------------------------------
+# CGRA-specific: reconfig overhead lives on the schema, not yet on
+# HardwareResourceModel
+# ---------------------------------------------------------------------------
+
+def test_reconfig_overhead_on_underlying_compute_product():
+    """The Plasticine v2 YAML carries reconfig_overhead_cycles=1000 on
+    the CGRABlock. The legacy HardwareResourceModel has no equivalent
+    field, so the loader doesn't surface it; downstream consumers
+    that need it read directly from the ComputeProduct.
+
+    This test pins the value via direct schema read so a future v6
+    HardwareResourceModel extension that surfaces reconfig overhead
+    has a known-good reference."""
+    from embodied_schemas.loaders import load_compute_products
+    from embodied_schemas import CGRABlock
+    cp = load_compute_products().get("stanford_plasticine_v2")
+    assert cp is not None
+    block = next(b for b in cp.dies[0].blocks if isinstance(b, CGRABlock))
+    assert block.reconfig_overhead_cycles == 1000
+    assert block.supports_partial_reconfig is False
+
+
+# ---------------------------------------------------------------------------
+# Loader error paths
+# ---------------------------------------------------------------------------
+
+def test_loader_raises_on_unknown_sku():
+    with pytest.raises(CGRAYamlLoaderError, match="no ComputeProduct with id"):
+        load_cgra_resource_model_from_yaml("definitely_not_a_real_cgra")
+
+
+def test_loader_raises_on_kpu_sku():
+    """KPU ComputeProducts have no CGRABlock; loader should reject."""
+    with pytest.raises(CGRAYamlLoaderError, match="no CGRABlock"):
+        load_cgra_resource_model_from_yaml("kpu_t64_32x32_lp5x4_16nm_tsmc_ffp")
+
+
+def test_loader_raises_on_npu_sku():
+    """NPU ComputeProducts have no CGRABlock; loader should reject."""
+    with pytest.raises(CGRAYamlLoaderError, match="no CGRABlock"):
+        load_cgra_resource_model_from_yaml("hailo_hailo_8")
+
+
+def test_loader_raises_on_gpu_sku():
+    with pytest.raises(CGRAYamlLoaderError, match="no CGRABlock"):
+        load_cgra_resource_model_from_yaml("nvidia_jetson_agx_orin_64gb")
+
+
+def test_loader_raises_on_cpu_sku():
+    with pytest.raises(CGRAYamlLoaderError, match="no CGRABlock"):
+        load_cgra_resource_model_from_yaml("intel_core_i7_12700k")


### PR DESCRIPTION
## Summary

- Adds ``cgra_yaml_loader.py`` (~455 LOC) mirroring ``npu_yaml_loader.py`` patterns.
- Builds ``HardwareResourceModel`` from a CGRABlock-bearing ``ComputeProduct``.
- 34-test parity suite pins YAML-loaded output against the hand-coded ``stanford_plasticine_cgra.py``.
- CI pin bumped to include embodied-schemas#34 (schema) + #35 (Plasticine YAML).
- PR 4 of 5 in the CGRA mini-sprint scoped at #196.

## Why now

The two embodied-schemas precursors are merged:
1. ``embodied-schemas#34`` — CGRABlock added to the discriminated union
2. ``embodied-schemas#35`` — first CGRA SKU YAML (Plasticine v2)

With both present, the graphs side can author the YAML loader so PR 5 (factory swap) can land.

## CGRA-specific loader decisions

| # | Decision | Why |
|---|---|---|
| 1 | ``peak_bandwidth = on_chip_bandwidth_gbps`` (PCU mesh) | CGRA workloads compile to fit on-chip; host DRAM is only for bitstream load. Matches Plasticine's hand-coded 40 GB/s. Contrasts with NPU loader's "DRAM tier when present". |
| 2 | ``energy_per_flop_fp32`` uses fabric's FP32 scaling | CGRAs ship honest FP energy scaling (unlike INT-only NPUs); loader prefers `INT8 * energy_scaling[FP32]` over `INT8 * 8` synthesis. |
| 3 | ``HardwareType.CGRA`` set directly | No transitional period (CGRA already in graphs enum; unlike NPU's #191 gap). |
| 4 | ``reconfig_overhead_cycles`` NOT surfaced on HardwareResourceModel | Legacy model has no equivalent field. v6 reconciliation. Downstream consumers read from ComputeProduct meanwhile. |

## Four documented drifts (YAML CORRECTS legacy bugs)

| Field | YAML | Legacy hand-coded | Why YAML is correct |
|---|---|---|---|
| INT8 peak | **10.24 TOPS** | 0.307 TOPS | Legacy ``theoretical_tops`` formula ignores PCU dual-issue/pipeline; YAML uses ``ops_per_unit_per_clock`` correctly. Matches Plasticine paper. |
| FP16 peak | **2.56 TOPS** | 0.077 TOPS | Same root cause. |
| ``memory_technology`` | **"DDR4"** | None | Legacy didn't populate; YAML reads from ``host_dram_type``. |
| ``soc_fabric`` | **4x8 mesh populated** | None | Legacy didn't model; YAML unblocks Layer 6 reporting. |

## CI pin bump

Bumped embodied-schemas pin from ``6e3aadb`` (PR #33 Coral YAML) to ``51b8287`` (PR #35 Plasticine YAML) across all 8 occurrences. History comment extended.

## Changes

| File | Δ | What |
|---|---|---|
| ``src/graphs/hardware/models/accelerators/cgra_yaml_loader.py`` | +455 LOC (new) | Full CGRA loader: mapping tables, helpers, ``load_cgra_resource_model_from_yaml`` |
| ``tests/hardware/test_cgra_yaml_loader_plasticine_parity.py`` | +240 LOC (new) | 34 parity + contract tests |
| ``.github/workflows/{ci,coverage,v4-validation}.yml`` | +24 LOC | CI pin bump + history |

## Test Results

| Suite | Result |
|---|---|
| ``test_cgra_yaml_loader_plasticine_parity.py`` | 34 passed (new) |
| Full suite | **2924 passed**, 13 skipped, 4 xfailed (was 2890) |

## Test plan

- [x] All 2924 graphs tests pass locally
- [x] Loader correctly handles host_dram_* gated fields
- [x] FP32 energy uses fabric's honest scaling (not INT8*8 synthesis)
- [x] Loader rejects KPU/GPU/CPU/NPU SKUs with clear error messages
- [x] Fast CI passes
- [x] Promote to ready when satisfied: ``gh pr ready PR_NUMBER``

## Follow-up (unblocked by this PR)

- PR 5 (graphs): retire ``stanford_plasticine_cgra.py`` ~170 LOC hand-coded factory to thin loader wrapper; closes #196

## Refs

- #196 (umbrella tracking issue; CGRA mini-sprint)
- #197 (paper exercise design doc)
- branes-ai/embodied-schemas#34, #35 (precursors)
- #189 (NPU loader — pattern source)

Generated with [Claude Code](https://claude.com/claude-code)