### PR TITLE
feat(hardware): DPU YAML loader (#200 sprint PR 4/5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,9 @@ jobs:
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
           #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
-          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
+          #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
+          #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
+          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
           path: embodied-schemas
           fetch-depth: 1
 
@@ -185,7 +187,9 @@ jobs:
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
           #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
-          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
+          #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
+          #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
+          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
           path: embodied-schemas
           fetch-depth: 1
 
@@ -298,7 +302,9 @@ jobs:
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
           #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
-          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
+          #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
+          #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
+          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
           path: embodied-schemas
           fetch-depth: 1
 
@@ -408,7 +414,9 @@ jobs:
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
           #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
-          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
+          #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
+          #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
+          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
           path: embodied-schemas
           fetch-depth: 1
 
@@ -491,7 +499,9 @@ jobs:
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
           #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
-          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
+          #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
+          #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
+          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
           path: embodied-schemas
           fetch-depth: 1
 
@@ -562,7 +572,9 @@ jobs:
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
           #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
-          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
+          #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
+          #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
+          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,7 +62,9 @@ jobs:
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
           #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
-          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
+          #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
+          #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
+          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -111,7 +111,9 @@ jobs:
           #   PR #33 (6e3aadb) third NPU SKU YAML: google_coral_edge_tpu (first systolic NPU)
           #   PR #34 (fd43608) CGRABlock added to ComputeProduct (v5, additive)
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
-          ref: 51b828719ed08a51e8fb6d225ac11f324ae8ad3f
+          #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
+          #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
+          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
           path: embodied-schemas
           fetch-depth: 1
 

--- a/src/graphs/hardware/models/accelerators/dpu_yaml_loader.py
+++ b/src/graphs/hardware/models/accelerators/dpu_yaml_loader.py
@@ -1,0 +1,553 @@
+"""DPU resource model loader from embodied-schemas ComputeProduct YAMLs.
+
+PR 4 of the DPU mini-sprint scoped at issue #200. Mirrors
+``src/graphs/hardware/models/accelerators/cgra_yaml_loader.py`` (CGRA
+sprint #198) but reads a DPUBlock-bearing ``ComputeProduct`` and
+builds a ``HardwareResourceModel`` with the DPU-shaped fields populated.
+
+Sibling to the hand-coded factory at
+``src/graphs/hardware/models/accelerators/xilinx_vitis_ai_dpu.py``
+during the parallel-migration phase. Adding the factory swap is PR 5;
+this PR ships the loader machinery and a parity test that proves the
+YAML-loaded model matches the hand-coded one's key fields.
+
+Scope of DPUBlock -> HardwareResourceModel mapping (one-to-one unless
+noted):
+
+  DPUBlock.num_aie_tiles          -> compute_units
+  DPUBlock.macs_per_tile          -> threads_per_unit
+  DPUBlock.simd_lanes_per_tile    -> warps_per_unit (legacy compat)
+  DPUBlock.compute_fabrics[*]     -> compute_fabrics[] (num_units =
+                                     num_aie_tiles per fabric)
+  DPUBlock.memory.{scratchpad,    -> peak_bandwidth, l1/l2_cache_*,
+    shared, external_dram}           main_memory, memory_technology,
+                                     memory_*_energy_per_byte_pj
+  DPUBlock.noc                    -> soc_fabric (SoCFabricModel)
+  DPUBlock.{min_occupancy,        -> matching HardwareResourceModel fields
+    max_concurrent_models,
+    wave_quantization}
+  ComputeProduct.power.thermal_profiles[]
+                                  -> thermal_operating_points
+  Roll-up performance             -> precision_profiles
+
+DPU-specific design decisions:
+
+1. **peak_bandwidth picks external_dram_bandwidth_gbps** when
+   has_external_dram=True (Versal VE2302 has chip-attached DDR4 at
+   50 GB/s). Mirrors NPU's "DRAM tier when present" convention --
+   different from CGRA, where on-chip mesh is the bottleneck because
+   workloads stay on-chip steady-state. DPUs use DDR4 as the model
+   weight tier; bandwidth-bound workloads hit the DDR4 ceiling.
+
+2. **energy_per_flop_fp32 uses fabric's FP32 scaling x
+   fpga_fabric_overhead_factor**. DPUs ship honest FP energy scaling
+   (like CGRAs) but also pay the FPGA-vs-ASIC penalty (25% for
+   Vitis AI). The loader multiplies through both.
+
+3. **HardwareType.DPU already exists** on the graphs side (unlike
+   NPU which needed #191). The loader sets it directly with no
+   transitional period.
+
+4. **is_statically_reconfigurable + bitstream_load_time_ms NOT
+   surfaced on HardwareResourceModel**. The v6 schema carries these
+   on DPUBlock but the legacy graphs model has no equivalent fields.
+   v7 reconciliation will add them. Downstream consumers that need
+   them read directly from the ComputeProduct.
+
+Out of scope for v6 (deferred to v7):
+
+  - BOMCostProfile (YAML doesn't carry; v7 Market.bom)
+  - Per-field provenance copy-through with rich source citations
+  - ``is_statically_reconfigurable`` / ``bitstream_load_time_ms`` /
+    ``fpga_fabric_overhead_factor`` surfacing on HardwareResourceModel
+    (v7 reconciliation)
+  - Multi-block-per-die (modeling the Versal ARM Cortex-A72 control
+    complex as a sibling CPUBlock on the same die)
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from embodied_schemas.compute_product import ComputeProduct
+from embodied_schemas.dpu_block import (
+    DPUBlock,
+    DPUFabricKind,
+    DPUNoCTopology,
+)
+from embodied_schemas.loaders import load_compute_products
+from embodied_schemas.process_node import ProcessNodeEntry
+
+from graphs.core.confidence import EstimationConfidence
+from graphs.hardware.fabric_model import SoCFabricModel, Topology
+from graphs.hardware.resource_model import (
+    ComputeFabric,
+    HardwareResourceModel,
+    HardwareType,
+    Precision,
+    PrecisionProfile,
+    ThermalOperatingPoint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class DPUYamlLoaderError(Exception):
+    """Raised when a ComputeProduct YAML can't be turned into a DPU
+    HardwareResourceModel (missing block, unsupported topology,
+    unresolved references, etc.)."""
+
+
+# ---------------------------------------------------------------------------
+# Mapping tables
+# ---------------------------------------------------------------------------
+
+_PRECISION_BY_NAME: dict[str, Precision] = {
+    "fp64": Precision.FP64,
+    "fp32": Precision.FP32,
+    "tf32": Precision.TF32,
+    "fp16": Precision.FP16,
+    "bf16": Precision.BF16,
+    "fp8_e4m3": Precision.FP8_E4M3,
+    "fp8_e5m2": Precision.FP8_E5M2,
+    "int8": Precision.INT8,
+    "int4": Precision.INT4,
+}
+
+_BYTES_PER_PRECISION: dict[Precision, float] = {
+    Precision.FP64: 8, Precision.FP32: 4, Precision.TF32: 4,
+    Precision.FP16: 2, Precision.BF16: 2,
+    Precision.FP8_E4M3: 1, Precision.FP8_E5M2: 1,
+    Precision.INT8: 1, Precision.INT4: 0.5,
+}
+
+# DPUFabricKind -> ComputeFabric.fabric_type. The choice of name
+# matches the existing hand-coded factory's fabric_type string
+# ("aie_ml_tile") so parity tests can pin equality.
+_FABRIC_TYPE_BY_KIND: dict[DPUFabricKind, str] = {
+    DPUFabricKind.AIE_ML_V1:    "aie_ml_tile",
+    DPUFabricKind.AIE_ML_V2:    "aie_ml_v2_tile",
+    DPUFabricKind.AIE_HD:       "aie_hd_tile",
+    DPUFabricKind.SOFT_LUT_DPU: "soft_lut_dpu",
+}
+
+# DPUs use standard-cell designs across all fabric kinds (AIE tiles
+# are hardened standard cells; FPGA glue logic is LUT-based but
+# wrapped under the same circuit_type for legacy compat).
+_CIRCUIT_TYPE_DEFAULT = "standard_cell"
+
+# DPUNoCTopology -> graphs SoCFabricModel Topology enum.
+_TOPOLOGY_BY_KIND: dict[DPUNoCTopology, Topology] = {
+    DPUNoCTopology.AIE_MESH: Topology.MESH_2D,  # AIE streaming mesh degenerates to mesh
+    DPUNoCTopology.CROSSBAR: Topology.CROSSBAR,
+}
+
+# DRAM read-energy table (per-byte). External DRAM only.
+_DRAM_READ_PJ_PER_BYTE: dict[str, float] = {
+    "ddr4": 28.0, "ddr5": 25.0,
+    "lpddr4": 18.0, "lpddr4x": 16.0,
+    "lpddr5": 15.0, "lpddr5x": 13.0,
+    "hbm2": 7.0, "hbm3": 6.0,
+}
+_DRAM_WRITE_RATIO = 1.2
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _dpu_block(cp: ComputeProduct) -> DPUBlock:
+    """Pick the (single) DPUBlock from a ComputeProduct's first die."""
+    for block in cp.dies[0].blocks:
+        if isinstance(block, DPUBlock):
+            return block
+    raise DPUYamlLoaderError(
+        f"ComputeProduct {cp.id!r} has no DPUBlock in dies[0].blocks "
+        f"(found: {[type(b).__name__ for b in cp.dies[0].blocks]})"
+    )
+
+
+def _precisions_from_ops_dict(
+    ops: dict[str, int],
+    *,
+    source: str = "ops_per_unit_per_clock",
+) -> dict[Precision, int]:
+    """Convert YAML's str-keyed ops/clock dict to graphs' Precision-keyed
+    dict. Fails fast on unknown precision names."""
+    out: dict[Precision, int] = {}
+    unknown: list[str] = []
+    for name, count in ops.items():
+        prec = _PRECISION_BY_NAME.get(name.lower())
+        if prec is None:
+            unknown.append(name)
+            continue
+        out[prec] = count
+    if unknown:
+        raise DPUYamlLoaderError(
+            f"unknown precision name(s) in {source}: {sorted(unknown)}. "
+            f"Known: {sorted(_PRECISION_BY_NAME)}"
+        )
+    return out
+
+
+def _energy_scaling_from_yaml(
+    scaling: dict[str, float],
+    *,
+    source: str = "energy_scaling",
+) -> dict[Precision, float]:
+    out: dict[Precision, float] = {}
+    unknown: list[str] = []
+    for name, factor in scaling.items():
+        prec = _PRECISION_BY_NAME.get(name.lower())
+        if prec is None:
+            unknown.append(name)
+            continue
+        out[prec] = factor
+    if unknown:
+        raise DPUYamlLoaderError(
+            f"unknown precision name(s) in {source}: {sorted(unknown)}. "
+            f"Known: {sorted(_PRECISION_BY_NAME)}"
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def load_dpu_resource_model_from_yaml(
+    base_id: str,
+    *,
+    products: Optional[dict[str, ComputeProduct]] = None,
+    process_nodes: Optional[dict[str, ProcessNodeEntry]] = None,
+    name_override: Optional[str] = None,
+) -> HardwareResourceModel:
+    """Build a ``HardwareResourceModel`` for ``base_id`` from a DPU
+    ComputeProduct YAML.
+
+    Args:
+        base_id: ComputeProduct id, e.g., "xilinx_vitis_ai_b4096".
+        products / process_nodes: optional pre-loaded catalogs.
+        name_override: optional override for the resource model's
+            ``name`` field. Vitis AI YAML name is
+            "Xilinx Vitis AI B4096 (Versal VE2302)"; the hand-coded
+            factory uses "DPU-Vitis-AI-B4096" -- pass that to
+            preserve compat.
+
+    Raises:
+        DPUYamlLoaderError: when ``base_id`` is not in the catalog,
+            doesn't carry a DPUBlock, or has unresolvable references.
+    """
+    if products is None:
+        products = load_compute_products()
+    if process_nodes is None:
+        from embodied_schemas.loaders import load_process_nodes
+        process_nodes = load_process_nodes()
+
+    cp = products.get(base_id)
+    if cp is None:
+        raise DPUYamlLoaderError(
+            f"no ComputeProduct with id={base_id!r}. Available: "
+            f"{', '.join(sorted(products))}"
+        )
+    block = _dpu_block(cp)
+
+    node = process_nodes.get(cp.dies[0].process_node_id)
+    if node is None:
+        raise DPUYamlLoaderError(
+            f"SKU {base_id!r} references process_node_id="
+            f"{cp.dies[0].process_node_id!r} which does not resolve"
+        )
+    process_node_nm = int(node.node_nm)
+
+    # ------------------------------------------------------------------
+    # Default thermal profile -> clock used as fabric core_frequency_hz
+    # ------------------------------------------------------------------
+    default_profile = next(
+        (p for p in cp.power.thermal_profiles
+         if p.name == cp.power.default_thermal_profile),
+        None,
+    )
+    if default_profile is None:
+        raise DPUYamlLoaderError(
+            f"SKU {base_id!r}: default_thermal_profile "
+            f"{cp.power.default_thermal_profile!r} is not in thermal_profiles"
+        )
+    default_clock_hz = default_profile.clock_mhz * 1e6
+
+    # ------------------------------------------------------------------
+    # ComputeFabric per DPU fabric. DPUs usually ship a single fabric
+    # (Vitis AI: AIE-ML v1 tile array). num_units = num_aie_tiles
+    # because the fabric "lives" on all tiles.
+    # ------------------------------------------------------------------
+    compute_fabrics: list[ComputeFabric] = []
+    for dpu_fabric in block.compute_fabrics:
+        ops_dict = _precisions_from_ops_dict(
+            dpu_fabric.ops_per_unit_per_clock,
+            source=f"fabric.{dpu_fabric.fabric_kind.value}",
+        )
+        if not ops_dict:
+            continue
+        # DPUs ship honest FP energy scaling AND pay the FPGA-vs-ASIC
+        # overhead penalty. Compute energy_per_flop_fp32 from the
+        # fabric's INT8 baseline * FP32 scaling * fpga overhead.
+        energy_per_op_int8_j = (
+            dpu_fabric.energy_per_op_int8_pj * 1e-12
+            * dpu_fabric.fpga_fabric_overhead_factor
+        )
+        dpu_scaling = _energy_scaling_from_yaml(dpu_fabric.energy_scaling)
+        if Precision.FP32 in dpu_scaling:
+            energy_per_flop_fp32_j = energy_per_op_int8_j * dpu_scaling[Precision.FP32]
+        else:
+            energy_per_flop_fp32_j = energy_per_op_int8_j * 8.0
+        # ComputeFabric.energy_scaling expects FP32-baseline scaling
+        # (legacy convention). Translate: scaling_fp32 = scaling_int8 / fp32_scaling.
+        fp32_scaling: dict[Precision, float] = {}
+        fp32_baseline = dpu_scaling.get(Precision.FP32, 8.0)
+        fp32_scaling[Precision.INT8] = 1.0 / fp32_baseline
+        for prec, factor in dpu_scaling.items():
+            if prec == Precision.FP32:
+                continue
+            fp32_scaling[prec] = factor / fp32_baseline
+        compute_fabrics.append(ComputeFabric(
+            fabric_type=_FABRIC_TYPE_BY_KIND[dpu_fabric.fabric_kind],
+            circuit_type=_CIRCUIT_TYPE_DEFAULT,
+            num_units=block.num_aie_tiles,
+            ops_per_unit_per_clock=ops_dict,
+            core_frequency_hz=default_clock_hz,
+            process_node_nm=process_node_nm,
+            energy_per_flop_fp32=energy_per_flop_fp32_j,
+            energy_scaling=fp32_scaling,
+        ))
+
+    if not compute_fabrics:
+        raise DPUYamlLoaderError(
+            f"SKU {base_id!r}: no DPUComputeFabric produced a valid "
+            f"ComputeFabric (check ops_per_unit_per_clock entries)."
+        )
+
+    # ------------------------------------------------------------------
+    # PrecisionProfile dict -- chip-wide peak ops/sec per precision
+    # ------------------------------------------------------------------
+    supported_precisions: set[Precision] = set()
+    for fabric in compute_fabrics:
+        supported_precisions.update(fabric.ops_per_unit_per_clock.keys())
+
+    precision_profiles: dict[Precision, PrecisionProfile] = {}
+    for precision in supported_precisions:
+        peak = sum(f.get_peak_ops_per_sec(precision) for f in compute_fabrics)
+        if peak <= 0:
+            continue
+        # AIE tiles act like tensor cores for INT8 / FP16 (native
+        # hardware support).
+        tensor_supported = precision in {Precision.INT8, Precision.FP16, Precision.INT4}
+        # Relative speedup vs INT8 (the DPU baseline).
+        int8_peak = sum(
+            f.get_peak_ops_per_sec(Precision.INT8) for f in compute_fabrics
+        )
+        relative_speedup = peak / int8_peak if int8_peak > 0 else 1.0
+        precision_profiles[precision] = PrecisionProfile(
+            precision=precision,
+            peak_ops_per_sec=peak,
+            tensor_core_supported=tensor_supported,
+            relative_speedup=relative_speedup,
+            bytes_per_element=_BYTES_PER_PRECISION.get(precision, 4),
+            accumulator_precision=(
+                Precision.INT32 if precision == Precision.INT8 else
+                Precision.FP32 if precision == Precision.FP16 else
+                None
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # ThermalOperatingPoint per chip-level thermal_profile
+    # ------------------------------------------------------------------
+    thermal_operating_points: dict[str, ThermalOperatingPoint] = {}
+    for profile in cp.power.thermal_profiles:
+        thermal_operating_points[profile.name] = ThermalOperatingPoint(
+            name=profile.name,
+            tdp_watts=profile.tdp_watts,
+            cooling_solution=profile.cooling_solution_id,
+            performance_specs={},
+        )
+
+    # ------------------------------------------------------------------
+    # Memory + cache (scratchpad + shared L2 + chip-attached DDR)
+    # ------------------------------------------------------------------
+    mem = block.memory
+    # peak_bandwidth picks the dominant *externally-visible* memory tier.
+    # DPUs use DDR4 as the model-weight tier; bandwidth-bound workloads
+    # hit the DDR4 ceiling. Mirrors NPU loader convention ("DRAM tier
+    # when present") -- different from CGRA where on-chip mesh dominates
+    # because workloads stay on-chip steady-state.
+    if mem.has_external_dram and mem.external_dram_bandwidth_gbps is not None:
+        peak_bandwidth_bps = mem.external_dram_bandwidth_gbps * 1e9
+    else:
+        peak_bandwidth_bps = mem.on_chip_bandwidth_gbps * 1e9
+
+    # External DRAM -> main_memory.
+    if mem.has_external_dram and mem.external_dram_size_gb is not None:
+        main_memory_bytes = int(mem.external_dram_size_gb * 1024**3)
+    else:
+        main_memory_bytes = 0
+
+    # Per-AIE-tile scratchpad is the "L1" of DPU-land.
+    l1_per_unit_bytes = mem.scratchpad_kib_per_tile * 1024
+
+    # Shared L2 SRAM.
+    l2_total_bytes = mem.shared_sram_kib * 1024
+    l2_per_unit_bytes = (
+        l2_total_bytes // block.num_aie_tiles
+        if block.num_aie_tiles > 0 else 0
+    )
+
+    # Memory technology label and per-byte access energy.
+    if mem.has_external_dram and mem.external_dram_type is not None:
+        memory_technology = mem.external_dram_type.value.upper()
+        dram_tech = mem.external_dram_type.value.lower()
+        read_pj = _DRAM_READ_PJ_PER_BYTE.get(dram_tech, 25.0)
+        write_pj = read_pj * _DRAM_WRITE_RATIO
+        # Honor the YAML's external_dram_access_energy_pj_per_byte
+        # when populated (more accurate than the lookup table).
+        if mem.external_dram_access_energy_pj_per_byte > 0:
+            read_pj = mem.external_dram_access_energy_pj_per_byte
+            write_pj = read_pj * _DRAM_WRITE_RATIO
+    else:
+        memory_technology = "on-chip SRAM (no external DRAM)"
+        read_pj = mem.scratchpad_access_energy_pj_per_byte
+        write_pj = read_pj
+
+    # ------------------------------------------------------------------
+    # SoC fabric (AIE streaming mesh)
+    # ------------------------------------------------------------------
+    soc_fabric_kwargs = dict(
+        topology=_TOPOLOGY_BY_KIND[block.noc.topology],
+        hop_latency_ns=block.noc.hop_latency_ns,
+        pj_per_flit_per_hop=block.noc.pj_per_flit_per_hop,
+        bisection_bandwidth_gbps=block.noc.bisection_bandwidth_gbps,
+        controller_count=block.noc.unit_count,
+        flit_size_bytes=block.noc.flit_size_bytes,
+        routing_distance_factor=block.noc.routing_distance_factor,
+        provenance=(
+            f"Loaded from compute_products YAML "
+            f"({base_id}.dies[0].blocks[0].noc); DPU NoC topology "
+            f"{block.noc.topology.value} mapped to graphs SoCFabric "
+            f"{_TOPOLOGY_BY_KIND[block.noc.topology].name}"
+        ),
+    )
+    # Mesh dimensions: pass through when AIE_MESH
+    if (block.noc.topology == DPUNoCTopology.AIE_MESH
+            and block.noc.mesh_rows is not None
+            and block.noc.mesh_cols is not None):
+        soc_fabric_kwargs["mesh_dimensions"] = (
+            block.noc.mesh_rows, block.noc.mesh_cols
+        )
+    from embodied_schemas.process_node import DataConfidence
+    if block.noc.confidence == DataConfidence.THEORETICAL:
+        soc_fabric_kwargs["low_confidence"] = True
+    soc_fabric = SoCFabricModel(**soc_fabric_kwargs)
+
+    # ------------------------------------------------------------------
+    # Assemble HardwareResourceModel
+    # ------------------------------------------------------------------
+    # Default precision: INT8 (the DPU default).
+    if Precision.INT8 in precision_profiles:
+        default_precision = Precision.INT8
+    elif Precision.INT4 in precision_profiles:
+        default_precision = Precision.INT4
+    else:
+        default_precision = next(iter(precision_profiles))
+
+    # Energy fields: use the first fabric.
+    first_fabric = compute_fabrics[0]
+    energy_per_flop_fp32 = first_fabric.energy_per_flop_fp32
+    energy_scaling: dict[Precision, float] = {}
+    for fabric in compute_fabrics:
+        energy_scaling.update(fabric.energy_scaling)
+
+    model = HardwareResourceModel(
+        name=name_override or cp.name,
+        hardware_type=HardwareType.DPU,
+
+        compute_fabrics=compute_fabrics,
+
+        compute_units=block.num_aie_tiles,
+        threads_per_unit=block.macs_per_tile,
+        warps_per_unit=block.simd_lanes_per_tile,
+        warp_size=block.simd_lanes_per_tile,
+
+        thermal_operating_points=thermal_operating_points,
+        default_thermal_profile=cp.power.default_thermal_profile,
+
+        precision_profiles=precision_profiles,
+        default_precision=default_precision,
+
+        peak_bandwidth=peak_bandwidth_bps,
+        l1_cache_per_unit=l1_per_unit_bytes,
+        l2_cache_total=l2_total_bytes,
+        main_memory=main_memory_bytes,
+
+        energy_per_flop_fp32=energy_per_flop_fp32,
+        energy_per_byte=read_pj * 1e-12,
+        energy_scaling=energy_scaling,
+
+        min_occupancy=block.min_occupancy,
+        max_concurrent_kernels=block.max_concurrent_models,
+        wave_quantization=block.wave_quantization,
+
+        # M3 Layer 3: software-managed AIE tile scratchpad.
+        l1_storage_kind="scratchpad",
+
+        # M4 Layer 4: shared L2 acts as LLC above per-tile scratchpads.
+        l2_cache_per_unit=l2_per_unit_bytes,
+        l2_topology="shared-llc",
+
+        # M5 Layer 5: DPUs don't have L3 between AIE tiles.
+        l3_present=False,
+        l3_cache_total=0,
+
+        # AIE streaming dataflow has no coherence
+        coherence_protocol=mem.coherence_protocol,
+
+        # M7 Layer 7
+        memory_technology=memory_technology,
+        memory_read_energy_per_byte_pj=read_pj,
+        memory_write_energy_per_byte_pj=write_pj,
+
+        # M6 Layer 6
+        soc_fabric=soc_fabric,
+    )
+
+    # Generic provenance for the YAML-loaded fields
+    yaml_provenance = EstimationConfidence.theoretical(
+        score=0.80,
+        source=f"Loaded from compute_products YAML ({base_id})",
+    )
+    for key in (
+        "l1_cache_per_unit", "l1_storage_kind",
+        "l2_cache_per_unit", "l2_topology",
+        "l3_present", "l3_cache_total", "coherence_protocol",
+        "memory_technology",
+        "memory_read_energy_per_byte_pj",
+        "memory_write_energy_per_byte_pj",
+        "soc_fabric",
+    ):
+        model.set_provenance(key, yaml_provenance)
+
+    # Per-precision provenance on compute_fabric ops/clock
+    fabric_provenance = EstimationConfidence.theoretical(
+        score=0.55,
+        source=(
+            f"Loaded from compute_products YAML ({base_id}): per-fabric "
+            f"ops_per_unit_per_clock at the dominant AIE-ML fabric"
+        ),
+    )
+    for precision in supported_precisions:
+        model.set_provenance(
+            f"compute_fabric.ops_per_clock.{precision.value}",
+            fabric_provenance,
+        )
+
+    return model

--- a/src/graphs/hardware/models/accelerators/dpu_yaml_loader.py
+++ b/src/graphs/hardware/models/accelerators/dpu_yaml_loader.py
@@ -452,7 +452,18 @@ def load_dpu_resource_model_from_yaml(
     # ------------------------------------------------------------------
     # Assemble HardwareResourceModel
     # ------------------------------------------------------------------
-    # Default precision: INT8 (the DPU default).
+    # Default precision: INT8 (the DPU default). Guard against the
+    # all-fabrics-yielded-zero-peak case so callers see a clear
+    # DPUYamlLoaderError instead of an unhandled StopIteration. The
+    # DPUComputeFabric validator on the schema side rejects non-positive
+    # ops, so this branch is defensive against future refactors.
+    if not precision_profiles:
+        raise DPUYamlLoaderError(
+            f"SKU {base_id!r}: no precision_profiles produced. All "
+            f"compute_fabrics returned zero peak ops/sec for every "
+            f"supported precision; check ops_per_unit_per_clock + "
+            f"thermal profile clock values."
+        )
     if Precision.INT8 in precision_profiles:
         default_precision = Precision.INT8
     elif Precision.INT4 in precision_profiles:

--- a/tests/hardware/test_dpu_yaml_loader_vitis_ai_parity.py
+++ b/tests/hardware/test_dpu_yaml_loader_vitis_ai_parity.py
@@ -1,0 +1,390 @@
+"""Contract test: Vitis AI B4096 YAML loader produces the expected model.
+
+PR 4 of the DPU mini-sprint scoped at issue #200. Mirror of
+``tests/hardware/test_cgra_yaml_loader_plasticine_parity.py``.
+Compares the YAML-loaded model against the hand-coded factory at
+``src/graphs/hardware/models/accelerators/xilinx_vitis_ai_dpu.py``.
+
+PR 5 will retire the hand-coded body and make ``xilinx_vitis_ai_dpu_resource_model()``
+a thin wrapper over the loader; at that point both ``hand_coded`` and
+``yaml_loaded`` fixtures will resolve through the same loader and
+these structural assertions become contract tests.
+
+Documented drifts (the loader follows a different convention; parity
+test pins the YAML values as the new contract):
+
+  - ``INT8 peak: 10.24 TOPS`` (yaml THEORETICAL) vs ``7.68 TOPS``
+    (hand-coded REALISTIC at 75% efficiency). The YAML reports
+    theoretical chip-level peak in precision_profiles; efficiency
+    is captured separately in thermal_operating_points'
+    efficiency_factor_by_precision. The Vitis AI marketed number
+    is 7.68 TOPS (realistic) but the schema convention is theoretical
+    peak; downstream consumers apply efficiency from the thermal
+    profile.
+  - ``FP16 peak: 2.56 TOPS`` (yaml THEORETICAL) vs ``1.92 TOPS``
+    (hand-coded REALISTIC). Same root cause -- 75% efficiency factor.
+  - ``FP32 peak``: not in YAML precision_profiles vs 0.96 TFLOPS
+    (hand-coded). YAML's compute_fabrics declare INT8 + FP16 in
+    ops_per_unit_per_clock; FP32 is captured only as energy_scaling
+    (for cost modeling) since it's emulated. Downstream consumers
+    can synthesize FP32 ops as INT8 / fp32_scaling if needed.
+  - ``memory_technology``: ``"DDR4"`` (yaml) vs ``None`` (hand-coded).
+    The legacy doesn't populate this field; the YAML loader does.
+  - ``soc_fabric``: populated (yaml) vs ``None`` (hand-coded). Same.
+  - ``energy_per_flop_fp32``: ~8% drift (2.5 pJ yaml vs 2.7 pJ hand-coded).
+    YAML uses INT8 * FPGA-overhead * FP32-scaling = 0.4 * 1.25 * 5.0
+    = 2.5 pJ. Hand-coded uses ``get_base_alu_energy(16, 'standard_cell')``
+    = 2.7 pJ. Both are valid 16nm estimates.
+
+Where the hand-coded and YAML-loaded agree (the actual parity
+assertions):
+
+  - compute_units, threads_per_unit, warps_per_unit
+  - peak_bandwidth (50 GB/s -- DDR4, chip-attached)
+  - l1_cache_per_unit, l2_cache_total, main_memory
+  - default_precision (INT8)
+  - hardware_type (DPU)
+  - thermal profile shape (single profile, 20W)
+  - scheduler attrs (min_occupancy, max_concurrent_kernels=4,
+    wave_quantization=2)
+"""
+
+import pytest
+
+from graphs.hardware.models.accelerators.dpu_yaml_loader import (
+    DPUYamlLoaderError,
+    load_dpu_resource_model_from_yaml,
+)
+from graphs.hardware.models.accelerators.xilinx_vitis_ai_dpu import (
+    xilinx_vitis_ai_dpu_resource_model,
+)
+from graphs.hardware.resource_model import HardwareType, Precision
+
+
+SKU_ID = "xilinx_vitis_ai_b4096"
+LEGACY_NAME = "DPU-Vitis-AI-B4096"
+
+
+@pytest.fixture(scope="module")
+def hand_coded():
+    return xilinx_vitis_ai_dpu_resource_model()
+
+
+@pytest.fixture(scope="module")
+def yaml_loaded():
+    return load_dpu_resource_model_from_yaml(
+        SKU_ID, name_override=LEGACY_NAME,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Identity / shape
+# ---------------------------------------------------------------------------
+
+def test_name_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.name == hand_coded.name == "DPU-Vitis-AI-B4096"
+
+
+def test_hardware_type_is_dpu(hand_coded, yaml_loaded):
+    """Both produce HardwareType.DPU -- no transitional period needed
+    (DPU already in graphs enum)."""
+    assert yaml_loaded.hardware_type == hand_coded.hardware_type == HardwareType.DPU
+
+
+def test_compute_units_matches(hand_coded, yaml_loaded):
+    """64 AIE-ML v1 tiles."""
+    assert yaml_loaded.compute_units == hand_coded.compute_units == 64
+
+
+def test_threads_per_unit_matches(hand_coded, yaml_loaded):
+    """64 MACs per AIE tile."""
+    assert yaml_loaded.threads_per_unit == hand_coded.threads_per_unit == 64
+
+
+def test_warps_per_unit_matches(hand_coded, yaml_loaded):
+    """8 SIMD vector lanes per AIE-ML v1 tile."""
+    assert yaml_loaded.warps_per_unit == hand_coded.warps_per_unit == 8
+
+
+# ---------------------------------------------------------------------------
+# Compute fabrics
+# ---------------------------------------------------------------------------
+
+def test_single_compute_fabric(hand_coded, yaml_loaded):
+    """Vitis AI B4096 has one fabric (AIE-ML v1 tile array)."""
+    assert len(yaml_loaded.compute_fabrics) == len(hand_coded.compute_fabrics) == 1
+
+
+def test_compute_fabric_is_aie_ml_tile(hand_coded, yaml_loaded):
+    """First SKU to exercise DPUFabricKind.AIE_ML_V1 -> fabric_type
+    'aie_ml_tile' via the loader's mapping table."""
+    assert yaml_loaded.compute_fabrics[0].fabric_type == "aie_ml_tile"
+    assert hand_coded.compute_fabrics[0].fabric_type == "aie_ml_tile"
+
+
+def test_compute_fabric_num_units(hand_coded, yaml_loaded):
+    """num_units = 64 AIE tiles."""
+    assert yaml_loaded.compute_fabrics[0].num_units == hand_coded.compute_fabrics[0].num_units == 64
+
+
+def test_compute_fabric_int8_ops_per_clock(hand_coded, yaml_loaded):
+    """128 INT8 ops/AIE tile/clock = 64 MACs * 2 ops/MAC."""
+    hand_int8 = hand_coded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.INT8)
+    yaml_int8 = yaml_loaded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.INT8)
+    assert yaml_int8 == hand_int8 == 128
+
+
+def test_compute_fabric_fp16_ops_per_clock(hand_coded, yaml_loaded):
+    """32 FP16 ops/AIE tile/clock = 1/4 INT8 (native AIE-ML)."""
+    hand_fp16 = hand_coded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.FP16)
+    yaml_fp16 = yaml_loaded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.FP16)
+    assert yaml_fp16 == hand_fp16 == 32
+
+
+def test_compute_fabric_energy_documented_drift(hand_coded, yaml_loaded):
+    """DOCUMENTED DRIFT: hand-coded uses
+    ``get_base_alu_energy(16, 'standard_cell')`` ~= 2.7 pJ; loader
+    uses INT8 * FPGA-overhead * FP32-scaling = 0.4 * 1.25 * 5.0 =
+    2.5 pJ. ~8% drift; both are valid 16nm estimates."""
+    for fab in (hand_coded.compute_fabrics[0], yaml_loaded.compute_fabrics[0]):
+        # Range sanity check: 16nm FP32 should be ~2-5 pJ
+        assert 1e-12 < fab.energy_per_flop_fp32 < 10e-12, (
+            f"fabric energy_per_flop_fp32={fab.energy_per_flop_fp32} "
+            f"outside [1, 10] pJ range for 16nm"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Precision profiles -- different conventions (theoretical vs realistic)
+# ---------------------------------------------------------------------------
+
+def test_int8_peak_yaml_is_theoretical_chip_level(yaml_loaded):
+    """YAML-loaded INT8 peak = 10.24 TOPS = 64 tiles * 128 ops/clk *
+    1.25 GHz. Theoretical chip-level peak (schema convention).
+    Efficiency factor (75%) lives in thermal_operating_points'
+    efficiency_factor_by_precision, applied by downstream consumers."""
+    assert yaml_loaded.precision_profiles[Precision.INT8].peak_ops_per_sec == pytest.approx(
+        10.24e12, rel=0.01
+    )
+
+
+def test_int8_peak_hand_coded_is_realistic(hand_coded):
+    """Pinned for visibility: legacy hand-coded reports 7.68 TOPS
+    (= 10.24 * 0.75 efficiency). Pre-multiplied efficiency factor.
+    PR 5 cleanup will retire the hand-coded path; downstream consumers
+    will read theoretical from precision_profiles and apply efficiency
+    from the thermal profile."""
+    legacy_peak = hand_coded.precision_profiles[Precision.INT8].peak_ops_per_sec
+    assert legacy_peak == pytest.approx(7.68e12, rel=0.01), (
+        f"unexpected legacy peak {legacy_peak/1e12:.3f} TOPS; if this "
+        f"changed the legacy was updated -- review this drift annotation."
+    )
+
+
+def test_fp16_peak_yaml_is_theoretical(yaml_loaded):
+    """YAML FP16 peak = 2.56 TFLOPS theoretical. Native AIE-ML FP16."""
+    assert yaml_loaded.precision_profiles[Precision.FP16].peak_ops_per_sec == pytest.approx(
+        2.56e12, rel=0.01
+    )
+
+
+def test_yaml_omits_emulated_fp32_from_precision_profiles(yaml_loaded, hand_coded):
+    """DOCUMENTED DRIFT: YAML's compute_fabrics declare INT8 + FP16 in
+    ops_per_unit_per_clock; FP32 is captured only as energy_scaling
+    (for cost modeling) since it's emulated. Hand-coded includes FP32
+    in precision_profiles at 0.96 TFLOPS (emulated, 1/8 INT8 realistic).
+    Downstream consumers needing FP32 ops/sec can compute as
+    INT8_realistic / 8."""
+    assert Precision.FP32 not in yaml_loaded.precision_profiles
+    # Hand-coded does include it (for reference)
+    assert Precision.FP32 in hand_coded.precision_profiles
+
+
+def test_default_precision_matches(hand_coded, yaml_loaded):
+    """Both prefer INT8 as default."""
+    assert yaml_loaded.default_precision == hand_coded.default_precision == Precision.INT8
+
+
+def test_int4_not_in_precision_profiles(hand_coded, yaml_loaded):
+    """AIE-ML v1 doesn't support INT4 (added in AIE-ML v2)."""
+    assert Precision.INT4 not in hand_coded.precision_profiles
+    assert Precision.INT4 not in yaml_loaded.precision_profiles
+
+
+# ---------------------------------------------------------------------------
+# Memory hierarchy (chip-attached DDR4)
+# ---------------------------------------------------------------------------
+
+def test_peak_bandwidth_matches_ddr4(hand_coded, yaml_loaded):
+    """50 GB/s -- chip-attached DDR4-3200 dual-channel. The loader
+    picks DDR4 (DPU loader convention: external DRAM is the
+    bottleneck tier for DPU workloads, unlike CGRA where on-chip
+    mesh dominates)."""
+    assert yaml_loaded.peak_bandwidth == pytest.approx(50e9, rel=0.01)
+    assert hand_coded.peak_bandwidth == pytest.approx(50e9, rel=0.01)
+
+
+def test_main_memory_matches(hand_coded, yaml_loaded):
+    """8 GiB chip-attached DDR4."""
+    assert yaml_loaded.main_memory == hand_coded.main_memory == 8 * 1024**3
+
+
+def test_l1_per_unit_matches(hand_coded, yaml_loaded):
+    """64 KiB AIE tile scratchpad."""
+    assert yaml_loaded.l1_cache_per_unit == hand_coded.l1_cache_per_unit
+    assert yaml_loaded.l1_cache_per_unit == 64 * 1024
+
+
+def test_l2_cache_total_matches(hand_coded, yaml_loaded):
+    """4 MiB shared L2."""
+    assert yaml_loaded.l2_cache_total == hand_coded.l2_cache_total
+    assert yaml_loaded.l2_cache_total == 4 * 1024 * 1024
+
+
+def test_l2_per_unit_calculated_correctly(yaml_loaded):
+    """4 MiB / 64 tiles = 64 KiB per-tile share."""
+    assert yaml_loaded.l2_cache_per_unit == (4 * 1024 * 1024) // 64
+
+
+def test_l3_absent(yaml_loaded):
+    """DPUs don't have L3 by construction."""
+    assert yaml_loaded.l3_present is False
+    assert yaml_loaded.l3_cache_total == 0
+
+
+def test_l1_storage_kind_is_scratchpad(yaml_loaded):
+    """AIE tile scratchpad is software-managed."""
+    assert yaml_loaded.l1_storage_kind == "scratchpad"
+
+
+def test_coherence_protocol_is_none(yaml_loaded):
+    """AIE streaming dataflow has no coherence (compiler-routed)."""
+    assert yaml_loaded.coherence_protocol == "none"
+
+
+def test_yaml_populates_memory_technology(yaml_loaded):
+    """DOCUMENTED DRIFT: hand-coded does NOT set memory_technology
+    (returns None); YAML loader populates it from external_dram_type.
+    The YAML's "DDR4" is structurally correct."""
+    assert yaml_loaded.memory_technology == "DDR4"
+
+
+def test_hand_coded_memory_technology_is_none(hand_coded):
+    """Pinned for visibility: PR 5 cleanup makes the YAML loader the
+    only source; both sides will then report "DDR4"."""
+    assert hand_coded.memory_technology is None
+
+
+# ---------------------------------------------------------------------------
+# SoC fabric (8x8 AIE mesh -- DRIFT: hand-coded doesn't populate)
+# ---------------------------------------------------------------------------
+
+def test_yaml_populates_soc_fabric(yaml_loaded):
+    """DOCUMENTED DRIFT: hand-coded does NOT set soc_fabric (returns
+    None); YAML loader populates it from NoC schema. The YAML's
+    8x8 mesh structure is correct and unblocks downstream Layer 6
+    reporting that the hand-coded couldn't support."""
+    from graphs.hardware.fabric_model import Topology
+    assert yaml_loaded.soc_fabric is not None
+    assert yaml_loaded.soc_fabric.topology == Topology.MESH_2D
+    assert yaml_loaded.soc_fabric.mesh_dimensions == (8, 8)
+    assert yaml_loaded.soc_fabric.controller_count == 64
+    assert yaml_loaded.soc_fabric.bisection_bandwidth_gbps == pytest.approx(80.0)
+    assert yaml_loaded.soc_fabric.low_confidence is True
+
+
+def test_hand_coded_soc_fabric_is_none(hand_coded):
+    """Pinned for visibility: PR 5 cleanup makes the YAML loader the
+    only source."""
+    assert hand_coded.soc_fabric is None
+
+
+# ---------------------------------------------------------------------------
+# Thermal profiles (single 20W operating point)
+# ---------------------------------------------------------------------------
+
+def test_thermal_profile_count_matches(hand_coded, yaml_loaded):
+    assert len(yaml_loaded.thermal_operating_points) == 1
+    assert len(hand_coded.thermal_operating_points) == 1
+
+
+def test_default_thermal_profile_tdp(hand_coded, yaml_loaded):
+    """Both default profiles report 20W."""
+    hand_default = hand_coded.thermal_operating_points[hand_coded.default_thermal_profile]
+    yaml_default = yaml_loaded.thermal_operating_points[yaml_loaded.default_thermal_profile]
+    assert yaml_default.tdp_watts == hand_default.tdp_watts == 20.0
+
+
+# ---------------------------------------------------------------------------
+# Scheduler attrs (DPU-specific: multi-model + pair-quantization)
+# ---------------------------------------------------------------------------
+
+def test_scheduler_attrs_match(hand_coded, yaml_loaded):
+    """0.3 occupancy (FPGA fabric overhead), 4 concurrent models
+    (DPUs partition AIE tiles), wave_q=2 (pair-quantization)."""
+    assert yaml_loaded.min_occupancy == pytest.approx(0.3, rel=0.05)
+    assert hand_coded.min_occupancy == pytest.approx(0.3, rel=0.05)
+    assert yaml_loaded.max_concurrent_kernels == hand_coded.max_concurrent_kernels == 4
+    assert yaml_loaded.wave_quantization == hand_coded.wave_quantization == 2
+
+
+# ---------------------------------------------------------------------------
+# DPU-specific: reconfig + FPGA overhead live on the schema, not on
+# HardwareResourceModel
+# ---------------------------------------------------------------------------
+
+def test_reconfig_and_fpga_overhead_on_underlying_compute_product():
+    """The Vitis AI YAML carries is_statically_reconfigurable=True,
+    bitstream_load_time_ms=2000, and fpga_fabric_overhead_factor=1.25
+    on the DPUBlock. The legacy HardwareResourceModel has no equivalent
+    fields, so the loader doesn't surface them; downstream consumers
+    that need them read directly from the ComputeProduct.
+
+    This test pins the values via direct schema read so a future v7
+    HardwareResourceModel extension that surfaces these has known-good
+    references."""
+    from embodied_schemas.loaders import load_compute_products
+    from embodied_schemas import DPUBlock
+    cp = load_compute_products().get("xilinx_vitis_ai_b4096")
+    assert cp is not None
+    block = next(b for b in cp.dies[0].blocks if isinstance(b, DPUBlock))
+    assert block.is_statically_reconfigurable is True
+    assert block.bitstream_load_time_ms == pytest.approx(2000.0)
+    assert block.compute_fabrics[0].fpga_fabric_overhead_factor == pytest.approx(1.25)
+
+
+# ---------------------------------------------------------------------------
+# Loader error paths
+# ---------------------------------------------------------------------------
+
+def test_loader_raises_on_unknown_sku():
+    with pytest.raises(DPUYamlLoaderError, match=r"no ComputeProduct with id"):
+        load_dpu_resource_model_from_yaml("definitely_not_a_real_dpu")
+
+
+def test_loader_raises_on_kpu_sku():
+    """KPU ComputeProducts have no DPUBlock; loader should reject."""
+    with pytest.raises(DPUYamlLoaderError, match=r"no DPUBlock"):
+        load_dpu_resource_model_from_yaml("kpu_t64_32x32_lp5x4_16nm_tsmc_ffp")
+
+
+def test_loader_raises_on_npu_sku():
+    """NPU ComputeProducts have no DPUBlock; loader should reject."""
+    with pytest.raises(DPUYamlLoaderError, match=r"no DPUBlock"):
+        load_dpu_resource_model_from_yaml("hailo_hailo_8")
+
+
+def test_loader_raises_on_cgra_sku():
+    """CGRA ComputeProducts have no DPUBlock; loader should reject."""
+    with pytest.raises(DPUYamlLoaderError, match=r"no DPUBlock"):
+        load_dpu_resource_model_from_yaml("stanford_plasticine_v2")
+
+
+def test_loader_raises_on_gpu_sku():
+    with pytest.raises(DPUYamlLoaderError, match=r"no DPUBlock"):
+        load_dpu_resource_model_from_yaml("nvidia_jetson_agx_orin_64gb")
+
+
+def test_loader_raises_on_cpu_sku():
+    with pytest.raises(DPUYamlLoaderError, match=r"no DPUBlock"):
+        load_dpu_resource_model_from_yaml("intel_core_i7_12700k")


### PR DESCRIPTION
## Summary

- Adds ``dpu_yaml_loader.py`` (~470 LOC) mirroring ``cgra_yaml_loader.py`` patterns.
- Builds ``HardwareResourceModel`` from a DPUBlock-bearing ``ComputeProduct``.
- 39-test parity suite pins YAML-loaded output against the hand-coded ``xilinx_vitis_ai_dpu.py``.
- CI pin bumped to include embodied-schemas#36 (schema) + #37 (Vitis AI YAML).
- PR 4 of 5 in the DPU mini-sprint scoped at #200.

## Why now

The two embodied-schemas precursors are merged:
1. ``embodied-schemas#36`` — DPUBlock added to the discriminated union
2. ``embodied-schemas#37`` — first DPU SKU YAML (Vitis AI B4096)

With both present, the graphs side can author the YAML loader so PR 5 (factory swap) can land.

## DPU-specific loader decisions

| # | Decision | Why |
|---|---|---|
| 1 | ``peak_bandwidth = external_dram_bandwidth_gbps`` when DDR4 present | DPUs use DDR4 as model-weight tier; bandwidth-bound workloads hit DDR4 ceiling (NPU-style, vs CGRA's on-chip-mesh convention) |
| 2 | ``energy_per_flop_fp32`` multiplies through three factors | INT8 * fpga_overhead * FP32_scaling. For Vitis AI: 0.4 * 1.25 * 5.0 = 2.5 pJ |
| 3 | ``HardwareType.DPU`` set directly | No transitional period (DPU already in graphs enum) |
| 4 | ``is_statically_reconfigurable`` / ``bitstream_load_time_ms`` / ``fpga_fabric_overhead_factor`` NOT surfaced | Legacy HardwareResourceModel has no equivalent fields; v7 reconciliation. Downstream reads from ComputeProduct. |

## Six documented drifts (loader follows schema conventions vs legacy)

| Field | YAML | Legacy | Why YAML's convention |
|---|---|---|---|
| INT8 peak | **10.24 TOPS** (theoretical) | 7.68 TOPS (realistic at 75%) | Schema reports theoretical; efficiency captured separately in thermal profile |
| FP16 peak | **2.56 TFLOPS** | 1.92 TFLOPS | Same 75% efficiency factor |
| FP32 peak | not in precision_profiles | 0.96 TFLOPS | Emulated; captured only as `energy_scaling` |
| ``memory_technology`` | **"DDR4"** | None | Legacy didn't populate |
| ``soc_fabric`` | **8x8 mesh populated** | None | Legacy didn't model; YAML unblocks Layer 6 reporting |
| ``energy_per_flop_fp32`` | 2.5 pJ | 2.7 pJ | ~8% drift; both valid 16nm estimates |

## CI pin bump

Bumped embodied-schemas pin from ``51b8287`` (PR #35 Plasticine YAML) to ``aa19f91`` (PR #37 Vitis AI YAML) across all 8 occurrences. History comment extended.

## Changes

| File | Δ | What |
|---|---|---|
| ``src/graphs/hardware/models/accelerators/dpu_yaml_loader.py`` | +470 LOC (new) | Full DPU loader |
| ``tests/hardware/test_dpu_yaml_loader_vitis_ai_parity.py`` | +320 LOC (new) | 39 parity + contract tests |
| ``.github/workflows/{ci,coverage,v4-validation}.yml`` | +24 LOC | CI pin bump + history |

## Test Results

| Suite | Result |
|---|---|
| ``test_dpu_yaml_loader_vitis_ai_parity.py`` | 39 passed (new) |
| Full suite | **2961 passed**, 13 skipped, 4 xfailed (was 2922) |

## Test plan

- [x] All 2961 graphs tests pass locally
- [x] Loader correctly handles external_dram_* gated fields
- [x] FP32 energy multiplies through INT8 * fpga_overhead * FP32_scaling
- [x] Loader rejects KPU/GPU/CPU/NPU/CGRA SKUs with clear error messages
- [x] Fast CI passes
- [x] Promote to ready when satisfied: ``gh pr ready PR_NUMBER``

## Follow-up (unblocked by this PR)

- PR 5 (graphs): retire ``xilinx_vitis_ai_dpu.py`` ~160 LOC hand-coded factory to thin loader wrapper; closes #200

## Refs

- #200 (umbrella tracking issue; DPU mini-sprint)
- #201 (paper exercise design doc)
- branes-ai/embodied-schemas#36, #37 (precursors)
- #198 (CGRA loader — pattern source)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DPU accelerators can now be configured through YAML specifications, enabling automated hardware resource model generation and configuration validation.

* **Tests**
  * Added comprehensive test suite for DPU configuration loading, including parity verification against reference models and thorough error handling validation.

* **Chores**
  * Updated CI/CD workflows to latest upstream hardware schema versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->