### PR TITLE
refactor(hardware): retire tpu_v4 factory (closes #204)

### DIFF
--- a/src/graphs/hardware/models/datacenter/tpu_v4.py
+++ b/src/graphs/hardware/models/datacenter/tpu_v4.py
@@ -1,176 +1,85 @@
-"""
-Tpu V4 Resource Model hardware resource model.
+"""Google TPU v4 resource model.
 
-Extracted from resource_model.py during refactoring.
+Final cleanup PR for issue #204 (TPU mini-sprint). As of this PR,
+the chip's architectural and thermal-profile data lives in the
+canonical YAML at
+``embodied-schemas:data/compute_products/google/tpu_v4.yaml``
+(landed in embodied-schemas#39) and is loaded via ``tpu_yaml_loader``.
+The previous ~176-LOC hand-coded ``HardwareResourceModel``
+constructor was retired here; its parity with the YAML-loaded model
+is pinned in ``tests/hardware/test_tpu_yaml_loader_v4_parity.py``.
+
+Schema precursors that had to land first:
+  - embodied-schemas#38 -- TPUBlock added to the discriminated union
+  - embodied-schemas#39 -- the TPU v4 YAML itself
+
+The public function name and signature are preserved so existing
+callers (``create_tpu_v4_mapper``, validation scripts, energy / BERT
+benchmarks, ``cli/compare_*.py``) continue to work unchanged.
+
+**Zero overlays remain.** Like Plasticine (#199) and Vitis AI (#203),
+this is a clean-cut migration because:
+
+  - ``HardwareType.TPU`` was already in the graphs enum (no
+    transitional period like NPU's #191).
+  - Loader's ``peak_bandwidth`` convention (external DRAM = HBM2e at
+    1.2 TB/s) matches the legacy hand-coded value exactly.
+  - Loader reconstructs the ``TPUTileEnergyModel`` from the schema's
+    ``TPUTileEnergyCoefficients`` sub-type with the same 9 canonical
+    coefficients the hand-coded factory used.
+  - No BOMCostProfile overlay needed (TPU v4 is Google Cloud rental
+    only; no commercial BoM).
+
+Four documented drifts where the YAML loader follows v7 schema
+conventions that differ from the legacy:
+
+  - ``energy_per_flop_fp32``: ~4x drift (0.45 pJ vs 1.8 pJ). YAML
+    computes from BF16 baseline * FP32 scaling = 0.225 * 2.0 = 0.45.
+    Hand-coded used ``get_base_alu_energy(7, 'standard_cell')`` =
+    1.8 pJ static 7nm baseline. Both valid 7nm estimates; v8 may add
+    a direct ``energy_per_flop_fp32_override`` field on
+    ``TPUComputeFabric``.
+  - ``memory_technology``: "HBM2E" (correct) vs None (legacy didn't set).
+  - ``soc_fabric``: populated 2-endpoint crossbar (vs legacy None).
+    Unblocks downstream Layer 6 reporting for TPU.
+  - **MXU count modeling**: both YAML and legacy model TPU v4 as
+    2 MXUs * 128x128 = 32,768 MACs (= 68.8 TOPS BF16). Google's actual
+    TPU v4 has 2 TensorCores * 4 MXUs each = 8 MXUs (= 275 TFLOPS
+    marketed). The schema's ``chip.performance.bf16_tflops = 275.0``
+    captures the marketed number, but the precision_profiles[BF16]
+    derived from the compute_fabric uses the 2-MXU model. v8
+    reconciliation: model 2 TC * 4 MXUs properly (might require
+    multi-block-per-die support).
+
+Two v8 reconciliation items:
+  - ``is_statically_reconfigurable=False`` (TPUs are fixed-function)
+    -- not in TPUBlock schema yet.
+  - ``ici_port_count`` / ``ici_bandwidth_per_port_gbps`` /
+    ``ici_topology_hint`` -- live on TPUBlock in the v7 schema but
+    have no equivalent fields on ``HardwareResourceModel``.
+    Downstream consumers read from ComputeProduct directly meanwhile.
+
+The legacy resource-model ``name`` ("TPU-v4") is preserved.
 """
 
-from ...resource_model import (
-    HardwareResourceModel,
-    HardwareType,
-    Precision,
-    PrecisionProfile,
-    ClockDomain,
-    ComputeResource,
-    TileSpecialization,
-    KPUComputeResource,
-    PerformanceCharacteristics,
-    ThermalOperatingPoint,
-    ComputeFabric,
-    get_base_alu_energy,
-)
-from ...architectural_energy import TPUTileEnergyModel
+from ...resource_model import HardwareResourceModel
+from .tpu_yaml_loader import load_tpu_resource_model_from_yaml
+
+
+_LEGACY_NAME = "TPU-v4"
+_YAML_BASE_ID = "google_tpu_v4"
 
 
 def tpu_v4_resource_model() -> HardwareResourceModel:
+    """Google TPU v4 -- 4th-generation datacenter training TPU.
+
+    See the YAML for the canonical chip description (2 MXUs * 128x128
+    at 1.05 GHz on TSMC N7, 32 MiB on-chip Unified Buffer, 32 GiB
+    chip-attached HBM2e at 1.2 TB/s, 350W active liquid cooling,
+    6-port ICI for 3D-torus pod, multi-precision BF16 + INT8 + emulated
+    FP32, full 9-coefficient tile energy model).
     """
-    Google TPU v4 resource model.
-
-    Architecture:
-    - 2 Matrix Multiplier Units (MXUs)
-    - Each MXU: 128×128 systolic array (16,384 MACs)
-    - Per MXU: 137.5 TFLOPS BF16, 275 TOPS INT8
-
-    Key characteristics:
-    - Optimized for BF16 and INT8
-    - 2× INT8 performance vs BF16
-    - Very energy efficient
-    """
-    # Thermal operating point (datacenter TPU pod)
-    thermal_default = ThermalOperatingPoint(
-        name="default",
-        tdp_watts=350.0,  # TPU v4 TDP
-        cooling_solution="active-liquid",
-        performance_specs={}  # Uses precision_profiles for performance
+    return load_tpu_resource_model_from_yaml(
+        _YAML_BASE_ID,
+        name_override=_LEGACY_NAME,
     )
-
-    # ========================================================================
-    # Systolic Array Fabric (7nm Standard Cell)
-    # ========================================================================
-    # TPU v4 has 2 MXUs with 128×128 systolic arrays each
-    # Process: 7nm (4th-gen TPU)
-    # Clock: 1050 MHz
-    # Peak BF16: 275 TFLOPS (2 MXUs × 128×128 × 2 ops × 1050 MHz)
-    # Peak INT8: 550 TOPS (2× BF16)
-    systolic_fabric = ComputeFabric(
-        fabric_type="systolic_array",
-        circuit_type="standard_cell",
-        num_units=2 * 128 * 128,  # 2 MXUs × 16,384 MACs = 32,768 total MACs
-        ops_per_unit_per_clock={
-            Precision.BF16: 2,  # MAC = 2 ops
-            Precision.INT8: 2,  # MAC = 2 ops
-        },
-        core_frequency_hz=1050e6,  # 1.05 GHz
-        process_node_nm=7,  # 7nm process
-        energy_per_flop_fp32=get_base_alu_energy(7, 'standard_cell'),  # 1.8 pJ
-        energy_scaling={
-            Precision.FP32: 1.0,
-            Precision.BF16: 0.5,  # BF16 is 2× more efficient
-            Precision.INT8: 0.125,  # INT8 is 8× more efficient
-        }
-    )
-
-    # TPU v4 tile energy model (for architectural analysis)
-    tile_energy_model = TPUTileEnergyModel(
-        # Array configuration (v4 uses 128×128 arrays × 2 MXUs)
-        array_width=128,
-        array_height=128,
-        num_arrays=2,  # 2 MXUs per chip
-
-        # Tile configuration (smaller than v1's 64 KiB)
-        weight_tile_size=32 * 1024,  # 32 KiB per tile
-        weight_fifo_depth=2,  # 2 tiles buffered (estimated)
-
-        # Pipeline (shorter than v1's 256 cycles)
-        pipeline_fill_cycles=128,  # 128 cycles to fill pipeline
-        clock_frequency_hz=1050e6,  # 1.05 GHz (estimated from 275 TFLOPS)
-
-        # Accumulator (2 MiB per MXU, sized for roofline knee)
-        accumulator_size=2 * 1024 * 1024,  # 2 MiB per MXU
-        accumulator_width=128,  # 128 elements wide
-
-        # Unified Buffer (estimated 32 MiB for v4)
-        unified_buffer_size=32 * 1024 * 1024,  # 32 MiB
-
-        # Energy coefficients (HBM2e, advanced process node)
-        weight_memory_energy_per_byte=10.0e-12,  # 10 pJ/byte (HBM2e)
-        weight_fifo_energy_per_byte=0.5e-12,  # 0.5 pJ/byte (on-chip SRAM)
-        unified_buffer_read_energy_per_byte=0.5e-12,  # 0.5 pJ/byte
-        unified_buffer_write_energy_per_byte=0.5e-12,  # 0.5 pJ/byte
-        accumulator_write_energy_per_element=0.4e-12,  # 0.4 pJ (32-bit write)
-        accumulator_read_energy_per_element=0.3e-12,  # 0.3 pJ (32-bit read)
-        weight_shift_in_energy_per_element=0.3e-12,  # 0.3 pJ (shift register)
-        activation_stream_energy_per_element=0.2e-12,  # 0.2 pJ (stream)
-        mac_energy=0.25e-12,  # 0.25 pJ per BF16 MAC (slightly higher than INT8)
-    )
-
-    # Calculate peak performance
-    bf16_peak = systolic_fabric.get_peak_ops_per_sec(Precision.BF16)
-    int8_peak = systolic_fabric.get_peak_ops_per_sec(Precision.INT8)
-
-    model = HardwareResourceModel(
-        name="TPU-v4",
-        hardware_type=HardwareType.TPU,
-
-        # NEW: Compute fabrics
-        compute_fabrics=[systolic_fabric],
-
-        # Legacy fields
-        compute_units=2,  # 2 MXUs (Matrix Multiplier Units)
-        threads_per_unit=128 * 128,  # 128×128 systolic array per MXU
-        warps_per_unit=128,  # rows in systolic array
-        warp_size=128,  # columns in systolic array
-
-        precision_profiles={
-            Precision.FP32: PrecisionProfile(
-                precision=Precision.FP32,
-                peak_ops_per_sec=bf16_peak / 2,  # Half of BF16 (not native)
-                tensor_core_supported=True,
-                relative_speedup=0.5,
-                bytes_per_element=4,
-            ),
-            Precision.BF16: PrecisionProfile(
-                precision=Precision.BF16,
-                peak_ops_per_sec=bf16_peak,  # 275 TFLOPS
-                tensor_core_supported=True,
-                relative_speedup=1.0,
-                bytes_per_element=2,
-            ),
-            Precision.INT8: PrecisionProfile(
-                precision=Precision.INT8,
-                peak_ops_per_sec=int8_peak,  # 550 TOPS (2× BF16)
-                tensor_core_supported=True,
-                relative_speedup=2.0,
-                bytes_per_element=1,
-                accumulator_precision=Precision.INT32,
-            ),
-        },
-        default_precision=Precision.BF16,
-
-        peak_bandwidth=1.2e12,  # 1.2 TB/s HBM2e
-        l1_cache_per_unit=16 * 1024 * 1024,  # 16 MB per MXU
-        l2_cache_total=32 * 1024 * 1024,  # 32 MB shared
-        main_memory=32 * 1024**3,  # 32 GB HBM2e
-        energy_per_flop_fp32=systolic_fabric.energy_per_flop_fp32,  # 1.8 pJ (7nm standard_cell)
-        energy_per_byte=10e-12,
-        energy_scaling={
-            Precision.FP32: 1.0,
-            Precision.BF16: 0.5,
-            Precision.INT8: 0.125,
-        },
-        min_occupancy=0.5,  # Systolic arrays need high utilization
-        max_concurrent_kernels=1,  # Typically runs one large batch
-        wave_quantization=1,
-
-        # Thermal profile
-        thermal_operating_points={
-            "default": thermal_default,
-        },
-        default_thermal_profile="default",
-    )
-
-    # Attach tile energy model to the resource model
-    model.tile_energy_model = tile_energy_model
-
-    return model
-
-

--- a/tests/hardware/test_tpu_yaml_loader_v4_parity.py
+++ b/tests/hardware/test_tpu_yaml_loader_v4_parity.py
@@ -1,50 +1,41 @@
-"""Contract test: TPU v4 YAML loader produces the expected model.
+"""Contract test: TPU v4 factory produces the expected model.
 
-PR 4 of the TPU mini-sprint scoped at issue #204. Mirror of
-``tests/hardware/test_dpu_yaml_loader_vitis_ai_parity.py``. Compares
-the YAML-loaded model against the hand-coded factory at
-``src/graphs/hardware/models/datacenter/tpu_v4.py``.
+Originally PR 4's parity test, comparing YAML-loaded against the
+hand-coded factory. PR 5 retired the 176-LOC hand-coded body of
+``tpu_v4_resource_model()`` and made it a thin wrapper over
+``load_tpu_resource_model_from_yaml``, so today both ``hand_coded``
+and ``yaml_loaded`` fixtures resolve through the same loader.
 
-PR 5 will retire the hand-coded body and make ``tpu_v4_resource_model()``
-a thin wrapper over the loader; at that point both ``hand_coded`` and
-``yaml_loaded`` fixtures will resolve through the same loader and
-these structural assertions become contract tests.
+The structural assertions are now **contract tests on the YAML
+loader's output** rather than parity checks. They still catch loader
+regressions and YAML drift; they also fail loudly if anyone changes
+the factory's name override or substitutes a different SKU id.
 
-Documented drifts:
+Zero factory overlays exist for TPU v4 (the same clean-cut migration
+as Plasticine #199 and Vitis AI #203 -- the YAML conventions match
+the chip's natural representation).
 
-  - ``energy_per_flop_fp32``: ~4x drift (0.45 pJ YAML vs 1.8 pJ
-    hand-coded). YAML computes from BF16 baseline (0.225 pJ) *
-    FP32 scaling (2.0) = 0.45 pJ. Hand-coded uses
-    ``get_base_alu_energy(7, 'standard_cell')`` = 1.8 pJ static
-    7nm baseline. The schema's BF16-relative FP32 scaling of 2.0
-    is optimistic for emulated FP32; v8 reconciliation may add a
-    direct ``energy_per_flop_fp32_override`` field.
-  - ``memory_technology``: "HBM2E" (yaml) vs None (hand-coded).
-    Legacy doesn't populate this field; YAML loader does.
-  - **TPU v4 modeled as 2 MXUs (not 8)** -- both YAML and legacy
-    model TPU v4 as 2 MXUs * 128x128 = 32,768 MACs. Google's actual
-    TPU v4 has 2 TensorCores * 4 MXUs each = 8 MXUs * 128x128 =
-    131,072 MACs (= 275 TFLOPS BF16 chip-level peak). The schema's
-    `chip.performance.bf16_tflops = 275.0` matches the marketed
-    number, but the `compute_fabric`-derived precision_profiles[BF16]
-    gives 68.8 TOPS (= 1/4 of marketed). This is a documented
-    legacy modeling choice that the parity test honors; v8
-    reconciliation can model 2 TC * 4 MXUs properly.
+One pre-cleanup drift retained -- the **2-MXU modeling gap**:
+  - Both legacy and YAML model TPU v4 as 2 MXUs * 128x128 = 32,768
+    MACs (= 68.8 TOPS BF16 from compute_fabric). Google's actual
+    TPU v4 has 2 TensorCores * 4 MXUs each = 8 MXUs (= 275 TFLOPS
+    marketed; matches the schema's chip-level performance roll-up).
+    Documented legacy modeling choice; v8 reconciliation can model
+    2 TC * 4 MXUs properly (might require multi-block-per-die support).
 
-Where the hand-coded and YAML-loaded agree (actual parity assertions):
+Two v8 reconciliation items:
+  - ``is_statically_reconfigurable=False`` (TPUs are fixed-function)
+    -- not in TPUBlock schema yet.
+  - ``ici_port_count`` / ``ici_bandwidth_per_port_gbps`` /
+    ``ici_topology_hint`` -- live on TPUBlock in the v7 schema but
+    have no equivalent fields on ``HardwareResourceModel``. Tested
+    via direct ComputeProduct read below.
 
-  - compute_units, threads_per_unit, warps_per_unit, warp_size
-  - peak_bandwidth (1.2 TB/s -- HBM2e)
-  - l1_cache_per_unit (16 MiB per MXU = UB / 2)
-  - l2_cache_total (32 MiB = full UB)
-  - main_memory (32 GiB HBM2e)
-  - default_precision (BF16 -- training-first)
-  - hardware_type (TPU)
-  - thermal profile shape (single profile, 350W liquid)
-  - scheduler attrs (min_occupancy=0.5, max_concurrent_kernels=1,
-    wave_quantization=1)
-  - precision_profiles[BF16/INT8] peak ops (68.8 TOPS for 2-MXU model)
-  - tile_energy_model (TPUTileEnergyModel attached on both sides)
+(Before PR 5 / cleanup, the legacy hand-coded had THREE additional
+documented drifts -- ``energy_per_flop_fp32`` 4x difference,
+``memory_technology=None``, ``soc_fabric=None``. Those are all
+resolved now because the hand-coded body is gone and both sides
+resolve through the loader.)
 """
 
 import pytest
@@ -143,17 +134,13 @@ def test_compute_fabric_int8_ops_per_clock(hand_coded, yaml_loaded):
     assert yaml_int8 == hand_int8 == 2
 
 
-def test_compute_fabric_energy_documented_drift(hand_coded, yaml_loaded):
-    """DOCUMENTED DRIFT: ~4x drift in FP32 fabric energy.
-
-    YAML: 0.225 pJ BF16 baseline * 2.0 FP32 scaling = 0.45 pJ
-    Hand-coded: get_base_alu_energy(7, 'standard_cell') = 1.8 pJ
-
-    Both are valid 7nm estimates with different methodologies. The
-    schema's 2.0x BF16-relative FP32 scaling is optimistic for
-    emulated FP32; v8 reconciliation may add a direct
-    energy_per_flop_fp32_override field on TPUComputeFabric."""
-    # Range sanity: 7nm FP32 should be ~0.2-3 pJ
+def test_compute_fabric_energy_in_sane_range(hand_coded, yaml_loaded):
+    """Both factories now resolve through the loader, which computes
+    energy_per_flop_fp32 from the fabric's BF16 baseline * FP32
+    scaling (0.225 * 2.0 = 0.45 pJ for TPU v4 7nm). Before PR 5
+    cleanup the legacy used ``get_base_alu_energy(7, 'standard_cell')``
+    = 1.8 pJ; both are valid 7nm estimates, the schema convention
+    won."""
     for fab in (hand_coded.compute_fabrics[0], yaml_loaded.compute_fabrics[0]):
         assert 1e-13 < fab.energy_per_flop_fp32 < 5e-12, (
             f"fabric energy_per_flop_fp32={fab.energy_per_flop_fp32} "
@@ -238,37 +225,28 @@ def test_coherence_protocol_is_none(yaml_loaded):
     assert yaml_loaded.coherence_protocol == "none"
 
 
-def test_yaml_populates_memory_technology(yaml_loaded):
-    """DOCUMENTED DRIFT: hand-coded does NOT set memory_technology
-    (returns None); YAML loader populates from external_dram_type.
-    YAML's "HBM2E" is structurally correct."""
-    assert yaml_loaded.memory_technology == "HBM2E"
-
-
-def test_hand_coded_memory_technology_is_none(hand_coded):
-    """Pinned for visibility: PR 5 cleanup makes both sides populate."""
-    assert hand_coded.memory_technology is None
+def test_memory_technology_populated(hand_coded, yaml_loaded):
+    """Both factories now resolve through the loader, which populates
+    ``memory_technology`` from the YAML's ``external_dram_type=hbm2e``.
+    Before PR 5 cleanup the legacy returned None here."""
+    assert yaml_loaded.memory_technology == hand_coded.memory_technology == "HBM2E"
 
 
 # ---------------------------------------------------------------------------
 # SoC fabric (UB-to-MXU crossbar)
 # ---------------------------------------------------------------------------
 
-def test_yaml_populates_soc_fabric(yaml_loaded):
-    """YAML loader populates soc_fabric from the noc block. Hand-coded
-    didn't model the SoC fabric (returns None); PR 5 cleanup makes both
-    sides match."""
+def test_soc_fabric_populated(hand_coded, yaml_loaded):
+    """Both factories now resolve through the loader, which populates
+    ``soc_fabric`` from the YAML's ``noc`` block (2-endpoint UB-to-MXU
+    crossbar). Before PR 5 cleanup the legacy returned None, which
+    blocked downstream Layer 6 reporting for TPU."""
     from graphs.hardware.fabric_model import Topology
-    assert yaml_loaded.soc_fabric is not None
-    assert yaml_loaded.soc_fabric.topology == Topology.CROSSBAR
-    assert yaml_loaded.soc_fabric.controller_count == 2
-    assert yaml_loaded.soc_fabric.bisection_bandwidth_gbps == pytest.approx(2000.0)
-
-
-def test_hand_coded_soc_fabric_is_none(hand_coded):
-    """Pinned for visibility: PR 5 cleanup makes the YAML loader the
-    only source."""
-    assert hand_coded.soc_fabric is None
+    for label, m in (("yaml_loaded", yaml_loaded), ("hand_coded", hand_coded)):
+        assert m.soc_fabric is not None, f"{label}.soc_fabric is None"
+        assert m.soc_fabric.topology == Topology.CROSSBAR
+        assert m.soc_fabric.controller_count == 2
+        assert m.soc_fabric.bisection_bandwidth_gbps == pytest.approx(2000.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Collapses ``tpu_v4.py`` from ~176 LOC hand-coded to 25 LOC thin loader wrapper.
- **Zero factory overlays** — clean-cut migration (like Plasticine #199 and Vitis AI #203).
- **Closes issue #204** (TPU mini-sprint umbrella).
- PR 5 of 5.

## Why "zero overlays"

Same pattern as Plasticine / Vitis AI cleanups:
- `HardwareType.TPU` already in enum
- Loader's HBM2e bandwidth matches legacy 1.2 TB/s exactly
- `TPUTileEnergyModel` reconstructed from schema's `TPUTileEnergyCoefficients` + per-MXU fields (functionally equivalent)
- Google Cloud rental → no BoM overlay needed

## YAML CHANGES legacy in 4 ways (all inherited automatically)

Downstream TPU tests (`test_tpu_tile_energy.py`, `test_tpu_datacenter_bert.py`) all pass with the thin factory — no other suites need updating.

| Field | Pre-cleanup (legacy) | Post-cleanup (loader) |
|---|---|---|
| ``energy_per_flop_fp32`` | 1.8 pJ | **0.45 pJ** (BF16 baseline * 2.0 FP32 scaling) |
| ``memory_technology`` | None | **"HBM2E"** |
| ``soc_fabric`` | None | **2-endpoint UB-to-MXU crossbar** (unblocks Layer 6) |
| MXU count modeling | 2 MXUs | 2 MXUs (unchanged; 2-vs-8 MXU gap **retained as v8 reconciliation**) |

## Test changes

`tests/hardware/test_tpu_yaml_loader_v4_parity.py`: 42 → 40 tests after retiring two now-stale "legacy drift" tests:
- `test_hand_coded_memory_technology_is_none` — both sides now populate "HBM2E"
- `test_hand_coded_soc_fabric_is_none` — both sides populate crossbar

Three drift assertions collapsed into mutual contract assertions:
- `test_compute_fabric_energy_in_sane_range` (renamed from `documented_drift`)
- `test_memory_technology_populated`: both = "HBM2E"
- `test_soc_fabric_populated`: both populate crossbar

## Two v8 reconciliation items documented

- `is_statically_reconfigurable=False` (TPUs are fixed-function) — not in TPUBlock schema yet
- `ici_port_count` / `ici_bandwidth_per_port_gbps` / `ici_topology_hint` — live on TPUBlock but no equivalent on HardwareResourceModel. Tested via direct ComputeProduct read.

## Changes

| File | Δ | What |
|---|---|---|
| ``src/graphs/hardware/models/datacenter/tpu_v4.py`` | −151 LOC | 176-LOC hand-coded → 25-LOC thin loader wrapper |
| ``tests/hardware/test_tpu_yaml_loader_v4_parity.py`` | −113 LOC | Retired 2 stale drift tests; converted 3 drift assertions to mutual contract assertions |

## Test Results

| Suite | Result |
|---|---|
| ``test_tpu_yaml_loader_v4_parity.py`` | 40 passed (was 42; -2 retired) |
| ``test_tpu_tile_energy.py`` | 5 passed (no regression) |
| ``test_tpu_datacenter_bert.py`` | 4 passed (no regression) |
| Full suite | **2998 passed**, 13 skipped, 4 xfailed (was 3000; net -2 from retired) |

## Test plan

- [x] All 2998 graphs tests pass locally
- [x] TPU v4 factory now returns YAML-corrected fields (HBM2E memory_technology, populated soc_fabric)
- [x] Downstream TPU tests (tile energy + datacenter BERT) all pass with thin factory
- [x] TPUMapper still accepts TPU v4 (no mapper guard changes needed)
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied: ``gh pr ready PR_NUMBER``

## Issue #204 — TPU mini-sprint complete

After this PR merges, the umbrella issue closes:

| PR | Repo | State |
|---|---|---|
| 1/5 paper exercise | graphs | ✅ Merged (#205) |
| 2/5 TPUBlock schema | embodied-schemas | ✅ Merged (#38) |
| 3/5 TPU v4 YAML | embodied-schemas | ✅ Merged (#39) |
| 4/5 graphs loader | graphs | ✅ Merged (#206) |
| **5/5 thin factory cleanup** | graphs | **This PR — closes #204** |

## Catalog migration progress

🎯 **21 of 42 hand-coded factories migrated (~50%) — HALFWAY POINT**

| Architecture | YAML-backed | Hand-coded remaining | Status |
|---|---|---|---|
| KPU | 12 | 0 | ✅ done |
| GPU | 2 | 8 | catalog expansion |
| CPU | 1 | 7 | catalog expansion |
| NPU | 3 | 0 | ✅ done (issue #192) |
| CGRA | 1 | 0 | ✅ done (issue #196) |
| DPU | 1 | 0 | ✅ done (issue #200) |
| **TPU** | **1** | **4** | **schema done (this PR / issue #204); 4 follow-up SKUs** |
| DSP | 0 | 10 | sprint (12+ PRs) |

After this sprint:
- 4 follow-up TPU SKUs (v1, v3, v5p, edge_pro) land as pure data PRs + cleanups (separate issues; ~8 PRs total)
- **v8 vendor-neutral `compute_block_common` unification** becomes the obvious next major sprint (7 architectures × 3+ shared primitives each)
- Only DSP remains as a schema gap (10 SKUs)

## Refs

- **Closes #204** (TPU mini-sprint umbrella)
- #205 (paper exercise; PR 1/5)
- #206 (YAML loader; PR 4/5)
- branes-ai/embodied-schemas#38, #39 (precursors)
- #203 (Vitis AI cleanup — pattern source)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated TPU v4 hardware resource model implementation for improved maintainability while maintaining backward compatibility.

* **Tests**
  * Enhanced testing framework for TPU v4 resource model validation to ensure consistent behavior and structural correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/graphs/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->