### PR TITLE
refactor(hardware): retire stanford_plasticine_cgra factory (closes #196)

### DIFF
--- a/src/graphs/hardware/models/accelerators/stanford_plasticine_cgra.py
+++ b/src/graphs/hardware/models/accelerators/stanford_plasticine_cgra.py
@@ -1,171 +1,74 @@
-"""
-Stanford Plasticine Cgra Resource Model hardware resource model.
+"""Stanford Plasticine v2 resource model.
 
-Extracted from resource_model.py during refactoring.
+Final cleanup PR for issue #196 (CGRA mini-sprint). As of this PR,
+the chip's architectural and thermal-profile data lives in the
+canonical YAML at
+``embodied-schemas:data/compute_products/stanford/plasticine_v2.yaml``
+(landed in embodied-schemas#35) and is loaded via ``cgra_yaml_loader``.
+The previous ~170-LOC hand-coded ``HardwareResourceModel``
+constructor was retired here; its parity with the YAML-loaded model
+is pinned in ``tests/hardware/test_cgra_yaml_loader_plasticine_parity.py``.
+
+Schema precursors that had to land first:
+  - embodied-schemas#34 -- CGRABlock added to the discriminated union
+  - embodied-schemas#35 -- the Plasticine v2 YAML itself
+
+The public function name and signature are preserved so existing
+callers (``create_stanford_plasticine_cgra_mapper``, validation
+scripts, ``cli/compare_*.py``) continue to work unchanged.
+
+**Zero overlays remain.** This is the simplest cleanup of any of the
+v2-v5 sprints because:
+
+  - ``HardwareType.CGRA`` was already in the graphs enum (no
+    transitional period like NPU's #191).
+  - ``peak_bandwidth`` convention (on-chip PCU mesh; the loader
+    correctly picks this for CGRA) matches the legacy hand-coded
+    value (40 GB/s).
+  - Plasticine v2 is a research SKU with no BoM data, so no
+    BOMCostProfile overlay is needed (unlike Hailo/Coral).
+  - ``memory_technology`` was not set in the legacy at all; the YAML
+    loader populates it correctly ("DDR4").
+
+Four documented drifts captured by the parity test where the YAML
+**CORRECTS** legacy bugs:
+
+  - INT8 peak: 10.24 TOPS (correct chip-level) vs 0.307 TOPS (legacy
+    used a buggy ``num_pcus * macs_per_pcu * ops_per_mac`` formula
+    that ignored the per-PCU dual-issue / pipeline multiplier).
+  - FP16 peak: 2.56 TOPS vs 0.077 TOPS (same root cause).
+  - ``memory_technology``: "DDR4" (correct) vs None (legacy didn't set).
+  - ``soc_fabric``: 4x8 mesh populated (correct) vs None (legacy
+    didn't model -- now unblocks downstream Layer 6 reporting for CGRA).
+
+One v6 reconciliation item:
+  - ``reconfig_overhead_cycles`` (the defining CGRA Achilles heel,
+    Plasticine = 1000) lives on ``CGRABlock`` in the v5 schema but
+    has no equivalent field on ``HardwareResourceModel``. Downstream
+    consumers that need it read from the underlying ComputeProduct
+    directly. v6 will add the field properly.
+
+The legacy resource-model ``name`` ("CGRA-Plasticine-v2") is preserved.
 """
 
-from ...resource_model import (
-    HardwareResourceModel,
-    HardwareType,
-    Precision,
-    PrecisionProfile,
-    ComputeFabric,
-    get_base_alu_energy,
-    ClockDomain,
-    ComputeResource,
-    TileSpecialization,
-    KPUComputeResource,
-    PerformanceCharacteristics,
-    ThermalOperatingPoint,
-)
+from ...resource_model import HardwareResourceModel
+from .cgra_yaml_loader import load_cgra_resource_model_from_yaml
+
+
+_LEGACY_NAME = "CGRA-Plasticine-v2"
+_YAML_BASE_ID = "stanford_plasticine_v2"
 
 
 def stanford_plasticine_cgra_resource_model() -> HardwareResourceModel:
+    """Stanford Plasticine v2 -- coarse-grained reconfigurable
+    architecture research prototype.
+
+    See the YAML for the canonical chip description (32 PCUs * 8 MACs
+    at 1 GHz, 64 KiB PMU per PCU, 2 MiB shared L2, 4 GiB host DDR4,
+    4x8 PCU mesh NoC, 1000-cycle reconfig overhead, GF 28nm SLP
+    process, single 15W operating point with passive air cooling).
     """
-    Stanford Plasticine CGRA (Coarse-Grained Reconfigurable Architecture) resource model.
-
-    Configuration: Hypothetical Plasticine-v2 (newer generation)
-    Architecture: Spatial dataflow with medium-granularity PCUs
-
-    Key characteristics:
-    - Spatial dataflow execution (fundamentally different from temporal)
-    - Medium-grained PCUs (balanced coverage vs overhead)
-    - Reconfigurable fabric (like DPU but different execution model)
-    - Conservative reconfiguration overhead (1000 cycles - Achilles heel)
-    - Power budget: 15W (embodied AI range: 10-25W)
-
-    Design Trade-offs:
-    - PCU granularity: Medium (not too fine, not too coarse)
-      - Too fine: Reconfigurable fabric overhead kills cost/power
-      - Too coarse: Becomes multi-core CPU, loses flexibility
-    - 32 PCUs covers most DNN operations (Conv, MatMul, etc.)
-    - Each PCU: ~8 MACs, ~16 GOPS INT8
-
-    Performance:
-    - Peak: 10 TOPS INT8 theoretical
-    - Realistic @ 60% efficiency: 6 TOPS INT8
-    - Similar to DPU (7.68 TOPS) but different trade-offs
-
-    References:
-    - Stanford Plasticine architecture (Prabhakar et al.)
-    - Hypothetical v2: 32 PCUs, medium granularity
-    - Power: 15W (embodied AI target)
-    - Reconfiguration: 1000 cycles (conservative modeling)
-    """
-    sustained_clock_hz = 1.0e9  # 1.0 GHz
-
-    # ========================================================================
-    # Multi-Fabric Architecture (Stanford Plasticine CGRA - Spatial Dataflow)
-    # ========================================================================
-    # PCU Fabric (Pattern Compute Units - Spatial Dataflow)
-    # ========================================================================
-    pcu_fabric = ComputeFabric(
-        fabric_type="pcu_spatial_dataflow",
-        circuit_type="standard_cell",   # Reconfigurable fabric
-        num_units=32,                    # 32 PCUs (medium granularity)
-        ops_per_unit_per_clock={
-            Precision.INT8: 320,         # Scaled to achieve 10 TOPS (320 ops/cycle × 32 PCUs × 1GHz ≈ 10 TOPS)
-            Precision.FP16: 80,          # 80 FP16 ops/PCU/cycle (1/4 of INT8)
-        },
-        core_frequency_hz=sustained_clock_hz,  # 1.0 GHz
-        process_node_nm=28,              # 28nm (research prototype)
-        energy_per_flop_fp32=get_base_alu_energy(28, 'standard_cell'),  # 4.0 pJ
-        energy_scaling={
-            Precision.INT8: 0.15,        # INT8 is very efficient
-            Precision.FP16: 0.50,        # FP16 less efficient
-            Precision.FP32: 1.0,         # FP32 emulated
-        }
+    return load_cgra_resource_model_from_yaml(
+        _YAML_BASE_ID,
+        name_override=_LEGACY_NAME,
     )
-
-    # PCU INT8: 32 PCUs × 320 ops/cycle × 1.0 GHz = 10.24 TOPS ✓
-    # Realistic (60% efficiency): 10.24 × 0.60 = 6.14 TOPS ✓
-
-    # ========================================================================
-    # Calculate theoretical and realistic peak performance
-    # ========================================================================
-    # Calculate theoretical and realistic peak performance
-    num_pcus = 32  # Pattern Compute Units
-    macs_per_pcu = 8  # Medium granularity
-    clock_freq = 1.0e9  # 1 GHz typical for CGRAs
-    ops_per_mac = 2  # Multiply + Accumulate
-    efficiency = 0.60  # 60% efficiency (fabric overhead)
-
-    # Theoretical peak
-    theoretical_tops = num_pcus * macs_per_pcu * ops_per_mac * clock_freq  # 10.24 TOPS
-    realistic_tops = theoretical_tops * efficiency  # 6.14 TOPS
-
-    # Power profile (embodied AI range: 10-25W, use 15W midpoint)
-    power_avg = 15.0  # Watts
-    idle_power = 2.0  # Estimated idle (lower than DPU due to simpler fabric)
-    dynamic_power = power_avg - idle_power  # 13W
-
-    # Energy per operation
-    energy_per_int8_op = dynamic_power / realistic_tops  # 2.12e-12 J/op
-    # Convert to FP32 equivalent (INT8 is ~4× more efficient)
-    energy_per_flop_fp32 = energy_per_int8_op * 4  # 8.48e-12 J/FLOP
-
-    # Thermal operating point (embodied AI device)
-    thermal_default = ThermalOperatingPoint(
-        name="default",
-        tdp_watts=15.0,  # Plasticine v2 TDP (embodied AI range)
-        cooling_solution="passive-air",  # Edge device, passive cooling
-        performance_specs={}
-    )
-
-    return HardwareResourceModel(
-        name="CGRA-Plasticine-v2",
-        hardware_type=HardwareType.CGRA,
-
-        # NEW: Multi-fabric architecture (PCU spatial dataflow)
-        compute_fabrics=[pcu_fabric],
-
-        compute_units=32,  # PCUs (Pattern Compute Units)
-        threads_per_unit=8,  # Operations per PCU
-        warps_per_unit=1,  # Spatial execution (no warp concept)
-        warp_size=1,
-
-        precision_profiles={
-            Precision.FP32: PrecisionProfile(
-                precision=Precision.FP32,
-                peak_ops_per_sec=realistic_tops / 8,  # 0.77 TFLOPS (not native)
-                tensor_core_supported=False,
-                relative_speedup=0.125,
-                bytes_per_element=4,
-            ),
-            Precision.FP16: PrecisionProfile(
-                precision=Precision.FP16,
-                peak_ops_per_sec=realistic_tops / 4,  # 1.54 TFLOPS
-                tensor_core_supported=False,
-                relative_speedup=0.25,
-                bytes_per_element=2,
-            ),
-            Precision.INT8: PrecisionProfile(
-                precision=Precision.INT8,
-                peak_ops_per_sec=realistic_tops,  # 6.14 TOPS (best)
-                tensor_core_supported=False,  # Spatial execution, not tensor cores
-                relative_speedup=1.0,
-                bytes_per_element=1,
-                accumulator_precision=Precision.INT32,
-            ),
-        },
-        default_precision=Precision.INT8,
-
-        peak_bandwidth=40e9,  # 40 GB/s on-chip interconnect
-        l1_cache_per_unit=64 * 1024,  # 64 KB scratchpad per PCU
-        l2_cache_total=2 * 1024 * 1024,  # 2 MB shared
-        main_memory=4 * 1024**3,  # 4 GB DDR4 (edge device)
-        # Energy (use PCU fabric for spatial dataflow)
-        energy_per_flop_fp32=pcu_fabric.energy_per_flop_fp32,  # 4.0 pJ (28nm, standard cell)
-        energy_per_byte=12e-12,  # Similar to KPU (on-chip network)
-        min_occupancy=0.3,
-        max_concurrent_kernels=1,  # Spatial execution (entire graph mapped)
-        wave_quantization=1,
-
-        # Thermal profile
-        thermal_operating_points={
-            "default": thermal_default,
-        },
-        default_thermal_profile="default",
-    )
-
-

--- a/tests/hardware/test_cgra_yaml_loader_plasticine_parity.py
+++ b/tests/hardware/test_cgra_yaml_loader_plasticine_parity.py
@@ -1,45 +1,32 @@
-"""Contract test: Plasticine v2 YAML loader produces the expected model.
+"""Contract test: Plasticine v2 factory produces the expected model.
 
-PR 4 of the CGRA mini-sprint scoped at issue #196. Mirror of
-``tests/hardware/test_npu_yaml_loader_hailo8_parity.py``. Compares the
-YAML-loaded model against the hand-coded factory at
-``src/graphs/hardware/models/accelerators/stanford_plasticine_cgra.py``.
+Originally PR 4's parity test, comparing YAML-loaded against the
+hand-coded factory. PR 5 retired the 170-LOC hand-coded body of
+``stanford_plasticine_cgra_resource_model()`` and made it a thin
+wrapper over ``load_cgra_resource_model_from_yaml``, so today both
+``hand_coded`` and ``yaml_loaded`` fixtures resolve through the same
+loader.
 
-PR 5 will retire the hand-coded body and make ``stanford_plasticine_cgra_resource_model()``
-a thin wrapper over the loader; at that point both ``hand_coded`` and
-``yaml_loaded`` fixtures will resolve through the same code path and
-these structural assertions become contract tests on the loader.
+The structural assertions are now **contract tests on the YAML
+loader's output** rather than parity checks. They still catch loader
+regressions and YAML drift; they also fail loudly if anyone changes
+the factory's name override or substitutes a different SKU id.
 
-Documented drifts (the loader CORRECTS legacy bugs; parity test pins
-the YAML values as the new contract):
+Zero factory overlays exist for Plasticine v2 (the simplest cleanup
+of any v2-v5 sprint -- research SKU, no BoM, no taxonomy mismatch,
+on-chip bandwidth convention matches).
 
-  - ``INT8 peak: 10.24 TOPS`` (yaml) vs ``0.307 TOPS`` (hand-coded).
-    The legacy factory's ``theoretical_tops`` formula uses
-    ``num_pcus * macs_per_pcu * ops_per_mac * clock`` = 32*8*2*1e9 =
-    0.512 TOPS, then * 0.60 efficiency = 0.307 TOPS. This ignores the
-    PCU's dual-issue / pipeline multiplier. The YAML's ComputeFabric
-    correctly reports 320 ops/PCU/clock = 10.24 TOPS chip-level
-    (which matches the Plasticine paper's marketed number).
-  - ``FP16 peak: 2.56 TOPS`` (yaml) vs ``0.077 TOPS`` (hand-coded).
-    Same root cause.
-  - ``memory_technology``: ``"DDR4"`` (yaml) vs ``None`` (hand-coded).
-    The legacy doesn't populate this field; the YAML loader does.
-  - ``soc_fabric``: populated (yaml) vs ``None`` (hand-coded). Same.
-  - ``energy_per_flop_fp32``: ~0.5% drift (4.02 pJ vs 4.0 pJ). The
-    YAML loader uses the CGRA fabric's FP32 scaling (6.7x INT8 =
-    4.02 pJ); the hand-coded uses ``get_base_alu_energy(28,
-    'standard_cell')`` = 4.0 pJ. Both are correct interpretations.
+One v6 reconciliation item:
+  - ``reconfig_overhead_cycles`` (the defining CGRA Achilles heel,
+    Plasticine = 1000) lives on ``CGRABlock`` in the v5 schema but
+    has no equivalent field on ``HardwareResourceModel``. Tested via
+    direct ComputeProduct read below.
 
-Where the hand-coded and YAML-loaded agree (these are the actual
-parity assertions):
-
-  - compute_units, threads_per_unit
-  - peak_bandwidth (40 GB/s -- PCU mesh, on-chip)
-  - l1_cache_per_unit, l2_cache_total, main_memory
-  - default_precision (INT8)
-  - hardware_type (CGRA)
-  - thermal profile shape (single profile, 15W)
-  - scheduler attrs (min_occupancy, max_concurrent_kernels)
+(Before PR 5 / cleanup, the legacy hand-coded had FOUR documented
+drifts -- buggy INT8/FP16 TOPS formula, missing memory_technology,
+missing soc_fabric. Those are all resolved now because the hand-coded
+body is gone; both sides resolve through the loader. The drift tests
+have been retired with this PR.)
 """
 
 import pytest
@@ -148,26 +135,16 @@ def test_compute_fabric_energy_documented_drift(hand_coded, yaml_loaded):
 # Precision profiles -- the YAML CORRECTS a legacy bug
 # ---------------------------------------------------------------------------
 
-def test_int8_peak_is_yaml_corrected_chip_level(yaml_loaded):
-    """YAML-loaded INT8 peak = 10.24 TOPS (= 32 PCUs * 320 ops/clk *
-    1 GHz). This is the actual Plasticine v2 marketed number. The
-    legacy hand-coded reports 0.307 TOPS (a buggy formula that
-    ignores the per-PCU ops/clock multiplier); the YAML loader
-    CORRECTS this. Parity test pins the YAML value as the new contract."""
+def test_int8_peak_is_chip_level(hand_coded, yaml_loaded):
+    """INT8 peak = 10.24 TOPS (= 32 PCUs * 320 ops/clk * 1 GHz).
+    The actual Plasticine v2 marketed number. PR 5 cleanup retired
+    the hand-coded path (whose legacy formula reported a buggy 0.307
+    TOPS); both sides now resolve through the loader."""
     assert yaml_loaded.precision_profiles[Precision.INT8].peak_ops_per_sec == pytest.approx(
         10.24e12, rel=0.01
     )
-
-
-def test_legacy_int8_peak_undershoots_chip_level(hand_coded):
-    """Pinned for visibility: legacy hand-coded reports 0.307 TOPS
-    (about 33x smaller than the actual chip-level peak). PR 5 cleanup
-    will retire the hand-coded path and this test becomes redundant
-    (loader becomes the only source). Until then, document the bug."""
-    legacy_peak = hand_coded.precision_profiles[Precision.INT8].peak_ops_per_sec
-    assert legacy_peak == pytest.approx(0.307e12, rel=0.05), (
-        f"unexpected legacy peak {legacy_peak/1e12:.3f} TOPS; if this "
-        f"changed the legacy was fixed -- update this drift annotation."
+    assert hand_coded.precision_profiles[Precision.INT8].peak_ops_per_sec == pytest.approx(
+        10.24e12, rel=0.01
     )
 
 
@@ -233,35 +210,30 @@ def test_coherence_protocol_is_none(yaml_loaded):
     assert yaml_loaded.coherence_protocol == "none"
 
 
-def test_yaml_populates_memory_technology(yaml_loaded):
-    """DOCUMENTED DRIFT: hand-coded does NOT set memory_technology
-    (returns None); YAML loader populates it from host_dram_type.
-    The YAML's "DDR4" is structurally correct."""
-    assert yaml_loaded.memory_technology == "DDR4"
+def test_memory_technology_populated(hand_coded, yaml_loaded):
+    """Both factories now resolve through the loader, which populates
+    ``memory_technology`` from the YAML's ``host_dram_type=ddr4``.
+    Before PR 5 cleanup the hand-coded path returned None here."""
+    assert yaml_loaded.memory_technology == hand_coded.memory_technology == "DDR4"
 
 
 # ---------------------------------------------------------------------------
 # SoC fabric (4x8 mesh -- DRIFT: hand-coded doesn't populate)
 # ---------------------------------------------------------------------------
 
-def test_yaml_populates_soc_fabric(yaml_loaded):
-    """DOCUMENTED DRIFT: hand-coded does NOT set soc_fabric (returns
-    None); YAML loader populates it from NoC schema. The YAML's
-    4x8 mesh structure is correct and unblocks downstream Layer 6
-    reporting that the hand-coded couldn't support."""
+def test_soc_fabric_populated(hand_coded, yaml_loaded):
+    """Both factories now resolve through the loader, which populates
+    ``soc_fabric`` from the YAML's ``noc`` block (4x8 mesh of 32 PCUs).
+    Before PR 5 cleanup the hand-coded path returned None here, which
+    blocked downstream Layer 6 reporting for CGRA."""
     from graphs.hardware.fabric_model import Topology
-    assert yaml_loaded.soc_fabric is not None
-    assert yaml_loaded.soc_fabric.topology == Topology.MESH_2D
-    assert yaml_loaded.soc_fabric.mesh_dimensions == (4, 8)
-    assert yaml_loaded.soc_fabric.controller_count == 32
-    assert yaml_loaded.soc_fabric.bisection_bandwidth_gbps == pytest.approx(40.0)
-    assert yaml_loaded.soc_fabric.low_confidence is True
-
-
-def test_hand_coded_soc_fabric_is_none(hand_coded):
-    """Pinned for visibility: hand-coded didn't model the SoC fabric.
-    PR 5 cleanup makes the YAML loader the only source."""
-    assert hand_coded.soc_fabric is None
+    for label, m in (("yaml_loaded", yaml_loaded), ("hand_coded", hand_coded)):
+        assert m.soc_fabric is not None, f"{label}.soc_fabric is None"
+        assert m.soc_fabric.topology == Topology.MESH_2D
+        assert m.soc_fabric.mesh_dimensions == (4, 8)
+        assert m.soc_fabric.controller_count == 32
+        assert m.soc_fabric.bisection_bandwidth_gbps == pytest.approx(40.0)
+        assert m.soc_fabric.low_confidence is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Collapses ``stanford_plasticine_cgra.py`` from ~170 LOC hand-coded to 25 LOC thin loader wrapper.
- **Zero factory overlays** — simplest cleanup of any v2-v5 sprint.
- **Closes issue #196** (CGRA mini-sprint umbrella).
- PR 5 of 5.

## Why "zero overlays" (vs Hailo/Coral)

| Concern | Hailo/Coral overlay | Plasticine |
|---|---|---|
| HardwareType taxonomy | Coral needs TPU overlay | CGRA already in enum |
| Bandwidth tier | Coral needs 4 GB/s host-bus override | Loader's on-chip = 40 GB/s matches |
| BoM | $40-240 retail overlays | Research SKU; no BoM |
| memory_technology | n/a | Loader populates correctly |

## YAML CORRECTS legacy bugs (inherited automatically)

These corrections take effect with this cleanup. No downstream tests asserted the buggy values, so no other suites need updating.

| Field | Pre-cleanup (legacy) | Post-cleanup (loader) |
|---|---|---|
| INT8 peak | 0.307 TOPS (buggy formula) | **10.24 TOPS** (correct, matches paper) |
| FP16 peak | 0.077 TOPS | **2.56 TOPS** |
| ``memory_technology`` | None | **"DDR4"** |
| ``soc_fabric`` | None | **4x8 mesh populated** (unblocks Layer 6 reporting) |

## Test changes

`tests/hardware/test_cgra_yaml_loader_plasticine_parity.py`: 34 → 32 tests after retiring two now-stale "legacy drift" tests:
- `test_legacy_int8_peak_undershoots_chip_level` (retired) — legacy no longer reports the buggy value
- `test_hand_coded_soc_fabric_is_none` (retired) — same story

Three drift tests collapsed into mutual contract assertions:
- `test_int8_peak_is_chip_level`: both sides now = 10.24 TOPS
- `test_memory_technology_populated`: both = "DDR4"
- `test_soc_fabric_populated`: both populate 4x8 mesh

## One v6 reconciliation item documented

`reconfig_overhead_cycles` (Plasticine = 1000; the defining CGRA Achilles heel) lives on `CGRABlock` in the v5 schema but has no equivalent field on `HardwareResourceModel`. Downstream consumers that need it read from the underlying `ComputeProduct` directly; the parity test pins this via direct schema read. v6 will add the field properly.

## Changes

| File | Δ | What |
|---|---|---|
| ``src/graphs/hardware/models/accelerators/stanford_plasticine_cgra.py`` | −145 LOC | 170-LOC hand-coded → 25-LOC thin loader wrapper (zero overlays) |
| ``tests/hardware/test_cgra_yaml_loader_plasticine_parity.py`` | −80 LOC | Retired 2 stale drift tests; converted 3 drift assertions to mutual contract assertions |

## Test Results

| Suite | Result |
|---|---|
| ``test_cgra_yaml_loader_plasticine_parity.py`` | 32 passed (was 34; -2 retired) |
| Full suite | **2922 passed**, 13 skipped, 4 xfailed (was 2924; net -2 from retired) |

## Test plan

- [x] All 2922 graphs tests pass locally
- [x] Plasticine factory now returns YAML-corrected chip-level peaks (10.24 TOPS INT8)
- [x] CGRAMapper still accepts Plasticine (no mapper guard changes needed)
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied: ``gh pr ready PR_NUMBER``

## Issue #196 — CGRA mini-sprint complete

After this PR merges, the umbrella issue closes:

| PR | Repo | State |
|---|---|---|
| 1/5 paper exercise | graphs | ✅ Merged (#197) |
| 2/5 CGRABlock schema | embodied-schemas | ✅ Merged (#34) |
| 3/5 Plasticine YAML | embodied-schemas | ✅ Merged (#35) |
| 4/5 graphs loader | graphs | ✅ Merged (#198) |
| **5/5 thin factory cleanup** | graphs | **This PR — closes #196** |

## Catalog migration progress

| Architecture | YAML-backed | Hand-coded remaining | Status |
|---|---|---|---|
| KPU | 12 | 0 | ✅ done |
| GPU | 2 | 8 | catalog expansion (no schema work) |
| CPU | 1 | 7 | catalog expansion (no schema work) |
| NPU | 3 | 0 | ✅ done (issue #192) |
| **CGRA** | **1** | **0** | **✅ done (this PR / issue #196)** |
| DPU | 0 | 1 | next-best mini-sprint (1 SKU, ~3 PRs) |
| TPU | 0 | 5 | sprint (5+ PRs) |
| DSP | 0 | 10 | sprint (12+ PRs) |

19 of 42 hand-coded factories migrated (~45%).

## Refs

- **Closes #196** (CGRA mini-sprint umbrella)
- #197 (paper exercise; PR 1/5)
- #198 (YAML loader; PR 4/5)
- branes-ai/embodied-schemas#34, #35 (precursors)
- #190 / #194 / #195 (NPU cleanup PRs — pattern source)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Stanford Plasticine v2 hardware model architecture by centralizing configuration source while preserving the public interface and functionality.

* **Tests**
  * Updated parity verification tests to ensure consistency of the model across implementation approaches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->