### PR TITLE
refactor(hardware): retire xilinx_vitis_ai_dpu factory (closes #200)

### DIFF
--- a/src/graphs/hardware/models/accelerators/xilinx_vitis_ai_dpu.py
+++ b/src/graphs/hardware/models/accelerators/xilinx_vitis_ai_dpu.py
@@ -1,157 +1,81 @@
-"""
-Xilinx Vitis Ai Dpu Resource Model hardware resource model.
+"""Xilinx Vitis AI DPU (Versal VE2302, B4096 config) resource model.
 
-Extracted from resource_model.py during refactoring.
+Final cleanup PR for issue #200 (DPU mini-sprint). As of this PR,
+the chip's architectural and thermal-profile data lives in the
+canonical YAML at
+``embodied-schemas:data/compute_products/xilinx/vitis_ai_b4096.yaml``
+(landed in embodied-schemas#37) and is loaded via ``dpu_yaml_loader``.
+The previous ~160-LOC hand-coded ``HardwareResourceModel``
+constructor was retired here; its parity with the YAML-loaded model
+is pinned in ``tests/hardware/test_dpu_yaml_loader_vitis_ai_parity.py``.
+
+Schema precursors that had to land first:
+  - embodied-schemas#36 -- DPUBlock added to the discriminated union
+  - embodied-schemas#37 -- the Vitis AI B4096 YAML itself
+
+The public function name and signature are preserved so existing
+callers (``create_xilinx_vitis_ai_dpu_mapper``, validation scripts,
+``cli/compare_*.py``) continue to work unchanged.
+
+**Zero overlays remain.** Like Plasticine (issue #196 cleanup), this
+is a clean-cut migration because:
+
+  - ``HardwareType.DPU`` was already in the graphs enum (no
+    transitional period like NPU's #191).
+  - ``peak_bandwidth`` convention (external DRAM tier when present;
+    50 GB/s DDR4 for Vitis AI) matches the legacy hand-coded value
+    exactly.
+  - ``memory_technology`` was None in the legacy; the YAML loader
+    populates it correctly ("DDR4").
+  - No BOMCostProfile overlay needed (the legacy factory didn't
+    include one either; Versal SoM/SoC pricing not yet modeled).
+
+Six documented drifts captured by the parity test where the YAML
+follows schema conventions that differ from the legacy:
+
+  - INT8 peak: 10.24 TOPS (theoretical chip-level, schema convention)
+    vs 7.68 TOPS (legacy realistic at 75% efficiency, pre-multiplied).
+    Downstream consumers that want realistic peak should multiply by
+    ``thermal_operating_points[default].efficiency_factor_by_precision[int8]``.
+  - FP16 peak: 2.56 TFLOPS vs 1.92 TFLOPS (same 75% efficiency factor).
+  - FP32 peak: not in YAML precision_profiles vs 0.96 TFLOPS legacy.
+    YAML's compute_fabrics declare INT8 + FP16; FP32 is captured only
+    as energy_scaling since it's emulated.
+  - ``memory_technology``: "DDR4" (correct) vs None (legacy didn't set).
+  - ``soc_fabric``: 8x8 AIE mesh populated vs None (legacy didn't
+    model -- now unblocks downstream Layer 6 reporting for DPU).
+  - ``energy_per_flop_fp32``: ~8% drift (2.5 pJ vs 2.7 pJ); both valid.
+
+One v7 reconciliation item:
+  - ``is_statically_reconfigurable`` / ``bitstream_load_time_ms`` /
+    ``fpga_fabric_overhead_factor`` (the defining DPU characteristics)
+    live on ``DPUBlock`` in the v6 schema but have no equivalent
+    fields on ``HardwareResourceModel``. Downstream consumers that
+    need them read from the underlying ComputeProduct directly. v7
+    will add the fields properly.
+
+The legacy resource-model ``name`` ("DPU-Vitis-AI-B4096") is preserved.
 """
 
-from ...resource_model import (
-    HardwareResourceModel,
-    HardwareType,
-    Precision,
-    PrecisionProfile,
-    ComputeFabric,
-    get_base_alu_energy,
-    ClockDomain,
-    ComputeResource,
-    TileSpecialization,
-    KPUComputeResource,
-    PerformanceCharacteristics,
-    ThermalOperatingPoint,
-)
+from ...resource_model import HardwareResourceModel
+from .dpu_yaml_loader import load_dpu_resource_model_from_yaml
+
+
+_LEGACY_NAME = "DPU-Vitis-AI-B4096"
+_YAML_BASE_ID = "xilinx_vitis_ai_b4096"
 
 
 def xilinx_vitis_ai_dpu_resource_model() -> HardwareResourceModel:
+    """Xilinx Vitis AI B4096 DPU on Versal VE2302 -- FPGA-based AI
+    accelerator with AIE-ML v1 tile array.
+
+    See the YAML for the canonical chip description (64 AIE-ML tiles *
+    64 MACs at 1.25 GHz, 64 KiB scratchpad per tile, 4 MiB shared L2,
+    8 GiB chip-attached DDR4, 8x8 AIE_MESH NoC, 20W active-fan,
+    TSMC N16 process, multi-precision INT8 + native FP16 + emulated
+    FP32, static FPGA reconfiguration with ~2 second bitstream load).
     """
-    Xilinx Vitis AI DPU (Deep Processing Unit) resource model.
-
-    Configuration: B4096 (4096 MACs) on Versal VE2302 (embodied AI target)
-    Architecture: AIE-ML v1 with 2D array of INT8 ALUs
-
-    Key characteristics:
-    - FPGA-based, reconfigurable
-    - Native INT8 support (best performance)
-    - Power efficient: 15-20W (embodied AI sweet spot)
-    - Scratchpad-based memory hierarchy (similar to KPU)
-    - 75% realistic efficiency (per specification)
-
-    References:
-    - Versal VE2302: 15-20W, edge-optimized
-    - AIE-ML v1: 512 INT8 ops/clock @ 1.25 GHz
-    - B4096: 4096 MACs
-    - Realistic peak: 10.24 TOPS × 0.75 = 7.68 TOPS INT8
-    """
-    sustained_clock_hz = 1.25e9  # 1.25 GHz
-
-    # ========================================================================
-    # Multi-Fabric Architecture (Xilinx Vitis AI DPU - FPGA-based)
-    # ========================================================================
-    # AIE-ML Tile Fabric (INT8 MAC array)
-    # ========================================================================
-    aie_ml_fabric = ComputeFabric(
-        fabric_type="aie_ml_tile",
-        circuit_type="standard_cell",   # FPGA fabric (has overhead vs ASIC)
-        num_units=64,                    # 64 AIE tiles (B4096 config)
-        ops_per_unit_per_clock={
-            Precision.INT8: 128,         # 128 INT8 ops/tile/cycle (4096 MACs / 64 tiles = 64 MACs/tile × 2 ops)
-            Precision.FP16: 32,          # 32 FP16 ops/tile/cycle (not native)
-        },
-        core_frequency_hz=sustained_clock_hz,  # 1.25 GHz
-        process_node_nm=16,              # 16nm Versal FPGA
-        energy_per_flop_fp32=get_base_alu_energy(16, 'standard_cell'),  # 2.7 pJ (FPGA has additional overhead)
-        energy_scaling={
-            Precision.INT8: 0.15,        # INT8 is very efficient
-            Precision.FP16: 0.50,        # FP16 less efficient
-            Precision.FP32: 1.0,         # FP32 emulated
-        }
+    return load_dpu_resource_model_from_yaml(
+        _YAML_BASE_ID,
+        name_override=_LEGACY_NAME,
     )
-
-    # AIE-ML INT8: 64 tiles × 128 ops/cycle × 1.25 GHz = 10.24 TOPS ✓
-    # Realistic (75% efficiency): 10.24 × 0.75 = 7.68 TOPS ✓
-
-    # ========================================================================
-    # Calculate theoretical and realistic peak performance
-    # ========================================================================
-    # Calculate theoretical and realistic peak performance
-    mac_units = 4096
-    clock_freq = 1.25e9  # 1.25 GHz (confirmed from Versal docs)
-    ops_per_mac = 2  # Multiply + Accumulate
-    efficiency = 0.75  # User-specified efficiency
-
-    theoretical_tops = mac_units * ops_per_mac * clock_freq  # 10.24 TOPS
-    realistic_tops = theoretical_tops * efficiency  # 7.68 TOPS
-
-    # Power profile (VE2302: 15-20W)
-    power_avg = 17.5  # Watts
-    idle_power = 3.0  # Estimated idle
-    dynamic_power = power_avg - idle_power  # 14.5W
-
-    # Energy per operation
-    energy_per_int8_op = dynamic_power / realistic_tops  # 1.89e-12 J/op
-    # Convert to FP32 equivalent (INT8 is ~4× more efficient)
-    energy_per_flop_fp32 = energy_per_int8_op * 4  # 7.56e-12 J/FLOP
-
-    # Thermal operating point (Versal VE2302: edge-optimized)
-    thermal_default = ThermalOperatingPoint(
-        name="default",
-        tdp_watts=20.0,  # VE2302 max TDP (15-20W range)
-        cooling_solution="active-fan",
-        performance_specs={}  # Uses precision_profiles for performance
-    )
-
-    return HardwareResourceModel(
-        name="DPU-Vitis-AI-B4096",
-        hardware_type=HardwareType.DPU,
-
-        # NEW: Multi-fabric architecture (AIE-ML tiles)
-        compute_fabrics=[aie_ml_fabric],
-
-        compute_units=64,  # Tiles (estimate for B4096)
-        threads_per_unit=64,  # Operations per tile
-        warps_per_unit=8,  # Vector lanes per tile
-        warp_size=8,
-
-        # Thermal operating points
-        thermal_operating_points={
-            "default": thermal_default,
-        },
-        default_thermal_profile="default",
-
-        precision_profiles={
-            Precision.FP32: PrecisionProfile(
-                precision=Precision.FP32,
-                peak_ops_per_sec=realistic_tops / 8,  # 0.96 TFLOPS (not native)
-                tensor_core_supported=False,
-                relative_speedup=0.125,
-                bytes_per_element=4,
-            ),
-            Precision.FP16: PrecisionProfile(
-                precision=Precision.FP16,
-                peak_ops_per_sec=realistic_tops / 4,  # 1.92 TFLOPS
-                tensor_core_supported=True,  # AIE support
-                relative_speedup=0.25,
-                bytes_per_element=2,
-            ),
-            Precision.INT8: PrecisionProfile(
-                precision=Precision.INT8,
-                peak_ops_per_sec=realistic_tops,  # 7.68 TOPS (native, best)
-                tensor_core_supported=True,  # Native INT8 MACs
-                relative_speedup=1.0,
-                bytes_per_element=1,
-                accumulator_precision=Precision.INT32,
-            ),
-        },
-        default_precision=Precision.INT8,
-
-        peak_bandwidth=50e9,  # 50 GB/s DDR4 (edge device)
-        l1_cache_per_unit=64 * 1024,  # 64 KB scratchpad per tile
-        l2_cache_total=4 * 1024 * 1024,  # 4 MB (estimate)
-        main_memory=8 * 1024**3,  # 8 GB DDR4 (edge deployment)
-        # Energy (use AIE-ML fabric, note: FPGA has overhead vs ASIC)
-        energy_per_flop_fp32=aie_ml_fabric.energy_per_flop_fp32,  # 2.7 pJ (16nm, standard cell)
-        energy_per_byte=15e-12,  # Similar to GPU (FPGA I/O)
-        min_occupancy=0.3,
-        max_concurrent_kernels=4,
-        wave_quantization=2,  # Tiles allocated in pairs
-    )
-
-

--- a/tests/hardware/test_dpu_yaml_loader_vitis_ai_parity.py
+++ b/tests/hardware/test_dpu_yaml_loader_vitis_ai_parity.py
@@ -1,52 +1,33 @@
-"""Contract test: Vitis AI B4096 YAML loader produces the expected model.
+"""Contract test: Vitis AI B4096 factory produces the expected model.
 
-PR 4 of the DPU mini-sprint scoped at issue #200. Mirror of
-``tests/hardware/test_cgra_yaml_loader_plasticine_parity.py``.
-Compares the YAML-loaded model against the hand-coded factory at
-``src/graphs/hardware/models/accelerators/xilinx_vitis_ai_dpu.py``.
+Originally PR 4's parity test, comparing YAML-loaded against the
+hand-coded factory. PR 5 retired the 160-LOC hand-coded body of
+``xilinx_vitis_ai_dpu_resource_model()`` and made it a thin wrapper
+over ``load_dpu_resource_model_from_yaml``, so today both
+``hand_coded`` and ``yaml_loaded`` fixtures resolve through the same
+loader.
 
-PR 5 will retire the hand-coded body and make ``xilinx_vitis_ai_dpu_resource_model()``
-a thin wrapper over the loader; at that point both ``hand_coded`` and
-``yaml_loaded`` fixtures will resolve through the same loader and
-these structural assertions become contract tests.
+The structural assertions are now **contract tests on the YAML
+loader's output** rather than parity checks. They still catch loader
+regressions and YAML drift; they also fail loudly if anyone changes
+the factory's name override or substitutes a different SKU id.
 
-Documented drifts (the loader follows a different convention; parity
-test pins the YAML values as the new contract):
+Zero factory overlays exist for Vitis AI (like Plasticine; the
+simplest cleanups of any sprint -- the YAML conventions match the
+chip's natural representation).
 
-  - ``INT8 peak: 10.24 TOPS`` (yaml THEORETICAL) vs ``7.68 TOPS``
-    (hand-coded REALISTIC at 75% efficiency). The YAML reports
-    theoretical chip-level peak in precision_profiles; efficiency
-    is captured separately in thermal_operating_points'
-    efficiency_factor_by_precision. The Vitis AI marketed number
-    is 7.68 TOPS (realistic) but the schema convention is theoretical
-    peak; downstream consumers apply efficiency from the thermal
-    profile.
-  - ``FP16 peak: 2.56 TOPS`` (yaml THEORETICAL) vs ``1.92 TOPS``
-    (hand-coded REALISTIC). Same root cause -- 75% efficiency factor.
-  - ``FP32 peak``: not in YAML precision_profiles vs 0.96 TFLOPS
-    (hand-coded). YAML's compute_fabrics declare INT8 + FP16 in
-    ops_per_unit_per_clock; FP32 is captured only as energy_scaling
-    (for cost modeling) since it's emulated. Downstream consumers
-    can synthesize FP32 ops as INT8 / fp32_scaling if needed.
-  - ``memory_technology``: ``"DDR4"`` (yaml) vs ``None`` (hand-coded).
-    The legacy doesn't populate this field; the YAML loader does.
-  - ``soc_fabric``: populated (yaml) vs ``None`` (hand-coded). Same.
-  - ``energy_per_flop_fp32``: ~8% drift (2.5 pJ yaml vs 2.7 pJ hand-coded).
-    YAML uses INT8 * FPGA-overhead * FP32-scaling = 0.4 * 1.25 * 5.0
-    = 2.5 pJ. Hand-coded uses ``get_base_alu_energy(16, 'standard_cell')``
-    = 2.7 pJ. Both are valid 16nm estimates.
+One v7 reconciliation item:
+  - ``is_statically_reconfigurable`` / ``bitstream_load_time_ms`` /
+    ``fpga_fabric_overhead_factor`` (the defining DPU characteristics)
+    live on ``DPUBlock`` in the v6 schema but have no equivalent
+    fields on ``HardwareResourceModel``. Tested via direct
+    ComputeProduct read below.
 
-Where the hand-coded and YAML-loaded agree (the actual parity
-assertions):
-
-  - compute_units, threads_per_unit, warps_per_unit
-  - peak_bandwidth (50 GB/s -- DDR4, chip-attached)
-  - l1_cache_per_unit, l2_cache_total, main_memory
-  - default_precision (INT8)
-  - hardware_type (DPU)
-  - thermal profile shape (single profile, 20W)
-  - scheduler attrs (min_occupancy, max_concurrent_kernels=4,
-    wave_quantization=2)
+(Before PR 5 / cleanup, the legacy hand-coded had SIX documented
+drifts -- buggy INT8/FP16/FP32 realistic-at-efficiency formulas,
+missing memory_technology, missing soc_fabric, slightly different
+FP32 energy. Those are all resolved now because the hand-coded
+body is gone; both sides resolve through the loader.)
 """
 
 import pytest
@@ -158,46 +139,41 @@ def test_compute_fabric_energy_documented_drift(hand_coded, yaml_loaded):
 # Precision profiles -- different conventions (theoretical vs realistic)
 # ---------------------------------------------------------------------------
 
-def test_int8_peak_yaml_is_theoretical_chip_level(yaml_loaded):
-    """YAML-loaded INT8 peak = 10.24 TOPS = 64 tiles * 128 ops/clk *
-    1.25 GHz. Theoretical chip-level peak (schema convention).
-    Efficiency factor (75%) lives in thermal_operating_points'
-    efficiency_factor_by_precision, applied by downstream consumers."""
+def test_int8_peak_is_theoretical_chip_level(hand_coded, yaml_loaded):
+    """INT8 peak = 10.24 TOPS = 64 tiles * 128 ops/clk * 1.25 GHz.
+    Theoretical chip-level peak (schema convention). Both factories
+    now resolve through the loader; before PR 5 cleanup the legacy
+    reported 7.68 TOPS (= 10.24 * 0.75 pre-applied efficiency).
+    Downstream consumers that want realistic peak multiply by
+    ``thermal_operating_points[default].efficiency_factor_by_precision[int8]``."""
     assert yaml_loaded.precision_profiles[Precision.INT8].peak_ops_per_sec == pytest.approx(
+        10.24e12, rel=0.01
+    )
+    assert hand_coded.precision_profiles[Precision.INT8].peak_ops_per_sec == pytest.approx(
         10.24e12, rel=0.01
     )
 
 
-def test_int8_peak_hand_coded_is_realistic(hand_coded):
-    """Pinned for visibility: legacy hand-coded reports 7.68 TOPS
-    (= 10.24 * 0.75 efficiency). Pre-multiplied efficiency factor.
-    PR 5 cleanup will retire the hand-coded path; downstream consumers
-    will read theoretical from precision_profiles and apply efficiency
-    from the thermal profile."""
-    legacy_peak = hand_coded.precision_profiles[Precision.INT8].peak_ops_per_sec
-    assert legacy_peak == pytest.approx(7.68e12, rel=0.01), (
-        f"unexpected legacy peak {legacy_peak/1e12:.3f} TOPS; if this "
-        f"changed the legacy was updated -- review this drift annotation."
-    )
-
-
-def test_fp16_peak_yaml_is_theoretical(yaml_loaded):
-    """YAML FP16 peak = 2.56 TFLOPS theoretical. Native AIE-ML FP16."""
+def test_fp16_peak_is_theoretical(hand_coded, yaml_loaded):
+    """FP16 peak = 2.56 TFLOPS theoretical. Native AIE-ML FP16."""
     assert yaml_loaded.precision_profiles[Precision.FP16].peak_ops_per_sec == pytest.approx(
+        2.56e12, rel=0.01
+    )
+    assert hand_coded.precision_profiles[Precision.FP16].peak_ops_per_sec == pytest.approx(
         2.56e12, rel=0.01
     )
 
 
-def test_yaml_omits_emulated_fp32_from_precision_profiles(yaml_loaded, hand_coded):
-    """DOCUMENTED DRIFT: YAML's compute_fabrics declare INT8 + FP16 in
-    ops_per_unit_per_clock; FP32 is captured only as energy_scaling
-    (for cost modeling) since it's emulated. Hand-coded includes FP32
-    in precision_profiles at 0.96 TFLOPS (emulated, 1/8 INT8 realistic).
-    Downstream consumers needing FP32 ops/sec can compute as
-    INT8_realistic / 8."""
+def test_fp32_not_in_precision_profiles(hand_coded, yaml_loaded):
+    """Both factories now resolve through the loader, which declares
+    INT8 + FP16 in compute_fabrics; FP32 is captured only as
+    ``energy_scaling`` (for cost modeling) since it's emulated.
+    Downstream consumers needing FP32 ops/sec compute as
+    INT8 / fp32_scaling. Before PR 5 cleanup the legacy included
+    FP32 at 0.96 TFLOPS in precision_profiles (emulated, 1/8 INT8
+    realistic)."""
     assert Precision.FP32 not in yaml_loaded.precision_profiles
-    # Hand-coded does include it (for reference)
-    assert Precision.FP32 in hand_coded.precision_profiles
+    assert Precision.FP32 not in hand_coded.precision_profiles
 
 
 def test_default_precision_matches(hand_coded, yaml_loaded):
@@ -262,41 +238,30 @@ def test_coherence_protocol_is_none(yaml_loaded):
     assert yaml_loaded.coherence_protocol == "none"
 
 
-def test_yaml_populates_memory_technology(yaml_loaded):
-    """DOCUMENTED DRIFT: hand-coded does NOT set memory_technology
-    (returns None); YAML loader populates it from external_dram_type.
-    The YAML's "DDR4" is structurally correct."""
-    assert yaml_loaded.memory_technology == "DDR4"
-
-
-def test_hand_coded_memory_technology_is_none(hand_coded):
-    """Pinned for visibility: PR 5 cleanup makes the YAML loader the
-    only source; both sides will then report "DDR4"."""
-    assert hand_coded.memory_technology is None
+def test_memory_technology_populated(hand_coded, yaml_loaded):
+    """Both factories now resolve through the loader, which populates
+    ``memory_technology`` from the YAML's ``external_dram_type=ddr4``.
+    Before PR 5 cleanup the legacy returned None here."""
+    assert yaml_loaded.memory_technology == hand_coded.memory_technology == "DDR4"
 
 
 # ---------------------------------------------------------------------------
 # SoC fabric (8x8 AIE mesh -- DRIFT: hand-coded doesn't populate)
 # ---------------------------------------------------------------------------
 
-def test_yaml_populates_soc_fabric(yaml_loaded):
-    """DOCUMENTED DRIFT: hand-coded does NOT set soc_fabric (returns
-    None); YAML loader populates it from NoC schema. The YAML's
-    8x8 mesh structure is correct and unblocks downstream Layer 6
-    reporting that the hand-coded couldn't support."""
+def test_soc_fabric_populated(hand_coded, yaml_loaded):
+    """Both factories now resolve through the loader, which populates
+    ``soc_fabric`` from the YAML's ``noc`` block (8x8 AIE mesh of 64
+    tiles). Before PR 5 cleanup the legacy returned None, which
+    blocked downstream Layer 6 reporting for DPU."""
     from graphs.hardware.fabric_model import Topology
-    assert yaml_loaded.soc_fabric is not None
-    assert yaml_loaded.soc_fabric.topology == Topology.MESH_2D
-    assert yaml_loaded.soc_fabric.mesh_dimensions == (8, 8)
-    assert yaml_loaded.soc_fabric.controller_count == 64
-    assert yaml_loaded.soc_fabric.bisection_bandwidth_gbps == pytest.approx(80.0)
-    assert yaml_loaded.soc_fabric.low_confidence is True
-
-
-def test_hand_coded_soc_fabric_is_none(hand_coded):
-    """Pinned for visibility: PR 5 cleanup makes the YAML loader the
-    only source."""
-    assert hand_coded.soc_fabric is None
+    for label, m in (("yaml_loaded", yaml_loaded), ("hand_coded", hand_coded)):
+        assert m.soc_fabric is not None, f"{label}.soc_fabric is None"
+        assert m.soc_fabric.topology == Topology.MESH_2D
+        assert m.soc_fabric.mesh_dimensions == (8, 8)
+        assert m.soc_fabric.controller_count == 64
+        assert m.soc_fabric.bisection_bandwidth_gbps == pytest.approx(80.0)
+        assert m.soc_fabric.low_confidence is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Collapses ``xilinx_vitis_ai_dpu.py`` from ~160 LOC hand-coded to 25 LOC thin loader wrapper.
- **Zero factory overlays** — clean-cut migration (like Plasticine #199).
- **Closes issue #200** (DPU mini-sprint umbrella).
- PR 5 of 5.

## Why "zero overlays" (vs Hailo/Coral)

| Concern | Hailo/Coral overlay | Vitis AI |
|---|---|---|
| HardwareType taxonomy | Coral needs TPU overlay | DPU already in enum |
| Bandwidth tier | Coral needs 4 GB/s host-bus override | Loader's DDR4 = 50 GB/s matches |
| BoM | $40-240 retail overlays | Versal SoM pricing not modeled; no BoM |
| memory_technology | n/a | Loader populates "DDR4" correctly |

## YAML CHANGES legacy behavior in 6 ways (all inherited automatically)

No downstream tests asserted the buggy values, so no other suites need updating.

| Field | Pre-cleanup (legacy) | Post-cleanup (loader) |
|---|---|---|
| INT8 peak | 7.68 TOPS (pre-applied 75% efficiency) | **10.24 TOPS** (theoretical; efficiency separate) |
| FP16 peak | 1.92 TFLOPS | **2.56 TFLOPS** |
| FP32 peak | 0.96 TFLOPS in profile | Captured only in energy_scaling (emulated) |
| ``memory_technology`` | None | **"DDR4"** |
| ``soc_fabric`` | None | **8x8 AIE mesh populated** (unblocks Layer 6 reporting) |
| ``energy_per_flop_fp32`` | 2.7 pJ | **2.5 pJ** (8% drift; both valid) |

## Test changes

`tests/hardware/test_dpu_yaml_loader_vitis_ai_parity.py`: 39 → 36 tests after retiring three now-stale "legacy drift" tests:
- `test_int8_peak_hand_coded_is_realistic` — legacy no longer reports realistic-at-75% pre-applied
- `test_hand_coded_memory_technology_is_none` — both sides populate "DDR4"
- `test_hand_coded_soc_fabric_is_none` — both sides populate 8x8 mesh

Four drift assertions collapsed into mutual contract assertions:
- `test_int8_peak_is_theoretical_chip_level`: both = 10.24 TOPS
- `test_fp16_peak_is_theoretical`: both = 2.56 TFLOPS
- `test_fp32_not_in_precision_profiles`: neither side includes FP32
- `test_memory_technology_populated`: both = "DDR4"
- `test_soc_fabric_populated`: both populate 8x8 mesh

## One v7 reconciliation item documented

`is_statically_reconfigurable` / `bitstream_load_time_ms` / `fpga_fabric_overhead_factor` (the defining DPU characteristics) live on `DPUBlock` in the v6 schema but have no equivalent fields on `HardwareResourceModel`. Downstream consumers read directly from the underlying `ComputeProduct`; the parity test pins this via direct schema read. v7 will add the fields properly.

## Changes

| File | Δ | What |
|---|---|---|
| ``src/graphs/hardware/models/accelerators/xilinx_vitis_ai_dpu.py`` | −135 LOC | 160-LOC hand-coded → 25-LOC thin loader wrapper (zero overlays) |
| ``tests/hardware/test_dpu_yaml_loader_vitis_ai_parity.py`` | −110 LOC | Retired 3 stale drift tests; converted 4 drift assertions to mutual contract assertions |

## Test Results

| Suite | Result |
|---|---|
| ``test_dpu_yaml_loader_vitis_ai_parity.py`` | 36 passed (was 39; -3 retired) |
| Full suite | **2958 passed**, 13 skipped, 4 xfailed (was 2961; net -3 from retired) |

## Test plan

- [x] All 2958 graphs tests pass locally
- [x] Vitis AI factory now returns YAML-corrected theoretical peaks (10.24 TOPS INT8)
- [x] DPUMapper still accepts Vitis AI (no mapper guard changes needed)
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied: ``gh pr ready PR_NUMBER``

## Issue #200 — DPU mini-sprint complete

After this PR merges, the umbrella issue closes:

| PR | Repo | State |
|---|---|---|
| 1/5 paper exercise | graphs | ✅ Merged (#201) |
| 2/5 DPUBlock schema | embodied-schemas | ✅ Merged (#36) |
| 3/5 Vitis AI YAML | embodied-schemas | ✅ Merged (#37) |
| 4/5 graphs loader | graphs | ✅ Merged (#202) |
| **5/5 thin factory cleanup** | graphs | **This PR — closes #200** |

## Catalog migration progress

| Architecture | YAML-backed | Hand-coded remaining | Status |
|---|---|---|---|
| KPU | 12 | 0 | ✅ done |
| GPU | 2 | 8 | catalog expansion (no schema work) |
| CPU | 1 | 7 | catalog expansion (no schema work) |
| NPU | 3 | 0 | ✅ done (issue #192) |
| CGRA | 1 | 0 | ✅ done (issue #196) |
| **DPU** | **1** | **0** | **✅ done (this PR / issue #200)** |
| TPU | 0 | 5 | sprint (5+ PRs) |
| DSP | 0 | 10 | sprint (12+ PRs) |

**20 of 42 hand-coded factories migrated (~48%)**. With DPU done, only TPU and DSP remain as schema gaps. The v7 vendor-neutral `compute_block_common` module becomes the obvious next move (6 architectures × 3+ shared primitives each = enough evidence).

## Refs

- **Closes #200** (DPU mini-sprint umbrella)
- #201 (paper exercise; PR 1/5)
- #202 (YAML loader; PR 4/5)
- branes-ai/embodied-schemas#36, #37 (precursors)
- #199 (Plasticine cleanup — pattern source)

Generated with [Claude Code](https://claude.com/claude-code)