### PR TITLE
feat(hardware): TPU YAML loader (#204 sprint PR 4/5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,9 @@ jobs:
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
           #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
           #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
-          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
+          #   PR #38 (e60989b) TPUBlock added to ComputeProduct (v7, additive) + MemoryType.DDR3
+          #   PR #39 (9bc4a7a) first TPU SKU YAML: google_tpu_v4 (datacenter, HBM2e, ICI)
+          ref: 9bc4a7afd8aa1361cdcc1abc6d3a921dcdbb1fe6
           path: embodied-schemas
           fetch-depth: 1
 
@@ -189,7 +191,9 @@ jobs:
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
           #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
           #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
-          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
+          #   PR #38 (e60989b) TPUBlock added to ComputeProduct (v7, additive) + MemoryType.DDR3
+          #   PR #39 (9bc4a7a) first TPU SKU YAML: google_tpu_v4 (datacenter, HBM2e, ICI)
+          ref: 9bc4a7afd8aa1361cdcc1abc6d3a921dcdbb1fe6
           path: embodied-schemas
           fetch-depth: 1
 
@@ -304,7 +308,9 @@ jobs:
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
           #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
           #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
-          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
+          #   PR #38 (e60989b) TPUBlock added to ComputeProduct (v7, additive) + MemoryType.DDR3
+          #   PR #39 (9bc4a7a) first TPU SKU YAML: google_tpu_v4 (datacenter, HBM2e, ICI)
+          ref: 9bc4a7afd8aa1361cdcc1abc6d3a921dcdbb1fe6
           path: embodied-schemas
           fetch-depth: 1
 
@@ -416,7 +422,9 @@ jobs:
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
           #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
           #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
-          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
+          #   PR #38 (e60989b) TPUBlock added to ComputeProduct (v7, additive) + MemoryType.DDR3
+          #   PR #39 (9bc4a7a) first TPU SKU YAML: google_tpu_v4 (datacenter, HBM2e, ICI)
+          ref: 9bc4a7afd8aa1361cdcc1abc6d3a921dcdbb1fe6
           path: embodied-schemas
           fetch-depth: 1
 
@@ -501,7 +509,9 @@ jobs:
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
           #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
           #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
-          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
+          #   PR #38 (e60989b) TPUBlock added to ComputeProduct (v7, additive) + MemoryType.DDR3
+          #   PR #39 (9bc4a7a) first TPU SKU YAML: google_tpu_v4 (datacenter, HBM2e, ICI)
+          ref: 9bc4a7afd8aa1361cdcc1abc6d3a921dcdbb1fe6
           path: embodied-schemas
           fetch-depth: 1
 
@@ -574,7 +584,9 @@ jobs:
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
           #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
           #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
-          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
+          #   PR #38 (e60989b) TPUBlock added to ComputeProduct (v7, additive) + MemoryType.DDR3
+          #   PR #39 (9bc4a7a) first TPU SKU YAML: google_tpu_v4 (datacenter, HBM2e, ICI)
+          ref: 9bc4a7afd8aa1361cdcc1abc6d3a921dcdbb1fe6
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,7 +64,9 @@ jobs:
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
           #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
           #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
-          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
+          #   PR #38 (e60989b) TPUBlock added to ComputeProduct (v7, additive) + MemoryType.DDR3
+          #   PR #39 (9bc4a7a) first TPU SKU YAML: google_tpu_v4 (datacenter, HBM2e, ICI)
+          ref: 9bc4a7afd8aa1361cdcc1abc6d3a921dcdbb1fe6
           path: embodied-schemas
           fetch-depth: 1
 

--- a/.github/workflows/v4-validation.yml
+++ b/.github/workflows/v4-validation.yml
@@ -113,7 +113,9 @@ jobs:
           #   PR #35 (51b8287) first CGRA SKU YAML: stanford_plasticine_v2
           #   PR #36 (4befc41) DPUBlock added to ComputeProduct (v6, additive)
           #   PR #37 (aa19f91) first DPU SKU YAML: xilinx_vitis_ai_b4096
-          ref: aa19f91869de0b6239579c1b8c74e59faa7d4cc7
+          #   PR #38 (e60989b) TPUBlock added to ComputeProduct (v7, additive) + MemoryType.DDR3
+          #   PR #39 (9bc4a7a) first TPU SKU YAML: google_tpu_v4 (datacenter, HBM2e, ICI)
+          ref: 9bc4a7afd8aa1361cdcc1abc6d3a921dcdbb1fe6
           path: embodied-schemas
           fetch-depth: 1
 

--- a/src/graphs/hardware/models/datacenter/tpu_yaml_loader.py
+++ b/src/graphs/hardware/models/datacenter/tpu_yaml_loader.py
@@ -1,0 +1,580 @@
+"""TPU resource model loader from embodied-schemas ComputeProduct YAMLs.
+
+PR 4 of the TPU mini-sprint scoped at issue #204. Mirrors
+``src/graphs/hardware/models/accelerators/dpu_yaml_loader.py`` (DPU
+sprint #202) but reads a TPUBlock-bearing ``ComputeProduct`` and
+builds a ``HardwareResourceModel`` with the TPU-shaped fields populated.
+
+Sibling to the hand-coded factory at
+``src/graphs/hardware/models/datacenter/tpu_v4.py`` during the
+parallel-migration phase. Adding the factory swap is PR 5; this PR
+ships the loader machinery and a parity test that proves the YAML-
+loaded model matches the hand-coded one's key fields.
+
+Scope of TPUBlock -> HardwareResourceModel mapping:
+
+  TPUBlock.num_mxus                  -> compute_units
+  TPUBlock.{mxu_dim_rows,            -> derived: threads_per_unit =
+    mxu_dim_cols}                       rows * cols (MACs per MXU)
+  TPUBlock.compute_fabrics[*]        -> compute_fabrics[] (num_units =
+                                        num_mxus * mxu_dim_rows *
+                                        mxu_dim_cols = total MACs)
+  TPUBlock.memory.{unified_buffer,   -> l1_cache_per_unit,
+    external_dram}                      l2_cache_total, main_memory,
+                                        peak_bandwidth, memory_technology,
+                                        memory_*_energy_per_byte_pj
+  TPUBlock.tile_energy_coefficients  -> ``model.tile_energy_model`` =
+                                        TPUTileEnergyModel(...)
+  TPUBlock.noc                       -> soc_fabric (SoCFabricModel)
+  TPUBlock.{min_occupancy,           -> matching HardwareResourceModel fields
+    max_concurrent_models,
+    wave_quantization}
+  ComputeProduct.power.thermal_profiles[]
+                                     -> thermal_operating_points
+
+TPU-specific loader decisions:
+
+1. **peak_bandwidth = external_dram_bandwidth_gbps** when
+   has_external_dram=True (TPU v4: 1.2 TB/s HBM2e). Mirrors NPU/DPU's
+   "DRAM tier when present" convention -- TPUs are HBM-bound for
+   training workloads. Falls back to UB bandwidth for SRAM-only SKUs
+   (none today; future hypothetical edge TPUs might be SRAM-only).
+
+2. **Unified Buffer is split across l1_cache_per_unit + l2_cache_total**
+   for legacy compat. The UB is a single shared tier in the v7 schema
+   (no L1/L2 distinction); the legacy HardwareResourceModel expects
+   both fields, so the loader sets both to the same UB size divided
+   into the per-MXU view (l1_cache_per_unit = unified_buffer_size /
+   num_mxus) and the chip total (l2_cache_total = unified_buffer_size).
+   The legacy hand-coded ``tpu_v4.py`` does the same split.
+
+3. **Tile energy model reconstructed from TPUTileEnergyCoefficients**.
+   The schema's ``TPUTileEnergyCoefficients`` (9 canonical fields)
+   maps directly to ``graphs.hardware.architectural_energy.TPUTileEnergyModel``,
+   combined with ``mxu_dim_rows``, ``mxu_dim_cols``, ``num_mxus``,
+   ``weight_tile_size_kib``, ``weight_fifo_depth``, ``pipeline_fill_cycles``,
+   ``accumulator_size_kib_per_mxu``, and ``unified_buffer_size_kib``
+   from ``TPUBlock`` itself.
+
+4. **HardwareType.TPU** set directly -- TPU already in graphs enum.
+
+5. **ICI fields NOT surfaced on HardwareResourceModel**. The v7 schema
+   carries `ici_port_count`, `ici_bandwidth_per_port_gbps`, and
+   `ici_topology_hint` on TPUBlock but the legacy model has no
+   equivalent fields. v8 reconciliation. Downstream consumers that
+   need multi-chip surface read directly from the ComputeProduct.
+
+6. **default_precision = BF16** (TPU training-default), not INT8 like
+   NPU/DPU/CGRA. Inference-focused TPU SKUs (tpu_edge_pro) could
+   override; the schema doesn't carry a per-SKU default_precision hint
+   yet (v8 reconciliation).
+
+Out of scope for v7 (deferred to v8):
+
+  - BOMCostProfile (YAML doesn't carry; v8 Market.bom)
+  - Per-field provenance copy-through with rich source citations
+  - ``ici_*`` / ``ici_topology_hint`` surfacing on
+    HardwareResourceModel (v8 reconciliation)
+  - SparseCore as sibling block (v8 multi-block-per-die)
+  - Per-SKU default_precision hint (v8 reconciliation)
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from embodied_schemas.compute_product import ComputeProduct
+from embodied_schemas.tpu_block import (
+    TPUBlock,
+    TPUFabricKind,
+    TPUNoCTopology,
+)
+from embodied_schemas.loaders import load_compute_products
+from embodied_schemas.process_node import ProcessNodeEntry
+
+from graphs.core.confidence import EstimationConfidence
+from graphs.hardware.architectural_energy import TPUTileEnergyModel
+from graphs.hardware.fabric_model import SoCFabricModel, Topology
+from graphs.hardware.resource_model import (
+    ComputeFabric,
+    HardwareResourceModel,
+    HardwareType,
+    Precision,
+    PrecisionProfile,
+    ThermalOperatingPoint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class TPUYamlLoaderError(Exception):
+    """Raised when a ComputeProduct YAML can't be turned into a TPU
+    HardwareResourceModel (missing block, unsupported topology,
+    unresolved references, etc.)."""
+
+
+# ---------------------------------------------------------------------------
+# Mapping tables
+# ---------------------------------------------------------------------------
+
+_PRECISION_BY_NAME: dict[str, Precision] = {
+    "fp64": Precision.FP64,
+    "fp32": Precision.FP32,
+    "tf32": Precision.TF32,
+    "fp16": Precision.FP16,
+    "bf16": Precision.BF16,
+    "fp8_e4m3": Precision.FP8_E4M3,
+    "fp8_e5m2": Precision.FP8_E5M2,
+    "int8": Precision.INT8,
+    "int4": Precision.INT4,
+}
+
+_BYTES_PER_PRECISION: dict[Precision, float] = {
+    Precision.FP64: 8, Precision.FP32: 4, Precision.TF32: 4,
+    Precision.FP16: 2, Precision.BF16: 2,
+    Precision.FP8_E4M3: 1, Precision.FP8_E5M2: 1,
+    Precision.INT8: 1, Precision.INT4: 0.5,
+}
+
+# TPUFabricKind -> ComputeFabric.fabric_type. Matches the hand-coded
+# factory's fabric_type string ("systolic_array") so parity tests can
+# pin equality.
+_FABRIC_TYPE_BY_KIND: dict[TPUFabricKind, str] = {
+    TPUFabricKind.TPU_V1_STYLE: "systolic_array",
+    TPUFabricKind.TPU_V2_PLUS:  "systolic_array",
+    TPUFabricKind.TPU_HD:       "systolic_array",
+}
+
+_CIRCUIT_TYPE_DEFAULT = "standard_cell"
+
+# TPUNoCTopology -> graphs SoCFabricModel Topology enum.
+_TOPOLOGY_BY_KIND: dict[TPUNoCTopology, Topology] = {
+    TPUNoCTopology.CROSSBAR:       Topology.CROSSBAR,
+    TPUNoCTopology.MULTI_CROSSBAR: Topology.CROSSBAR,   # multi-crossbar = crossbar w/ multiple endpoints
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _tpu_block(cp: ComputeProduct) -> TPUBlock:
+    """Pick the (single) TPUBlock from a ComputeProduct's first die."""
+    for block in cp.dies[0].blocks:
+        if isinstance(block, TPUBlock):
+            return block
+    raise TPUYamlLoaderError(
+        f"ComputeProduct {cp.id!r} has no TPUBlock in dies[0].blocks "
+        f"(found: {[type(b).__name__ for b in cp.dies[0].blocks]})"
+    )
+
+
+def _precisions_from_ops_dict(
+    ops: dict[str, int],
+    *,
+    source: str = "ops_per_unit_per_clock",
+) -> dict[Precision, int]:
+    """Convert YAML's str-keyed ops/clock dict to graphs' Precision-keyed
+    dict. Fails fast on unknown precision names."""
+    out: dict[Precision, int] = {}
+    unknown: list[str] = []
+    for name, count in ops.items():
+        prec = _PRECISION_BY_NAME.get(name.lower())
+        if prec is None:
+            unknown.append(name)
+            continue
+        out[prec] = count
+    if unknown:
+        raise TPUYamlLoaderError(
+            f"unknown precision name(s) in {source}: {sorted(unknown)}. "
+            f"Known: {sorted(_PRECISION_BY_NAME)}"
+        )
+    return out
+
+
+def _energy_scaling_from_yaml(
+    scaling: dict[str, float],
+    *,
+    source: str = "energy_scaling",
+) -> dict[Precision, float]:
+    out: dict[Precision, float] = {}
+    unknown: list[str] = []
+    for name, factor in scaling.items():
+        prec = _PRECISION_BY_NAME.get(name.lower())
+        if prec is None:
+            unknown.append(name)
+            continue
+        out[prec] = factor
+    if unknown:
+        raise TPUYamlLoaderError(
+            f"unknown precision name(s) in {source}: {sorted(unknown)}. "
+            f"Known: {sorted(_PRECISION_BY_NAME)}"
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def load_tpu_resource_model_from_yaml(
+    base_id: str,
+    *,
+    products: Optional[dict[str, ComputeProduct]] = None,
+    process_nodes: Optional[dict[str, ProcessNodeEntry]] = None,
+    name_override: Optional[str] = None,
+) -> HardwareResourceModel:
+    """Build a ``HardwareResourceModel`` for ``base_id`` from a TPU
+    ComputeProduct YAML.
+
+    Args:
+        base_id: ComputeProduct id, e.g., "google_tpu_v4".
+        products / process_nodes: optional pre-loaded catalogs.
+        name_override: optional override for the resource model's
+            ``name`` field. TPU v4 YAML name is "Google TPU v4"; the
+            hand-coded factory uses "TPU-v4" -- pass that to preserve
+            compat.
+
+    Raises:
+        TPUYamlLoaderError: when ``base_id`` is not in the catalog,
+            doesn't carry a TPUBlock, or has unresolvable references.
+    """
+    if products is None:
+        products = load_compute_products()
+    if process_nodes is None:
+        from embodied_schemas.loaders import load_process_nodes
+        process_nodes = load_process_nodes()
+
+    cp = products.get(base_id)
+    if cp is None:
+        raise TPUYamlLoaderError(
+            f"no ComputeProduct with id={base_id!r}. Available: "
+            f"{', '.join(sorted(products))}"
+        )
+    block = _tpu_block(cp)
+
+    node = process_nodes.get(cp.dies[0].process_node_id)
+    if node is None:
+        raise TPUYamlLoaderError(
+            f"SKU {base_id!r} references process_node_id="
+            f"{cp.dies[0].process_node_id!r} which does not resolve"
+        )
+    process_node_nm = int(node.node_nm)
+
+    # ------------------------------------------------------------------
+    # Default thermal profile -> clock used as fabric core_frequency_hz
+    # ------------------------------------------------------------------
+    default_profile = next(
+        (p for p in cp.power.thermal_profiles
+         if p.name == cp.power.default_thermal_profile),
+        None,
+    )
+    if default_profile is None:
+        raise TPUYamlLoaderError(
+            f"SKU {base_id!r}: default_thermal_profile "
+            f"{cp.power.default_thermal_profile!r} is not in thermal_profiles"
+        )
+    default_clock_hz = default_profile.clock_mhz * 1e6
+
+    # ------------------------------------------------------------------
+    # ComputeFabric per TPU fabric. TPU v4 ships a single systolic
+    # fabric. num_units = total MACs across all MXUs.
+    # ------------------------------------------------------------------
+    total_macs = block.num_mxus * block.mxu_dim_rows * block.mxu_dim_cols
+    compute_fabrics: list[ComputeFabric] = []
+    for tpu_fabric in block.compute_fabrics:
+        ops_dict = _precisions_from_ops_dict(
+            tpu_fabric.ops_per_unit_per_clock,
+            source=f"fabric.{tpu_fabric.fabric_kind.value}",
+        )
+        if not ops_dict:
+            continue
+        # TPU energy_per_op_bf16_pj is the per-BF16-op cost. Compute
+        # per-FP32-op for the legacy field as bf16 * fp32_scaling.
+        energy_per_op_bf16_j = tpu_fabric.energy_per_op_bf16_pj * 1e-12
+        tpu_scaling = _energy_scaling_from_yaml(tpu_fabric.energy_scaling)
+        if Precision.FP32 in tpu_scaling:
+            energy_per_flop_fp32_j = energy_per_op_bf16_j * tpu_scaling[Precision.FP32]
+        else:
+            # Default: FP32 = 2x BF16 (TPU emulation cost; matches legacy)
+            energy_per_flop_fp32_j = energy_per_op_bf16_j * 2.0
+        # ComputeFabric.energy_scaling expects FP32-baseline scaling
+        # (legacy convention). Translate from BF16-baseline:
+        # scaling_fp32[prec] = scaling_bf16[prec] / fp32_scaling
+        fp32_scaling: dict[Precision, float] = {}
+        fp32_baseline = tpu_scaling.get(Precision.FP32, 2.0)
+        # BF16 is the schema's 1.0 baseline; in FP32-baseline terms
+        # it's 1/fp32_scaling
+        fp32_scaling[Precision.BF16] = 1.0 / fp32_baseline
+        for prec, factor in tpu_scaling.items():
+            if prec == Precision.FP32:
+                continue
+            fp32_scaling[prec] = factor / fp32_baseline
+        compute_fabrics.append(ComputeFabric(
+            fabric_type=_FABRIC_TYPE_BY_KIND[tpu_fabric.fabric_kind],
+            circuit_type=_CIRCUIT_TYPE_DEFAULT,
+            num_units=total_macs,
+            ops_per_unit_per_clock=ops_dict,
+            core_frequency_hz=default_clock_hz,
+            process_node_nm=process_node_nm,
+            energy_per_flop_fp32=energy_per_flop_fp32_j,
+            energy_scaling=fp32_scaling,
+        ))
+
+    if not compute_fabrics:
+        raise TPUYamlLoaderError(
+            f"SKU {base_id!r}: no TPUComputeFabric produced a valid "
+            f"ComputeFabric (check ops_per_unit_per_clock entries)."
+        )
+
+    # ------------------------------------------------------------------
+    # PrecisionProfile dict -- chip-wide peak ops/sec per precision
+    # ------------------------------------------------------------------
+    supported_precisions: set[Precision] = set()
+    for fabric in compute_fabrics:
+        supported_precisions.update(fabric.ops_per_unit_per_clock.keys())
+
+    precision_profiles: dict[Precision, PrecisionProfile] = {}
+    for precision in supported_precisions:
+        peak = sum(f.get_peak_ops_per_sec(precision) for f in compute_fabrics)
+        if peak <= 0:
+            continue
+        # TPUs ARE tensor cores -- the systolic array IS the tensor engine
+        tensor_supported = True
+        # Relative speedup vs BF16 (the TPU training baseline).
+        bf16_peak = sum(
+            f.get_peak_ops_per_sec(Precision.BF16) for f in compute_fabrics
+        )
+        relative_speedup = peak / bf16_peak if bf16_peak > 0 else 1.0
+        precision_profiles[precision] = PrecisionProfile(
+            precision=precision,
+            peak_ops_per_sec=peak,
+            tensor_core_supported=tensor_supported,
+            relative_speedup=relative_speedup,
+            bytes_per_element=_BYTES_PER_PRECISION.get(precision, 4),
+            accumulator_precision=(
+                Precision.INT32 if precision == Precision.INT8 else
+                Precision.FP32 if precision == Precision.BF16 else
+                None
+            ),
+        )
+
+    # Same guard as DPU loader fix (graphs#202): empty profiles would
+    # crash on default_precision selection; raise a clear error instead.
+    if not precision_profiles:
+        raise TPUYamlLoaderError(
+            f"SKU {base_id!r}: no precision_profiles produced. All "
+            f"compute_fabrics returned zero peak ops/sec for every "
+            f"supported precision; check ops_per_unit_per_clock + "
+            f"thermal profile clock values."
+        )
+
+    # ------------------------------------------------------------------
+    # ThermalOperatingPoint per chip-level thermal_profile
+    # ------------------------------------------------------------------
+    thermal_operating_points: dict[str, ThermalOperatingPoint] = {}
+    for profile in cp.power.thermal_profiles:
+        thermal_operating_points[profile.name] = ThermalOperatingPoint(
+            name=profile.name,
+            tdp_watts=profile.tdp_watts,
+            cooling_solution=profile.cooling_solution_id,
+            performance_specs={},
+        )
+
+    # ------------------------------------------------------------------
+    # Memory + cache (Unified Buffer + HBM)
+    # ------------------------------------------------------------------
+    mem = block.memory
+    # peak_bandwidth: TPUs are HBM-bound for training. Pick external
+    # DRAM when present (TPU v4: HBM2e at 1.2 TB/s).
+    if mem.has_external_dram and mem.external_dram_bandwidth_gbps is not None:
+        peak_bandwidth_bps = mem.external_dram_bandwidth_gbps * 1e9
+    else:
+        peak_bandwidth_bps = mem.on_chip_bandwidth_gbps * 1e9
+
+    # External DRAM -> main_memory.
+    if mem.has_external_dram and mem.external_dram_size_gb is not None:
+        main_memory_bytes = int(mem.external_dram_size_gb * 1024**3)
+    else:
+        main_memory_bytes = 0
+
+    # Unified Buffer split across legacy l1/l2 fields. The UB is a
+    # single tier in the v7 schema; the legacy expects both. Same
+    # split as the hand-coded factory.
+    ub_total_bytes = mem.unified_buffer_size_kib * 1024
+    l1_per_unit_bytes = (
+        ub_total_bytes // block.num_mxus
+        if block.num_mxus > 0 else 0
+    )
+    l2_total_bytes = ub_total_bytes
+
+    # Memory technology label and per-byte access energy.
+    if mem.has_external_dram and mem.external_dram_type is not None:
+        memory_technology = mem.external_dram_type.value.upper()
+        if mem.external_dram_access_energy_pj_per_byte > 0:
+            read_pj = mem.external_dram_access_energy_pj_per_byte
+        else:
+            read_pj = 10.0   # HBM2e default
+        write_pj = read_pj * 1.2   # standard write-vs-read ratio
+    else:
+        memory_technology = "on-chip SRAM (no external DRAM)"
+        read_pj = mem.unified_buffer_access_energy_pj_per_byte
+        write_pj = read_pj
+
+    # ------------------------------------------------------------------
+    # SoC fabric (UB-to-MXU crossbar)
+    # ------------------------------------------------------------------
+    soc_fabric_kwargs = dict(
+        topology=_TOPOLOGY_BY_KIND[block.noc.topology],
+        hop_latency_ns=block.noc.hop_latency_ns,
+        pj_per_flit_per_hop=block.noc.pj_per_flit_per_hop,
+        bisection_bandwidth_gbps=block.noc.bisection_bandwidth_gbps,
+        controller_count=block.noc.unit_count,
+        flit_size_bytes=block.noc.flit_size_bytes,
+        routing_distance_factor=block.noc.routing_distance_factor,
+        provenance=(
+            f"Loaded from compute_products YAML "
+            f"({base_id}.dies[0].blocks[0].noc); TPU NoC topology "
+            f"{block.noc.topology.value} mapped to graphs SoCFabric "
+            f"{_TOPOLOGY_BY_KIND[block.noc.topology].name}"
+        ),
+    )
+    from embodied_schemas.process_node import DataConfidence
+    if block.noc.confidence == DataConfidence.THEORETICAL:
+        soc_fabric_kwargs["low_confidence"] = True
+    soc_fabric = SoCFabricModel(**soc_fabric_kwargs)
+
+    # ------------------------------------------------------------------
+    # Tile energy model reconstructed from TPUTileEnergyCoefficients
+    # ------------------------------------------------------------------
+    tile_coeffs = block.tile_energy_coefficients
+    tile_energy_model = TPUTileEnergyModel(
+        array_width=block.mxu_dim_cols,
+        array_height=block.mxu_dim_rows,
+        num_arrays=block.num_mxus,
+        weight_tile_size=block.weight_tile_size_kib * 1024,
+        weight_fifo_depth=block.weight_fifo_depth,
+        pipeline_fill_cycles=block.pipeline_fill_cycles,
+        clock_frequency_hz=default_clock_hz,
+        accumulator_size=block.accumulator_size_kib_per_mxu * 1024,
+        accumulator_width=block.mxu_dim_cols,
+        unified_buffer_size=ub_total_bytes,
+        weight_memory_energy_per_byte=tile_coeffs.weight_memory_energy_pj_per_byte * 1e-12,
+        weight_fifo_energy_per_byte=tile_coeffs.weight_fifo_energy_pj_per_byte * 1e-12,
+        unified_buffer_read_energy_per_byte=tile_coeffs.unified_buffer_read_energy_pj_per_byte * 1e-12,
+        unified_buffer_write_energy_per_byte=tile_coeffs.unified_buffer_write_energy_pj_per_byte * 1e-12,
+        accumulator_write_energy_per_element=tile_coeffs.accumulator_write_energy_pj_per_element * 1e-12,
+        accumulator_read_energy_per_element=tile_coeffs.accumulator_read_energy_pj_per_element * 1e-12,
+        weight_shift_in_energy_per_element=tile_coeffs.weight_shift_in_energy_pj_per_element * 1e-12,
+        activation_stream_energy_per_element=tile_coeffs.activation_stream_energy_pj_per_element * 1e-12,
+        mac_energy=tile_coeffs.mac_energy_pj * 1e-12,
+    )
+
+    # ------------------------------------------------------------------
+    # Assemble HardwareResourceModel
+    # ------------------------------------------------------------------
+    # Default precision: BF16 (TPU training default; vs INT8 for
+    # NPU/DPU/CGRA inference-default).
+    if Precision.BF16 in precision_profiles:
+        default_precision = Precision.BF16
+    elif Precision.INT8 in precision_profiles:
+        default_precision = Precision.INT8
+    else:
+        default_precision = next(iter(precision_profiles))
+
+    # Energy fields: use the first fabric.
+    first_fabric = compute_fabrics[0]
+    energy_per_flop_fp32 = first_fabric.energy_per_flop_fp32
+    energy_scaling: dict[Precision, float] = {}
+    for fabric in compute_fabrics:
+        energy_scaling.update(fabric.energy_scaling)
+
+    model = HardwareResourceModel(
+        name=name_override or cp.name,
+        hardware_type=HardwareType.TPU,
+
+        compute_fabrics=compute_fabrics,
+
+        compute_units=block.num_mxus,
+        threads_per_unit=block.mxu_dim_rows * block.mxu_dim_cols,
+        warps_per_unit=block.mxu_dim_rows,    # rows in systolic array
+        warp_size=block.mxu_dim_cols,         # columns in systolic array
+
+        thermal_operating_points=thermal_operating_points,
+        default_thermal_profile=cp.power.default_thermal_profile,
+
+        precision_profiles=precision_profiles,
+        default_precision=default_precision,
+
+        peak_bandwidth=peak_bandwidth_bps,
+        l1_cache_per_unit=l1_per_unit_bytes,
+        l2_cache_total=l2_total_bytes,
+        main_memory=main_memory_bytes,
+
+        energy_per_flop_fp32=energy_per_flop_fp32,
+        energy_per_byte=read_pj * 1e-12,
+        energy_scaling=energy_scaling,
+
+        min_occupancy=block.min_occupancy,
+        max_concurrent_kernels=block.max_concurrent_models,
+        wave_quantization=block.wave_quantization,
+
+        # M3 Layer 3: software-managed Unified Buffer.
+        l1_storage_kind="scratchpad",
+
+        # M4 Layer 4: UB IS the LLC (collapses L1+L2). No separate L2.
+        l2_cache_per_unit=l1_per_unit_bytes,
+        l2_topology="shared-llc",
+
+        # M5 Layer 5: TPUs don't have L3.
+        l3_present=False,
+        l3_cache_total=0,
+
+        # XLA-routed systolic dataflow has no coherence
+        coherence_protocol=mem.coherence_protocol,
+
+        # M7 Layer 7
+        memory_technology=memory_technology,
+        memory_read_energy_per_byte_pj=read_pj,
+        memory_write_energy_per_byte_pj=write_pj,
+
+        # M6 Layer 6
+        soc_fabric=soc_fabric,
+    )
+
+    # Attach the TPU tile energy model (TPU-specific architectural
+    # field; lives on the legacy HardwareResourceModel as an attribute)
+    model.tile_energy_model = tile_energy_model
+
+    # Generic provenance for the YAML-loaded fields
+    yaml_provenance = EstimationConfidence.theoretical(
+        score=0.80,
+        source=f"Loaded from compute_products YAML ({base_id})",
+    )
+    for key in (
+        "l1_cache_per_unit", "l1_storage_kind",
+        "l2_cache_per_unit", "l2_topology",
+        "l3_present", "l3_cache_total", "coherence_protocol",
+        "memory_technology",
+        "memory_read_energy_per_byte_pj",
+        "memory_write_energy_per_byte_pj",
+        "soc_fabric",
+    ):
+        model.set_provenance(key, yaml_provenance)
+
+    fabric_provenance = EstimationConfidence.theoretical(
+        score=0.55,
+        source=(
+            f"Loaded from compute_products YAML ({base_id}): per-fabric "
+            f"ops_per_unit_per_clock at the systolic MXU fabric"
+        ),
+    )
+    for precision in supported_precisions:
+        model.set_provenance(
+            f"compute_fabric.ops_per_clock.{precision.value}",
+            fabric_provenance,
+        )
+
+    return model

--- a/tests/hardware/test_tpu_yaml_loader_v4_parity.py
+++ b/tests/hardware/test_tpu_yaml_loader_v4_parity.py
@@ -1,0 +1,400 @@
+"""Contract test: TPU v4 YAML loader produces the expected model.
+
+PR 4 of the TPU mini-sprint scoped at issue #204. Mirror of
+``tests/hardware/test_dpu_yaml_loader_vitis_ai_parity.py``. Compares
+the YAML-loaded model against the hand-coded factory at
+``src/graphs/hardware/models/datacenter/tpu_v4.py``.
+
+PR 5 will retire the hand-coded body and make ``tpu_v4_resource_model()``
+a thin wrapper over the loader; at that point both ``hand_coded`` and
+``yaml_loaded`` fixtures will resolve through the same loader and
+these structural assertions become contract tests.
+
+Documented drifts:
+
+  - ``energy_per_flop_fp32``: ~4x drift (0.45 pJ YAML vs 1.8 pJ
+    hand-coded). YAML computes from BF16 baseline (0.225 pJ) *
+    FP32 scaling (2.0) = 0.45 pJ. Hand-coded uses
+    ``get_base_alu_energy(7, 'standard_cell')`` = 1.8 pJ static
+    7nm baseline. The schema's BF16-relative FP32 scaling of 2.0
+    is optimistic for emulated FP32; v8 reconciliation may add a
+    direct ``energy_per_flop_fp32_override`` field.
+  - ``memory_technology``: "HBM2E" (yaml) vs None (hand-coded).
+    Legacy doesn't populate this field; YAML loader does.
+  - **TPU v4 modeled as 2 MXUs (not 8)** -- both YAML and legacy
+    model TPU v4 as 2 MXUs * 128x128 = 32,768 MACs. Google's actual
+    TPU v4 has 2 TensorCores * 4 MXUs each = 8 MXUs * 128x128 =
+    131,072 MACs (= 275 TFLOPS BF16 chip-level peak). The schema's
+    `chip.performance.bf16_tflops = 275.0` matches the marketed
+    number, but the `compute_fabric`-derived precision_profiles[BF16]
+    gives 68.8 TOPS (= 1/4 of marketed). This is a documented
+    legacy modeling choice that the parity test honors; v8
+    reconciliation can model 2 TC * 4 MXUs properly.
+
+Where the hand-coded and YAML-loaded agree (actual parity assertions):
+
+  - compute_units, threads_per_unit, warps_per_unit, warp_size
+  - peak_bandwidth (1.2 TB/s -- HBM2e)
+  - l1_cache_per_unit (16 MiB per MXU = UB / 2)
+  - l2_cache_total (32 MiB = full UB)
+  - main_memory (32 GiB HBM2e)
+  - default_precision (BF16 -- training-first)
+  - hardware_type (TPU)
+  - thermal profile shape (single profile, 350W liquid)
+  - scheduler attrs (min_occupancy=0.5, max_concurrent_kernels=1,
+    wave_quantization=1)
+  - precision_profiles[BF16/INT8] peak ops (68.8 TOPS for 2-MXU model)
+  - tile_energy_model (TPUTileEnergyModel attached on both sides)
+"""
+
+import pytest
+
+from graphs.hardware.architectural_energy import TPUTileEnergyModel
+from graphs.hardware.models.datacenter.tpu_v4 import tpu_v4_resource_model
+from graphs.hardware.models.datacenter.tpu_yaml_loader import (
+    TPUYamlLoaderError,
+    load_tpu_resource_model_from_yaml,
+)
+from graphs.hardware.resource_model import HardwareType, Precision
+
+
+SKU_ID = "google_tpu_v4"
+LEGACY_NAME = "TPU-v4"
+
+
+@pytest.fixture(scope="module")
+def hand_coded():
+    return tpu_v4_resource_model()
+
+
+@pytest.fixture(scope="module")
+def yaml_loaded():
+    return load_tpu_resource_model_from_yaml(
+        SKU_ID, name_override=LEGACY_NAME,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Identity / shape
+# ---------------------------------------------------------------------------
+
+def test_name_matches(hand_coded, yaml_loaded):
+    assert yaml_loaded.name == hand_coded.name == "TPU-v4"
+
+
+def test_hardware_type_is_tpu(hand_coded, yaml_loaded):
+    """Both produce HardwareType.TPU -- no transitional period
+    (TPU already in graphs enum)."""
+    assert yaml_loaded.hardware_type == hand_coded.hardware_type == HardwareType.TPU
+
+
+def test_compute_units_matches(hand_coded, yaml_loaded):
+    """2 MXUs (legacy modeling; see drift note re: actual 8-MXU TPU v4)."""
+    assert yaml_loaded.compute_units == hand_coded.compute_units == 2
+
+
+def test_threads_per_unit_matches(hand_coded, yaml_loaded):
+    """128 * 128 = 16,384 MACs per MXU."""
+    assert yaml_loaded.threads_per_unit == hand_coded.threads_per_unit == 16384
+
+
+def test_warps_per_unit_matches(hand_coded, yaml_loaded):
+    """128 rows per systolic array."""
+    assert yaml_loaded.warps_per_unit == hand_coded.warps_per_unit == 128
+
+
+def test_warp_size_matches(hand_coded, yaml_loaded):
+    """128 cols per systolic array."""
+    assert yaml_loaded.warp_size == hand_coded.warp_size == 128
+
+
+# ---------------------------------------------------------------------------
+# Compute fabrics
+# ---------------------------------------------------------------------------
+
+def test_single_compute_fabric(hand_coded, yaml_loaded):
+    """TPU v4 has one fabric (systolic array)."""
+    assert len(yaml_loaded.compute_fabrics) == len(hand_coded.compute_fabrics) == 1
+
+
+def test_compute_fabric_is_systolic_array(hand_coded, yaml_loaded):
+    """First SKU to exercise TPUFabricKind.TPU_V2_PLUS -> fabric_type
+    'systolic_array' via the loader's mapping table."""
+    assert yaml_loaded.compute_fabrics[0].fabric_type == "systolic_array"
+    assert hand_coded.compute_fabrics[0].fabric_type == "systolic_array"
+
+
+def test_compute_fabric_num_units(hand_coded, yaml_loaded):
+    """num_units = 2 MXUs * 128 * 128 = 32,768 total MACs."""
+    assert yaml_loaded.compute_fabrics[0].num_units == hand_coded.compute_fabrics[0].num_units == 2 * 128 * 128
+
+
+def test_compute_fabric_bf16_ops_per_clock(hand_coded, yaml_loaded):
+    """BF16: 2 ops/MAC (multiply + accumulate)."""
+    hand_bf16 = hand_coded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.BF16)
+    yaml_bf16 = yaml_loaded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.BF16)
+    assert yaml_bf16 == hand_bf16 == 2
+
+
+def test_compute_fabric_int8_ops_per_clock(hand_coded, yaml_loaded):
+    """INT8: 2 ops/MAC at the same per-MAC rate as BF16."""
+    hand_int8 = hand_coded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.INT8)
+    yaml_int8 = yaml_loaded.compute_fabrics[0].ops_per_unit_per_clock.get(Precision.INT8)
+    assert yaml_int8 == hand_int8 == 2
+
+
+def test_compute_fabric_energy_documented_drift(hand_coded, yaml_loaded):
+    """DOCUMENTED DRIFT: ~4x drift in FP32 fabric energy.
+
+    YAML: 0.225 pJ BF16 baseline * 2.0 FP32 scaling = 0.45 pJ
+    Hand-coded: get_base_alu_energy(7, 'standard_cell') = 1.8 pJ
+
+    Both are valid 7nm estimates with different methodologies. The
+    schema's 2.0x BF16-relative FP32 scaling is optimistic for
+    emulated FP32; v8 reconciliation may add a direct
+    energy_per_flop_fp32_override field on TPUComputeFabric."""
+    # Range sanity: 7nm FP32 should be ~0.2-3 pJ
+    for fab in (hand_coded.compute_fabrics[0], yaml_loaded.compute_fabrics[0]):
+        assert 1e-13 < fab.energy_per_flop_fp32 < 5e-12, (
+            f"fabric energy_per_flop_fp32={fab.energy_per_flop_fp32} "
+            f"outside [0.1, 5] pJ range for 7nm"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Precision profiles (the BF16/INT8 peaks match exactly)
+# ---------------------------------------------------------------------------
+
+def test_bf16_peak_matches(hand_coded, yaml_loaded):
+    """68.8 TOPS BF16 (= 32,768 MACs * 2 ops * 1.05 GHz).
+
+    Note: this is 1/4 of the marketed 275 TFLOPS BF16 because both
+    legacy and YAML model TPU v4 as 2 MXUs (not the actual 8 MXUs =
+    2 TensorCores * 4 MXUs). Documented drift; v8 reconciliation."""
+    hand_peak = hand_coded.precision_profiles[Precision.BF16].peak_ops_per_sec
+    yaml_peak = yaml_loaded.precision_profiles[Precision.BF16].peak_ops_per_sec
+    assert yaml_peak == pytest.approx(hand_peak, rel=0.01)
+    assert yaml_peak == pytest.approx(68.8e12, rel=0.01)
+
+
+def test_int8_peak_matches(hand_coded, yaml_loaded):
+    """68.8 TOPS INT8 (same per-MAC rate as BF16 in this fabric model)."""
+    hand_peak = hand_coded.precision_profiles[Precision.INT8].peak_ops_per_sec
+    yaml_peak = yaml_loaded.precision_profiles[Precision.INT8].peak_ops_per_sec
+    assert yaml_peak == pytest.approx(hand_peak, rel=0.01)
+
+
+def test_default_precision_matches(hand_coded, yaml_loaded):
+    """Both prefer BF16 as default (TPU training-first design)."""
+    assert yaml_loaded.default_precision == hand_coded.default_precision == Precision.BF16
+
+
+def test_int4_not_in_precision_profiles(hand_coded, yaml_loaded):
+    """TPU v4 doesn't support INT4 (added in v5p)."""
+    assert Precision.INT4 not in hand_coded.precision_profiles
+    assert Precision.INT4 not in yaml_loaded.precision_profiles
+
+
+# ---------------------------------------------------------------------------
+# Memory hierarchy (UB + HBM2e)
+# ---------------------------------------------------------------------------
+
+def test_peak_bandwidth_matches_hbm2e(hand_coded, yaml_loaded):
+    """1.2 TB/s HBM2e -- chip-attached external DRAM."""
+    assert yaml_loaded.peak_bandwidth == pytest.approx(1.2e12, rel=0.01)
+    assert hand_coded.peak_bandwidth == pytest.approx(1.2e12, rel=0.01)
+
+
+def test_main_memory_matches(hand_coded, yaml_loaded):
+    """32 GiB HBM2e."""
+    assert yaml_loaded.main_memory == hand_coded.main_memory == 32 * 1024**3
+
+
+def test_l1_per_unit_matches(hand_coded, yaml_loaded):
+    """16 MiB per MXU (= 32 MiB UB / 2 MXUs)."""
+    assert yaml_loaded.l1_cache_per_unit == hand_coded.l1_cache_per_unit
+    assert yaml_loaded.l1_cache_per_unit == 16 * 1024 * 1024
+
+
+def test_l2_cache_total_matches(hand_coded, yaml_loaded):
+    """32 MiB shared (full UB)."""
+    assert yaml_loaded.l2_cache_total == hand_coded.l2_cache_total
+    assert yaml_loaded.l2_cache_total == 32 * 1024 * 1024
+
+
+def test_l3_absent(yaml_loaded):
+    """TPUs don't have L3."""
+    assert yaml_loaded.l3_present is False
+    assert yaml_loaded.l3_cache_total == 0
+
+
+def test_l1_storage_kind_is_scratchpad(yaml_loaded):
+    """UB is software-managed."""
+    assert yaml_loaded.l1_storage_kind == "scratchpad"
+
+
+def test_coherence_protocol_is_none(yaml_loaded):
+    """XLA-routed systolic dataflow has no coherence."""
+    assert yaml_loaded.coherence_protocol == "none"
+
+
+def test_yaml_populates_memory_technology(yaml_loaded):
+    """DOCUMENTED DRIFT: hand-coded does NOT set memory_technology
+    (returns None); YAML loader populates from external_dram_type.
+    YAML's "HBM2E" is structurally correct."""
+    assert yaml_loaded.memory_technology == "HBM2E"
+
+
+def test_hand_coded_memory_technology_is_none(hand_coded):
+    """Pinned for visibility: PR 5 cleanup makes both sides populate."""
+    assert hand_coded.memory_technology is None
+
+
+# ---------------------------------------------------------------------------
+# SoC fabric (UB-to-MXU crossbar)
+# ---------------------------------------------------------------------------
+
+def test_yaml_populates_soc_fabric(yaml_loaded):
+    """YAML loader populates soc_fabric from the noc block. Hand-coded
+    didn't model the SoC fabric (returns None); PR 5 cleanup makes both
+    sides match."""
+    from graphs.hardware.fabric_model import Topology
+    assert yaml_loaded.soc_fabric is not None
+    assert yaml_loaded.soc_fabric.topology == Topology.CROSSBAR
+    assert yaml_loaded.soc_fabric.controller_count == 2
+    assert yaml_loaded.soc_fabric.bisection_bandwidth_gbps == pytest.approx(2000.0)
+
+
+def test_hand_coded_soc_fabric_is_none(hand_coded):
+    """Pinned for visibility: PR 5 cleanup makes the YAML loader the
+    only source."""
+    assert hand_coded.soc_fabric is None
+
+
+# ---------------------------------------------------------------------------
+# Thermal profiles (single 350W liquid-cooled profile)
+# ---------------------------------------------------------------------------
+
+def test_thermal_profile_count_matches(hand_coded, yaml_loaded):
+    assert len(yaml_loaded.thermal_operating_points) == 1
+    assert len(hand_coded.thermal_operating_points) == 1
+
+
+def test_default_thermal_profile_tdp(hand_coded, yaml_loaded):
+    """Both default profiles report 350W."""
+    hand_default = hand_coded.thermal_operating_points[hand_coded.default_thermal_profile]
+    yaml_default = yaml_loaded.thermal_operating_points[yaml_loaded.default_thermal_profile]
+    assert yaml_default.tdp_watts == hand_default.tdp_watts == 350.0
+
+
+# ---------------------------------------------------------------------------
+# Scheduler attrs
+# ---------------------------------------------------------------------------
+
+def test_scheduler_attrs_match(hand_coded, yaml_loaded):
+    """0.5 occupancy (TPU systolic needs high utilization), 1 concurrent
+    model (datacenter training pattern), wave_q=1."""
+    assert yaml_loaded.min_occupancy == pytest.approx(0.5, rel=0.05)
+    assert hand_coded.min_occupancy == pytest.approx(0.5, rel=0.05)
+    assert yaml_loaded.max_concurrent_kernels == hand_coded.max_concurrent_kernels == 1
+    assert yaml_loaded.wave_quantization == hand_coded.wave_quantization == 1
+
+
+# ---------------------------------------------------------------------------
+# Tile energy model -- TPU-specific architectural decomposition
+# ---------------------------------------------------------------------------
+
+def test_tile_energy_model_attached_on_both_sides(hand_coded, yaml_loaded):
+    """Both factories attach a TPUTileEnergyModel. The YAML loader
+    reconstructs it from the schema's TPUTileEnergyCoefficients
+    sub-type + the per-MXU fields on TPUBlock."""
+    assert isinstance(hand_coded.tile_energy_model, TPUTileEnergyModel)
+    assert isinstance(yaml_loaded.tile_energy_model, TPUTileEnergyModel)
+
+
+def test_tile_energy_model_dimensions_match(hand_coded, yaml_loaded):
+    """128x128 array, 2 MXUs."""
+    for tem in (hand_coded.tile_energy_model, yaml_loaded.tile_energy_model):
+        assert tem.array_width == 128
+        assert tem.array_height == 128
+        assert tem.num_arrays == 2
+        assert tem.unified_buffer_size == 32 * 1024 * 1024
+
+
+def test_tile_energy_model_mac_energy_matches(hand_coded, yaml_loaded):
+    """0.25 pJ per BF16 MAC (the TPU v4 reference number)."""
+    assert hand_coded.tile_energy_model.mac_energy == pytest.approx(0.25e-12)
+    assert yaml_loaded.tile_energy_model.mac_energy == pytest.approx(0.25e-12)
+
+
+def test_tile_energy_model_weight_memory_energy_matches(hand_coded, yaml_loaded):
+    """10 pJ/byte for HBM2e access."""
+    assert hand_coded.tile_energy_model.weight_memory_energy_per_byte == pytest.approx(10e-12)
+    assert yaml_loaded.tile_energy_model.weight_memory_energy_per_byte == pytest.approx(10e-12)
+
+
+# ---------------------------------------------------------------------------
+# TPU-specific: ICI surface lives on the schema, not yet on
+# HardwareResourceModel
+# ---------------------------------------------------------------------------
+
+def test_ici_surface_on_underlying_compute_product():
+    """The TPU v4 YAML carries ici_port_count=6, ici_bandwidth_per_port_gbps=400.0,
+    and ici_topology_hint='3d_torus_2x2x2' on the TPUBlock. The legacy
+    HardwareResourceModel has no equivalent fields, so the loader
+    doesn't surface them; downstream consumers that need ICI surface
+    read directly from the ComputeProduct.
+
+    Pins values via direct schema read so a future v8 HardwareResourceModel
+    extension that surfaces ICI has known-good references."""
+    from embodied_schemas.loaders import load_compute_products
+    from embodied_schemas import TPUBlock
+    cp = load_compute_products().get("google_tpu_v4")
+    assert cp is not None
+    block = next(b for b in cp.dies[0].blocks if isinstance(b, TPUBlock))
+    assert block.ici_port_count == 6
+    assert block.ici_bandwidth_per_port_gbps == pytest.approx(400.0)
+    assert block.ici_topology_hint == "3d_torus_2x2x2"
+
+
+# ---------------------------------------------------------------------------
+# Loader error paths
+# ---------------------------------------------------------------------------
+
+def test_loader_raises_on_unknown_sku():
+    with pytest.raises(TPUYamlLoaderError, match=r"no ComputeProduct with id"):
+        load_tpu_resource_model_from_yaml("definitely_not_a_real_tpu")
+
+
+def test_loader_raises_on_kpu_sku():
+    """KPU ComputeProducts have no TPUBlock; loader should reject."""
+    with pytest.raises(TPUYamlLoaderError, match=r"no TPUBlock"):
+        load_tpu_resource_model_from_yaml("kpu_t64_32x32_lp5x4_16nm_tsmc_ffp")
+
+
+def test_loader_raises_on_npu_sku():
+    """NPU ComputeProducts have no TPUBlock; loader should reject."""
+    with pytest.raises(TPUYamlLoaderError, match=r"no TPUBlock"):
+        load_tpu_resource_model_from_yaml("hailo_hailo_8")
+
+
+def test_loader_raises_on_cgra_sku():
+    """CGRA ComputeProducts have no TPUBlock; loader should reject."""
+    with pytest.raises(TPUYamlLoaderError, match=r"no TPUBlock"):
+        load_tpu_resource_model_from_yaml("stanford_plasticine_v2")
+
+
+def test_loader_raises_on_dpu_sku():
+    """DPU ComputeProducts have no TPUBlock; loader should reject."""
+    with pytest.raises(TPUYamlLoaderError, match=r"no TPUBlock"):
+        load_tpu_resource_model_from_yaml("xilinx_vitis_ai_b4096")
+
+
+def test_loader_raises_on_gpu_sku():
+    with pytest.raises(TPUYamlLoaderError, match=r"no TPUBlock"):
+        load_tpu_resource_model_from_yaml("nvidia_jetson_agx_orin_64gb")
+
+
+def test_loader_raises_on_cpu_sku():
+    with pytest.raises(TPUYamlLoaderError, match=r"no TPUBlock"):
+        load_tpu_resource_model_from_yaml("intel_core_i7_12700k")


### PR DESCRIPTION
## Summary

- Adds ``tpu_yaml_loader.py`` (~530 LOC) mirroring ``dpu_yaml_loader.py``.
- Builds ``HardwareResourceModel`` from a TPUBlock-bearing ``ComputeProduct``.
- 42-test parity suite pins YAML-loaded output against hand-coded ``tpu_v4.py``.
- CI pin bumped to include embodied-schemas#38 (schema) + #39 (TPU v4 YAML).
- PR 4 of 5 in the TPU mini-sprint scoped at #204.

## TPU-specific loader decisions (vs DPU/CGRA loaders)

| # | Decision | Why |
|---|---|---|
| 1 | ``peak_bandwidth = external_dram_bandwidth_gbps`` (HBM2e 1.2 TB/s) | TPUs are HBM-bound for training (NPU-style) |
| 2 | **Unified Buffer split** across legacy l1/l2 fields | UB is a single tier in v7 schema; legacy expects both. Same split as hand-coded |
| 3 | **Tile energy model reconstructed** from 9-field coefficients + per-MXU fields | TPU-specific architectural model attached as `model.tile_energy_model` |
| 4 | ``HardwareType.TPU`` set directly | No transitional period |
| 5 | ``default_precision = BF16`` | Training-first (vs INT8 for NPU/DPU/CGRA inference) |
| 6 | **ICI fields NOT surfaced** on HardwareResourceModel | v8 reconciliation; read from ComputeProduct |
| 7 | **Empty precision_profiles guard** | Same defensive pattern as DPU loader fix (graphs#202) |

## Four documented drifts

| Field | YAML | Legacy | Why YAML's choice |
|---|---|---|---|
| `energy_per_flop_fp32` | 0.45 pJ | 1.8 pJ | YAML computes BF16 * FP32_scaling; legacy uses static 7nm baseline. Both valid; v8 may add override field |
| `memory_technology` | "HBM2E" | None | Legacy didn't populate |
| `soc_fabric` | populated | None | Legacy didn't model |
| **MXU count modeling** | 2 MXUs (both) | 2 MXUs (both) | Actual TPU v4 has 2 TC × 4 MXUs = 8; both legacy/YAML model as 2. Documented v8 reconciliation |

## CI pin bump

Bumped embodied-schemas pin from ``aa19f91`` (PR #37 Vitis AI YAML) to ``9bc4a7a`` (PR #39 TPU v4 YAML) across all 8 occurrences. History comment extended to record PR #38 (TPUBlock schema + MemoryType.DDR3) and PR #39 (TPU v4 YAML).

## Changes

| File | Δ | What |
|---|---|---|
| ``src/graphs/hardware/models/datacenter/tpu_yaml_loader.py`` | +530 LOC (new) | Full TPU loader |
| ``tests/hardware/test_tpu_yaml_loader_v4_parity.py`` | +340 LOC (new) | 42 parity + contract tests |
| ``.github/workflows/{ci,coverage,v4-validation}.yml`` | +24 LOC | CI pin bump + history |

## Test Results

| Suite | Result |
|---|---|
| ``test_tpu_yaml_loader_v4_parity.py`` | 42 passed (new) |
| Full suite | **3000 passed**, 13 skipped, 4 xfailed (was 2958) |

🎯 **3000 passing tests** — milestone for the graphs catalog!

## Test plan

- [x] All 3000 graphs tests pass locally
- [x] Loader correctly handles external_dram (HBM2e) gated fields
- [x] Tile energy model reconstructed from 9-field coefficients + per-MXU fields
- [x] Loader rejects KPU/GPU/CPU/NPU/CGRA/DPU SKUs with clear error messages
- [x] Empty-precision-profiles guard prevents StopIteration
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied: ``gh pr ready PR_NUMBER``

## Follow-up (unblocked by this PR)

- PR 5 (graphs): retire ``tpu_v4.py`` ~176 LOC hand-coded factory to thin loader wrapper; closes #204

## Refs

- #204 (umbrella tracking issue; TPU mini-sprint)
- #205 (paper exercise design doc)
- branes-ai/embodied-schemas#38, #39 (precursors)
- #202 (DPU loader — pattern source)

Generated with [Claude Code](https://claude.com/claude-code)